### PR TITLE
Fix deploy script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="1; url=./rmf_site_editor/web">
+  </head>
+  <body>
+    Redirecting to the 'web' subdirectory...
+  </body>
+</html>

--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -19,7 +19,7 @@ echo "Starting deployment process using branch $BRANCH"
 
 set -o verbose
 
-git clone ssh://git@github.com/open-rmf/rmf_site_editor temp-deploy-checkout --branch $BRANCH --single-branch --depth 1
+git clone ssh://git@github.com/open-rmf/rmf_site temp-deploy-checkout --branch $BRANCH --single-branch --depth 1
 
 cd temp-deploy-checkout/rmf_editor
 git checkout --orphan gh-pages
@@ -28,7 +28,7 @@ scripts/build-web.sh
 
 git add -f web
 cd ..
-cp rmf_editor/web/root_index.html index.html
+cp web/root_index.html index.html
 git add index.html
 
 git commit -a -m "publish to github pages"

--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -21,7 +21,7 @@ set -o verbose
 
 git clone ssh://git@github.com/open-rmf/rmf_site temp-deploy-checkout --branch $BRANCH --single-branch --depth 1
 
-cd temp-deploy-checkout/rmf_editor
+cd temp-deploy-checkout
 git checkout --orphan gh-pages
 git reset
 scripts/build-web.sh

--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -27,7 +27,6 @@ git reset
 scripts/build-web.sh
 
 git add -f web
-cd ..
 cp web/root_index.html index.html
 git add index.html
 

--- a/web/root_index.html
+++ b/web/root_index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="1; url=./rmf_site_editor/web">
+    <meta http-equiv="refresh" content="1; url=./web">
   </head>
   <body>
     Redirecting to the 'web' subdirectory...


### PR DESCRIPTION
I introduced some errors into the web demo deployment script when migrating to `rmf_site`.

This PR fixes those errors and was used to generate the latest version of the web demo deployment: https://open-rmf.github.io/rmf_site/web/