### PR TITLE
Correct the parsing of door properties

### DIFF
--- a/rmf_site_format/src/legacy/door.rs
+++ b/rmf_site_format/src/legacy/door.rs
@@ -42,7 +42,9 @@ impl Door {
         } else if self.2.motion_axis.1 == "end" {
             Ok(Side::Right)
         } else {
-            Err(PortingError::InvalidMotionAxis(self.2.motion_axis.1.clone()))
+            Err(PortingError::InvalidMotionAxis(
+                self.2.motion_axis.1.clone(),
+            ))
         }
     }
 
@@ -54,7 +56,7 @@ impl Door {
                 } else {
                     Ok(Swing::Backward(Angle::Deg(self.2.motion_degrees.1 as f32)))
                 }
-            },
+            }
             Side::Right => {
                 if self.2.motion_direction.1 < 0 {
                     Ok(Swing::Backward(Angle::Deg(self.2.motion_degrees.1 as f32)))

--- a/rmf_site_format/src/legacy/error.rs
+++ b/rmf_site_format/src/legacy/error.rs
@@ -37,6 +37,8 @@ pub enum PortingError {
         level: String,
         door: String,
     },
+    #[error("A door had an invalid motion axis value: {0}")]
+    InvalidMotionAxis(String),
     #[error("the data contained a known type which has been deprecated: {0}")]
     DeprecatedType(String),
     #[error("the data contained an unknown/invalid type: {0}")]


### PR DESCRIPTION
When implementing the conversion from the legacy `.building.yaml` format to the new `.site.ron` format, I misinterpreted the meaning of some of the door parameters. This PR fixes the conversion to reflect the real meaning of those parameters.