### PR TITLE
Support CLI and improve main menu behavior

### DIFF
--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -28,6 +28,7 @@ dirs = "4.0"
 thread_local = "*"
 lyon = "1"
 thiserror = "*"
+clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }
 rmf_site_format = { path = "../rmf_site_format", features = ["bevy"] }
 
 # only enable the 'dynamic' feature if we're not building for web or windows

--- a/rmf_site_editor/src/interaction/cursor.rs
+++ b/rmf_site_editor/src/interaction/cursor.rs
@@ -178,7 +178,10 @@ impl FromWorld for Cursor {
         let cursor = world
             .spawn()
             .push_children(&[halo, dagger, level_anchor_placement, site_anchor_placement])
-            .insert_bundle(SpatialBundle::default())
+            .insert_bundle(SpatialBundle {
+                visibility: Visibility { is_visible: false },
+                ..default()
+            })
             .id();
 
         Self {

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -3,6 +3,7 @@ use bevy_egui::EguiPlugin;
 use main_menu::MainMenuPlugin;
 // use warehouse_generator::WarehouseGeneratorPlugin;
 use wasm_bindgen::prelude::*;
+use clap::Parser;
 
 // a few more imports needed for wasm32 only
 #[cfg(target_arch = "wasm32")]
@@ -23,6 +24,7 @@ mod demo_world;
 mod shapes;
 
 mod main_menu;
+use main_menu::Autoload;
 mod site;
 // mod warehouse_generator;
 mod interaction;
@@ -35,6 +37,12 @@ use animate::AnimationPlugin;
 use interaction::InteractionPlugin;
 use site::SitePlugin;
 use site_asset_io::SiteAssetIoPlugin;
+
+#[derive(Parser)]
+struct CommandLineArgs {
+    /// Filename of a Site (.site.ron) or Building (.building.yaml) file
+    filename: Option<String>,
+}
 
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
 pub enum AppState {
@@ -71,8 +79,17 @@ fn init_settings(mut settings: ResMut<Settings>, adapter_info: Res<WgpuAdapterIn
 }
 
 #[wasm_bindgen]
-pub fn run() {
+pub fn run_js() {
+    run(vec!["web".to_string()]);
+}
+
+pub fn run(command_line_args: Vec<String>) {
     let mut app = App::new();
+
+    let command_line_args = CommandLineArgs::parse_from(command_line_args);
+    if let Some(path) = command_line_args.filename {
+        app.insert_resource(Autoload::file(path.into()));
+    }
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -2,8 +2,8 @@ use bevy::{pbr::DirectionalLightShadowMap, prelude::*, render::render_resource::
 use bevy_egui::EguiPlugin;
 use main_menu::MainMenuPlugin;
 // use warehouse_generator::WarehouseGeneratorPlugin;
-use wasm_bindgen::prelude::*;
 use clap::Parser;
+use wasm_bindgen::prelude::*;
 
 // a few more imports needed for wasm32 only
 #[cfg(target_arch = "wasm32")]

--- a/rmf_site_editor/src/main.rs
+++ b/rmf_site_editor/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    librmf_site_editor::run();
+    librmf_site_editor::run(std::env::args().collect());
 }

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -17,12 +17,12 @@
 
 use super::demo_world::demo_office;
 use crate::{interaction::InteractionState, site::LoadSite, AppState, OpenedMapFile};
-use rmf_site_format::{legacy::building_map::BuildingMap, Site};
 use bevy::{app::AppExit, prelude::*, tasks::AsyncComputeTaskPool};
 use bevy_egui::{egui, EguiContext};
-use {bevy::tasks::Task, futures_lite::future};
 use rfd::{AsyncFileDialog, FileHandle};
+use rmf_site_format::{legacy::building_map::BuildingMap, Site};
 use std::path::PathBuf;
+use {bevy::tasks::Task, futures_lite::future};
 
 struct LoadSiteFileResult(Option<OpenedMapFile>, Site);
 
@@ -67,10 +67,7 @@ fn egui_ui(
             let filename = autoload.filename.clone();
             let future = AsyncComputeTaskPool::get().spawn(async move {
                 let site = load_site_file(&FileHandle::wrap(filename.clone())).await?;
-                Some(LoadSiteFileResult(
-                    Some(OpenedMapFile(filename)),
-                    site,
-                ))
+                Some(LoadSiteFileResult(Some(OpenedMapFile(filename)), site))
             });
             _commands.spawn().insert(LoadSiteFileTask(future));
             _commands.remove_resource::<Autoload>();
@@ -246,9 +243,7 @@ impl Plugin for MainMenuPlugin {
     }
 }
 
-async fn load_site_file(
-    file: &FileHandle,
-) -> Option<Site> {
+async fn load_site_file(file: &FileHandle) -> Option<Site> {
     let is_legacy = file.file_name().ends_with(".building.yaml");
     let data = file.read().await;
     if is_legacy {

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -17,16 +17,27 @@
 
 use super::demo_world::demo_office;
 use crate::{interaction::InteractionState, site::LoadSite, AppState, OpenedMapFile};
+use rmf_site_format::{legacy::building_map::BuildingMap, Site};
 use bevy::{app::AppExit, prelude::*, tasks::AsyncComputeTaskPool};
 use bevy_egui::{egui, EguiContext};
-use rmf_site_format::{legacy::building_map::BuildingMap, Site};
-
-use {bevy::tasks::Task, futures_lite::future, rfd::AsyncFileDialog};
+use {bevy::tasks::Task, futures_lite::future};
+use rfd::{AsyncFileDialog, FileHandle};
+use std::path::PathBuf;
 
 struct LoadSiteFileResult(Option<OpenedMapFile>, Site);
 
 #[derive(Component)]
 struct LoadSiteFileTask(Task<Option<LoadSiteFileResult>>);
+
+pub struct Autoload {
+    filename: PathBuf,
+}
+
+impl Autoload {
+    pub fn file(filename: PathBuf) -> Self {
+        Autoload { filename }
+    }
+}
 
 fn egui_ui(
     mut egui_context: ResMut<EguiContext>,
@@ -35,7 +46,38 @@ fn egui_ui(
     mut _load_site: EventWriter<LoadSite>,
     mut _interaction_state: ResMut<State<InteractionState>>,
     mut app_state: ResMut<State<AppState>>,
+    autoload: Option<Res<Autoload>>,
+    loading_tasks: Query<(), With<LoadSiteFileTask>>,
 ) {
+    if !loading_tasks.is_empty() {
+        egui::Window::new("Welcome!")
+            .collapsible(false)
+            .resizable(false)
+            .title_bar(false)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0., 0.))
+            .show(egui_context.ctx_mut(), |ui| {
+                ui.heading("Loading...");
+            });
+        return;
+    }
+
+    if let Some(mut autoload) = autoload {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let filename = autoload.filename.clone();
+            let future = AsyncComputeTaskPool::get().spawn(async move {
+                let site = load_site_file(&FileHandle::wrap(filename.clone())).await?;
+                Some(LoadSiteFileResult(
+                    Some(OpenedMapFile(filename)),
+                    site,
+                ))
+            });
+            _commands.spawn().insert(LoadSiteFileTask(future));
+            _commands.remove_resource::<Autoload>();
+        }
+        return;
+    }
+
     egui::Window::new("Welcome!")
         .collapsible(false)
         .resizable(false)
@@ -120,32 +162,8 @@ fn egui_ui(
                                 }
                             };
                             println!("Loading site map");
-                            let is_legacy = file.file_name().ends_with(".building.yaml");
-                            let data = file.read().await;
-                            let site = if is_legacy {
-                                match BuildingMap::from_bytes(&data) {
-                                    Ok(building) => match building.to_site() {
-                                        Ok(site) => site,
-                                        Err(err) => {
-                                            println!("{:?}", err);
-                                            return None;
-                                        }
-                                    },
-                                    Err(err) => {
-                                        println!("{:?}", err);
-                                        return None;
-                                    }
-                                }
-                            } else {
-                                match Site::from_bytes(&data) {
-                                    Ok(site) => site,
-                                    Err(err) => {
-                                        println!("{:?}", err);
-                                        return None;
-                                    }
-                                }
-                            };
 
+                            let site = load_site_file(&file).await?;
                             Some(LoadSiteFileResult(
                                 Some(OpenedMapFile(file.path().to_path_buf())),
                                 site,
@@ -225,5 +243,35 @@ impl Plugin for MainMenuPlugin {
         app.add_system_set(
             SystemSet::on_update(AppState::MainMenu).with_system(site_file_load_complete),
         );
+    }
+}
+
+async fn load_site_file(
+    file: &FileHandle,
+) -> Option<Site> {
+    let is_legacy = file.file_name().ends_with(".building.yaml");
+    let data = file.read().await;
+    if is_legacy {
+        match BuildingMap::from_bytes(&data) {
+            Ok(building) => match building.to_site() {
+                Ok(site) => Some(site),
+                Err(err) => {
+                    println!("{:?}", err);
+                    return None;
+                }
+            },
+            Err(err) => {
+                println!("{:?}", err);
+                return None;
+            }
+        }
+    } else {
+        match Site::from_bytes(&data) {
+            Ok(site) => Some(site),
+            Err(err) => {
+                println!("{:?}", err);
+                return None;
+            }
+        }
     }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -33,7 +33,7 @@
   }
 
   init("./librmf_site_editor_bg_optimized.wasm").then(function (wasm) {
-    wasm.run();
+    wasm.run_js();
   });
 </script>
 </body>


### PR DESCRIPTION
This PR adds support for specifying a map to load from the commands line, e.g. from the root directory of this repo:

```
cargo run --release -- assets/demo_maps/office.building.yaml
```

The general format is
```
cargo run <cargo options> -- <site editor options>
```
but right now the only command line argument we only support is specifying one file to load at startup.

This PR also takes the opportunity to fix some other aspects of the main menu behavior. In the past I've noticed cases where an extra file selection dialogue pops up and gets permanently stuck. I believe this PR should fix that issue as well.