### PR TITLE
flattened_FOO_offset is no longer saved by Traffic Editor I

### DIFF
--- a/rmf_site_format/src/legacy/level.rs
+++ b/rmf_site_format/src/legacy/level.rs
@@ -26,7 +26,9 @@ pub struct Level {
     #[serde(default)]
     pub drawing: LevelDrawing,
     pub elevation: f64,
+    #[serde(default)]
     pub flattened_x_offset: f64,
+    #[serde(default)]
     pub flattened_y_offset: f64,
     #[serde(default)]
     pub floors: Vec<Floor>,

--- a/rmf_site_format/src/legacy/level.rs
+++ b/rmf_site_format/src/legacy/level.rs
@@ -27,10 +27,6 @@ pub struct Level {
     pub drawing: LevelDrawing,
     pub elevation: f64,
     #[serde(default)]
-    pub flattened_x_offset: f64,
-    #[serde(default)]
-    pub flattened_y_offset: f64,
-    #[serde(default)]
     pub floors: Vec<Floor>,
     #[serde(default)]
     pub physical_cameras: Vec<PhysicalCamera>,


### PR DESCRIPTION
As of https://github.com/open-rmf/rmf_traffic_editor/pull/418/files#diff-fb5555f6057f74143c5aeb3cbec283ba77df9b1aaf91780957d140986dce2168L223-L224  the Qt-based Traffic Editor no longer saves `flattened_x_offset` and `flattened_y_offset` fields for levels in its YAML output. This PR just makes those fields optional. They have always been set to zero anyway.