### PR TITLE
More intuitive lift parameter meanings

### DIFF
--- a/rmf_site_editor/src/site/lift.rs
+++ b/rmf_site_editor/src/site/lift.rs
@@ -89,7 +89,7 @@ fn make_lift_transform(
         .point_in_parent_frame_of(reference_anchors.end(), Category::Lift, entity)
         .unwrap();
     let (p_start, p_end) = if reference_anchors.left() == reference_anchors.right() {
-        (p_start, p_start + DEFAULT_CABIN_WIDTH * Vec3::Y)
+        (p_start, p_start - DEFAULT_CABIN_WIDTH * Vec3::Y)
     } else {
         (p_start, p_end)
     };

--- a/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
@@ -248,6 +248,22 @@ impl<'a, 'w1, 's1, 'w2, 's2> InspectLiftCabin<'a, 'w1, 's1, 'w2, 's2> {
         }
 
         if new_cabin != *cabin {
+            if let (
+                LiftCabin::Rect(new_params),
+                LiftCabin::Rect(old_params)
+            ) = (&mut new_cabin, cabin) {
+                if new_params.width != old_params.width {
+                    if let Some(shift) = &mut new_params.shift {
+                        // The user has already assigned a shift to the cabin,
+                        // so any change to the width should be half-applied to
+                        // the shift so that the two parameters aren't fighting
+                        // against each other.
+                        let delta = (new_params.width - old_params.width)/2.0;
+                        *shift -= delta;
+                    }
+                }
+            }
+
             return Some(new_cabin);
         }
 

--- a/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
@@ -248,17 +248,16 @@ impl<'a, 'w1, 's1, 'w2, 's2> InspectLiftCabin<'a, 'w1, 's1, 'w2, 's2> {
         }
 
         if new_cabin != *cabin {
-            if let (
-                LiftCabin::Rect(new_params),
-                LiftCabin::Rect(old_params)
-            ) = (&mut new_cabin, cabin) {
+            if let (LiftCabin::Rect(new_params), LiftCabin::Rect(old_params)) =
+                (&mut new_cabin, cabin)
+            {
                 if new_params.width != old_params.width {
                     if let Some(shift) = &mut new_params.shift {
                         // The user has already assigned a shift to the cabin,
                         // so any change to the width should be half-applied to
                         // the shift so that the two parameters aren't fighting
                         // against each other.
-                        let delta = (new_params.width - old_params.width)/2.0;
+                        let delta = (new_params.width - old_params.width) / 2.0;
                         *shift -= delta;
                     }
                 }

--- a/rmf_site_format/src/legacy/optimization.rs
+++ b/rmf_site_format/src/legacy/optimization.rs
@@ -58,7 +58,7 @@ pub fn align_building(building: &BuildingMap) -> HashMap<String, Alignment> {
     // globally optimized across the different levels, instead levels will only
     // be scaled according to their individual measurements. This likely means
     // that scaling won't be quite as accurate overall, but everything should
-    // basically work.
+    // basically work as long as each level has one or more measurements.
     #[cfg(not(target_arch = "wasm32"))]
     {
         let constraints = constraints::Rectangle::new(Some(&min_vals), Some(&max_vals));

--- a/rmf_site_format/src/lift.rs
+++ b/rmf_site_format/src/lift.rs
@@ -366,7 +366,7 @@ impl<T: RefTrait> RectangularLiftCabin<T> {
         let door = self.door(face).as_ref()?;
         let (u, v) = face.uv2();
         let n = Vec2::new(self.depth / 2.0, self.width / 2.0);
-        let half_door_t = door.thickness()/2.0;
+        let half_door_t = door.thickness() / 2.0;
         let delta = self.thickness() + door.custom_gap.unwrap_or(self.gap()) + half_door_t;
         let base = (n.dot(u).abs() + delta) * u;
         let left = base + door.left_coordinate() * v;
@@ -388,12 +388,15 @@ impl<T: RefTrait> RectangularLiftCabin<T> {
 #[cfg(feature = "bevy")]
 impl<T: RefTrait> RectangularLiftCabin<T> {
     pub fn aabb(&self) -> Aabb {
-        let front_door_t = self.front_door.as_ref().map(|d| d.thickness())
+        let front_door_t = self
+            .front_door
+            .as_ref()
+            .map(|d| d.thickness())
             .unwrap_or(DEFAULT_CABIN_DOOR_THICKNESS);
 
         Aabb {
             center: Vec3A::new(
-                -self.depth / 2.0 - self.thickness() - self.gap() - front_door_t/2.0,
+                -self.depth / 2.0 - self.thickness() - self.gap() - front_door_t / 2.0,
                 self.shift(),
                 DEFAULT_LEVEL_HEIGHT / 2.0,
             ),

--- a/rmf_site_format/src/lift.rs
+++ b/rmf_site_format/src/lift.rs
@@ -366,11 +366,12 @@ impl<T: RefTrait> RectangularLiftCabin<T> {
         let door = self.door(face).as_ref()?;
         let (u, v) = face.uv2();
         let n = Vec2::new(self.depth / 2.0, self.width / 2.0);
-        let delta = self.thickness() + door.custom_gap.unwrap_or(self.gap()) + door.thickness();
+        let half_door_t = door.thickness()/2.0;
+        let delta = self.thickness() + door.custom_gap.unwrap_or(self.gap()) + half_door_t;
         let base = (n.dot(u).abs() + delta) * u;
         let left = base + door.left_coordinate() * v;
         let right = base + door.right_coordinate() * v;
-        let d_floor = door.thickness() * u;
+        let d_floor = half_door_t * u;
         Some([
             Anchor::CategorizedTranslate2D(
                 Categorized::new(left.into())
@@ -387,9 +388,12 @@ impl<T: RefTrait> RectangularLiftCabin<T> {
 #[cfg(feature = "bevy")]
 impl<T: RefTrait> RectangularLiftCabin<T> {
     pub fn aabb(&self) -> Aabb {
+        let front_door_t = self.front_door.as_ref().map(|d| d.thickness())
+            .unwrap_or(DEFAULT_CABIN_DOOR_THICKNESS);
+
         Aabb {
             center: Vec3A::new(
-                -self.depth / 2.0 - self.thickness() - self.gap(),
+                -self.depth / 2.0 - self.thickness() - self.gap() - front_door_t/2.0,
                 self.shift(),
                 DEFAULT_LEVEL_HEIGHT / 2.0,
             ),


### PR DESCRIPTION
The lift parameters were not being rendered quite how they were meant to be. This PR fixes that to have the rendered outcome match the originally intended meanings of the parameters.