### PR TITLE
Allow default values for crowd sim and lifts

### DIFF
--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -28,7 +28,9 @@ pub struct BuildingMap {
     #[serde(default)]
     pub coordinate_system: CoordinateSystem,
     pub levels: BTreeMap<String, Level>,
+    #[serde(default)]
     pub crowd_sim: CrowdSim,
+    #[serde(default)]
     pub lifts: BTreeMap<String, Lift>,
 }
 


### PR DESCRIPTION
Following the theme of https://github.com/open-rmf/rmf_site/pull/66 this should help make our building parsing more flexible towards the old building parameters that are optional.