### PR TITLE
Prevent visual cues from showing for physical camera feeds

### DIFF
--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -15,7 +15,8 @@ name = "rmf_site_editor"
 bevy_egui = "0.15"
 bevy_mod_picking = "0.8"
 bevy_mod_raycast = "0.6"
-bevy_mod_outline = "0.2"
+# bevy_mod_outline = "0.2"
+bevy_mod_outline = { git = "https://github.com/mxgrey/bevy_mod_outline", branch = "outline_render_layers_v0.2" }
 smallvec = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.23"

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -15,8 +15,7 @@ name = "rmf_site_editor"
 bevy_egui = "0.15"
 bevy_mod_picking = "0.8"
 bevy_mod_raycast = "0.6"
-# bevy_mod_outline = "0.2"
-bevy_mod_outline = { git = "https://github.com/mxgrey/bevy_mod_outline", branch = "outline_render_layers_v0.2" }
+bevy_mod_outline = "0.2.5"
 smallvec = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.23"

--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -89,7 +89,7 @@ pub fn add_anchor_visual_cues(
                 body,
                 drag: None,
             })
-            .insert(VisualCue);
+            .insert(VisualCue::no_outline());
     }
 }
 

--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -55,7 +55,6 @@ pub fn add_anchor_visual_cues(
                 })
                 .insert(Bobbing::default())
                 .insert(Spinning::default())
-                .insert(VisualCue)
                 .id();
 
             let halo = parent
@@ -67,7 +66,6 @@ pub fn add_anchor_visual_cues(
                     ..default()
                 })
                 .insert(Spinning::default())
-                .insert(VisualCue)
                 .id();
 
             let mut body = parent.spawn_bundle(PbrBundle {
@@ -75,7 +73,7 @@ pub fn add_anchor_visual_cues(
                 material: site_assets.passive_anchor_material.clone(),
                 ..default()
             });
-            body.insert(Selectable::new(e)).insert(VisualCue);
+            body.insert(Selectable::new(e));
             if subordinate.is_none() {
                 body.insert_bundle(DragPlaneBundle::new(e, Vec3::Z));
             }
@@ -84,12 +82,14 @@ pub fn add_anchor_visual_cues(
             (dagger, halo, body)
         });
 
-        commands.insert(AnchorVisualization {
-            dagger,
-            halo,
-            body,
-            drag: None,
-        });
+        commands
+            .insert(AnchorVisualization {
+                dagger,
+                halo,
+                body,
+                drag: None,
+            })
+            .insert(VisualCue);
     }
 }
 

--- a/rmf_site_editor/src/interaction/camera_controls.rs
+++ b/rmf_site_editor/src/interaction/camera_controls.rs
@@ -20,8 +20,19 @@ use bevy::{
     core_pipeline::core_3d::Camera3dBundle,
     input::mouse::{MouseButton, MouseWheel},
     prelude::*,
-    render::camera::{Camera, Projection, ScalingMode, WindowOrigin},
+    render::{
+        camera::{Camera, Projection, ScalingMode, WindowOrigin},
+        view::RenderLayers,
+    },
 };
+
+/// RenderLayers are used to inform cameras which entities they should render.
+/// The user's viewport will see all layers, but physical cameras will only see
+/// entities in the default layer 0. In the site editor, each layer value has a
+/// specific semantic meaning so we need to make sure we never reuse these
+/// values.
+pub const PHYSICAL_RENDER_LAYER: u8 = 0;
+pub const VISUAL_CUE_RENDER_LAYER: u8 = 1;
 
 struct MouseLocation {
     previous: Vec2,
@@ -153,6 +164,10 @@ impl FromWorld for CameraControls {
             })
             .insert(Visibility::visible())
             .insert(ComputedVisibility::default())
+            .insert(RenderLayers::from_layers(&[
+                PHYSICAL_RENDER_LAYER,
+                VISUAL_CUE_RENDER_LAYER,
+            ]))
             .push_children(&[persp_headlight])
             .id();
 
@@ -190,6 +205,10 @@ impl FromWorld for CameraControls {
             })
             .insert(Visibility::visible())
             .insert(ComputedVisibility::default())
+            .insert(RenderLayers::from_layers(&[
+                PHYSICAL_RENDER_LAYER,
+                VISUAL_CUE_RENDER_LAYER,
+            ]))
             .push_children(&[ortho_headlight])
             .id();
 

--- a/rmf_site_editor/src/interaction/cursor.rs
+++ b/rmf_site_editor/src/interaction/cursor.rs
@@ -134,7 +134,7 @@ impl FromWorld for Cursor {
                 ..default()
             })
             .insert(Spinning::default())
-            .insert(VisualCue)
+            .insert(VisualCue::no_outline())
             .id();
 
         let dagger = world
@@ -147,7 +147,7 @@ impl FromWorld for Cursor {
             })
             .insert(Spinning::default())
             .insert(Bobbing::default())
-            .insert(VisualCue)
+            .insert(VisualCue::no_outline())
             .id();
 
         let level_anchor_placement = world
@@ -155,7 +155,7 @@ impl FromWorld for Cursor {
             .insert_bundle(AnchorBundle::new([0., 0.].into()).visible(false))
             .insert(Pending)
             .insert(Preview)
-            .insert(VisualCue)
+            .insert(VisualCue::no_outline())
             .with_children(|parent| {
                 parent.spawn_bundle(PbrBundle {
                     mesh: level_anchor_mesh,
@@ -170,7 +170,7 @@ impl FromWorld for Cursor {
             .insert_bundle(AnchorBundle::new([0., 0.].into()).visible(false))
             .insert(Pending)
             .insert(Preview)
-            .insert(VisualCue)
+            .insert(VisualCue::no_outline())
             .with_children(|parent| {
                 parent.spawn_bundle(PbrBundle {
                     mesh: site_anchor_mesh,
@@ -183,7 +183,7 @@ impl FromWorld for Cursor {
         let cursor = world
             .spawn()
             .push_children(&[halo, dagger, level_anchor_placement, site_anchor_placement])
-            .insert(VisualCue)
+            .insert(VisualCue::no_outline())
             .insert_bundle(SpatialBundle {
                 visibility: Visibility { is_visible: false },
                 ..default()

--- a/rmf_site_editor/src/interaction/lane.rs
+++ b/rmf_site_editor/src/interaction/lane.rs
@@ -32,7 +32,8 @@ pub fn add_lane_visual_cues(
     new_lane_segments: Query<(Entity, &LaneSegments), Added<LaneSegments>>,
 ) {
     for (e, lane) in &new_lanes {
-        commands.entity(e)
+        commands
+            .entity(e)
             .insert(LaneVisualCue {
                 supporters: Some(*lane),
             })

--- a/rmf_site_editor/src/interaction/lane.rs
+++ b/rmf_site_editor/src/interaction/lane.rs
@@ -37,7 +37,7 @@ pub fn add_lane_visual_cues(
             .insert(LaneVisualCue {
                 supporters: Some(*lane),
             })
-            .insert(VisualCue);
+            .insert(VisualCue::no_outline());
     }
 
     for (e, segments) in &new_lane_segments {

--- a/rmf_site_editor/src/interaction/lane.rs
+++ b/rmf_site_editor/src/interaction/lane.rs
@@ -32,9 +32,11 @@ pub fn add_lane_visual_cues(
     new_lane_segments: Query<(Entity, &LaneSegments), Added<LaneSegments>>,
 ) {
     for (e, lane) in &new_lanes {
-        commands.entity(e).insert(LaneVisualCue {
-            supporters: Some(*lane),
-        });
+        commands.entity(e)
+            .insert(LaneVisualCue {
+                supporters: Some(*lane),
+            })
+            .insert(VisualCue);
     }
 
     for (e, segments) in &new_lane_segments {

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -59,6 +59,9 @@ pub use select::*;
 pub mod select_anchor;
 pub use select_anchor::*;
 
+pub mod visual_cue;
+pub use visual_cue::*;
+
 use bevy::prelude::*;
 use bevy_mod_outline::{AutoGenerateOutlineNormalsPlugin, OutlinePlugin};
 use bevy_mod_picking::{PickingPlugin, PickingSystem};
@@ -77,12 +80,9 @@ pub enum InteractionUpdateStage {
     /// Since parentage can have an effect on visuals, we should wait to add
     /// the visuals until after any orphans have been assigned.
     AddVisuals,
+    /// This stage happens after the AddVisuals stage has flushed
+    ProcessVisuals,
 }
-
-/// A unit component to tag entities that are only meant to be visual cues and
-/// should be excluded from visualization or analysis of physical objects.
-#[derive(Component, Debug)]
-pub struct VisualCue;
 
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
@@ -92,8 +92,17 @@ impl Plugin for InteractionPlugin {
                 InteractionUpdateStage::AddVisuals,
                 SystemStage::parallel(),
             )
+            .add_stage_after(
+                InteractionUpdateStage::AddVisuals,
+                InteractionUpdateStage::ProcessVisuals,
+                SystemStage::parallel(),
+            )
             .add_state_to_stage(
                 InteractionUpdateStage::AddVisuals,
+                InteractionState::Disable,
+            )
+            .add_state_to_stage(
+                InteractionUpdateStage::ProcessVisuals,
                 InteractionState::Disable,
             )
             .add_state_to_stage(CoreStage::PostUpdate, InteractionState::Disable)
@@ -159,6 +168,11 @@ impl Plugin for InteractionPlugin {
                     .with_system(add_outline_visualization)
                     .with_system(add_cursor_hover_visualization)
                     .with_system(add_physical_light_visual_cues),
+            )
+            .add_system_set_to_stage(
+                InteractionUpdateStage::ProcessVisuals,
+                SystemSet::on_update(InteractionState::Enable)
+                    .with_system(propagate_visual_cues)
             )
             .add_system_set(SystemSet::on_exit(InteractionState::Enable).with_system(hide_cursor))
             .add_system_set_to_stage(

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -171,8 +171,7 @@ impl Plugin for InteractionPlugin {
             )
             .add_system_set_to_stage(
                 InteractionUpdateStage::ProcessVisuals,
-                SystemSet::on_update(InteractionState::Enable)
-                    .with_system(propagate_visual_cues)
+                SystemSet::on_update(InteractionState::Enable).with_system(propagate_visual_cues),
             )
             .add_system_set(SystemSet::on_exit(InteractionState::Enable).with_system(hide_cursor))
             .add_system_set_to_stage(

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -16,7 +16,8 @@
 */
 
 use crate::interaction::*;
-use bevy_mod_outline::{Outline, OutlineBundle, OutlineStencil};
+use bevy::render::view::RenderLayers;
+use bevy_mod_outline::{Outline, OutlineBundle, OutlineStencil, OutlineRenderLayers};
 use rmf_site_format::{
     DoorType, LiftCabin, LightKind, LocationTags, MeasurementMarker, ModelMarker,
     PhysicalCameraProperties, WallMarker,
@@ -88,7 +89,8 @@ pub fn update_outline_visualization(
                             colour: color,
                         },
                         stencil: OutlineStencil,
-                    });
+                    })
+                    .insert(OutlineRenderLayers(RenderLayers::layer(VISUAL_CUE_RENDER_LAYER)));
                 } else {
                     commands
                         .entity(top)

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -17,7 +17,7 @@
 
 use crate::interaction::*;
 use bevy::render::view::RenderLayers;
-use bevy_mod_outline::{Outline, OutlineBundle, OutlineStencil, OutlineRenderLayers};
+use bevy_mod_outline::{Outline, OutlineBundle, OutlineRenderLayers, OutlineStencil};
 use rmf_site_format::{
     DoorType, LiftCabin, LightKind, LocationTags, MeasurementMarker, ModelMarker,
     PhysicalCameraProperties, WallMarker,
@@ -82,15 +82,19 @@ pub fn update_outline_visualization(
         while let Some(top) = queue.pop() {
             if let Ok(children) = descendants.get(top) {
                 if let Some(color) = color {
-                    commands.entity(top).insert_bundle(OutlineBundle {
-                        outline: Outline {
-                            visible: true,
-                            width: 3.0,
-                            colour: color,
-                        },
-                        stencil: OutlineStencil,
-                    })
-                    .insert(OutlineRenderLayers(RenderLayers::layer(VISUAL_CUE_RENDER_LAYER)));
+                    commands
+                        .entity(top)
+                        .insert_bundle(OutlineBundle {
+                            outline: Outline {
+                                visible: true,
+                                width: 3.0,
+                                colour: color,
+                            },
+                            stencil: OutlineStencil,
+                        })
+                        .insert(OutlineRenderLayers(RenderLayers::layer(
+                            VISUAL_CUE_RENDER_LAYER,
+                        )));
                 } else {
                     commands
                         .entity(top)

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -62,7 +62,7 @@ pub fn update_outline_visualization(
             Or<(Changed<Hovered>, Changed<Selected>)>,
         ),
     >,
-    descendants: Query<Option<&Children>, Without<VisualCue>>,
+    descendants: Query<(Option<&Children>, Option<&VisualCue>)>,
 ) {
     for (e, hovering, selected) in &outlinable {
         let color = if hovering.cue() || selected.cue() {
@@ -80,7 +80,15 @@ pub fn update_outline_visualization(
         let mut queue: SmallVec<[Entity; 10]> = SmallVec::new();
         queue.push(e);
         while let Some(top) = queue.pop() {
-            if let Ok(children) = descendants.get(top) {
+            if let Ok((children, cue)) = descendants.get(top) {
+                if let Some(cue) = cue {
+                    if !cue.allow_outline {
+                        // TODO(MXG): Consider if we should allow the children
+                        // to be added. What if the non-outlined visual cue
+                        // has descendents that should be outlined?
+                        continue;
+                    }
+                }
                 if let Some(color) = color {
                     commands
                         .entity(top)

--- a/rmf_site_editor/src/interaction/preview.rs
+++ b/rmf_site_editor/src/interaction/preview.rs
@@ -18,8 +18,8 @@
 use bevy::{
     prelude::*,
     render::{
+        camera::{Projection, RenderTarget},
         view::RenderLayers,
-        camera::{Projection, RenderTarget}
     },
     window::{CreateWindow, PresentMode, WindowClosed, WindowId, Windows},
 };
@@ -62,7 +62,8 @@ fn create_camera_window(
         },
     });
     // Now spawn the camera
-    commands.entity(entity)
+    commands
+        .entity(entity)
         .insert(Camera {
             target: RenderTarget::Window(window_id),
             is_active: true,

--- a/rmf_site_editor/src/interaction/preview.rs
+++ b/rmf_site_editor/src/interaction/preview.rs
@@ -15,9 +15,14 @@
  *
 */
 
-use bevy::prelude::*;
-use bevy::render::camera::{Projection, RenderTarget};
-use bevy::window::{CreateWindow, PresentMode, WindowClosed, WindowId, Windows};
+use bevy::{
+    prelude::*,
+    render::{
+        view::RenderLayers,
+        camera::{Projection, RenderTarget}
+    },
+    window::{CreateWindow, PresentMode, WindowClosed, WindowId, Windows},
+};
 
 use rmf_site_format::{NameInSite, PhysicalCameraProperties, PreviewableMarker};
 
@@ -57,11 +62,13 @@ fn create_camera_window(
         },
     });
     // Now spawn the camera
-    commands.entity(entity).insert(Camera {
-        target: RenderTarget::Window(window_id),
-        is_active: true,
-        ..default()
-    });
+    commands.entity(entity)
+        .insert(Camera {
+            target: RenderTarget::Window(window_id),
+            is_active: true,
+            ..default()
+        })
+        .insert(RenderLayers::layer(0));
     window_id
 }
 

--- a/rmf_site_editor/src/interaction/select_anchor.rs
+++ b/rmf_site_editor/src/interaction/select_anchor.rs
@@ -753,10 +753,8 @@ impl Placement for PointPlacement {
         target: Entity,
         params: &mut SelectAnchorPlacementParams<'w, 's>,
     ) -> Result<Transition, ()> {
-        dbg!();
         if let Ok(mut point) = params.points.get_mut(target) {
             if let Ok(mut deps) = params.dependents.get_mut(**point) {
-                dbg!();
                 deps.remove(&target);
             }
 

--- a/rmf_site_editor/src/interaction/visual_cue.rs
+++ b/rmf_site_editor/src/interaction/visual_cue.rs
@@ -15,12 +15,9 @@
  *
 */
 
-use bevy::{
-    prelude::*,
-    render::view::visibility::RenderLayers,
-};
-use smallvec::SmallVec;
 use crate::interaction::VISUAL_CUE_RENDER_LAYER;
+use bevy::{prelude::*, render::view::visibility::RenderLayers};
+use smallvec::SmallVec;
 
 /// A unit component to tag entities that are only meant to be visual cues and
 /// should be excluded from visualization or analysis of physical objects.
@@ -42,7 +39,8 @@ pub fn propagate_visual_cues(
         let mut queue = SmallVec::<[Entity; 5]>::new();
         queue.push(e);
         while let Some(top) = queue.pop() {
-            commands.entity(top)
+            commands
+                .entity(top)
                 .insert(VisualCue)
                 .insert(RenderLayers::layer(VISUAL_CUE_RENDER_LAYER));
             if let Ok(children) = children.get(top) {

--- a/rmf_site_editor/src/interaction/visual_cue.rs
+++ b/rmf_site_editor/src/interaction/visual_cue.rs
@@ -29,11 +29,17 @@ pub struct VisualCue {
 
 impl VisualCue {
     pub fn outline() -> VisualCue {
-        VisualCue { allow_outline: true, inherited: false }
+        VisualCue {
+            allow_outline: true,
+            inherited: false,
+        }
     }
 
     pub fn no_outline() -> VisualCue {
-        VisualCue { allow_outline: false, inherited: false }
+        VisualCue {
+            allow_outline: false,
+            inherited: false,
+        }
     }
 
     pub fn inherit(other: Self) -> VisualCue {

--- a/rmf_site_editor/src/interaction/visual_cue.rs
+++ b/rmf_site_editor/src/interaction/visual_cue.rs
@@ -21,8 +21,28 @@ use smallvec::SmallVec;
 
 /// A unit component to tag entities that are only meant to be visual cues and
 /// should be excluded from visualization or analysis of physical objects.
-#[derive(Component, Debug)]
-pub struct VisualCue;
+#[derive(Component, Debug, Clone, Copy)]
+pub struct VisualCue {
+    pub allow_outline: bool,
+    pub inherited: bool,
+}
+
+impl VisualCue {
+    pub fn outline() -> VisualCue {
+        VisualCue { allow_outline: true, inherited: false }
+    }
+
+    pub fn no_outline() -> VisualCue {
+        VisualCue { allow_outline: false, inherited: false }
+    }
+
+    pub fn inherit(other: Self) -> VisualCue {
+        VisualCue {
+            inherited: true,
+            ..other
+        }
+    }
+}
 
 /// This system propagates visual cue tags and the correct RenderLayer to all
 /// entities that are meant to be visual cues. This system makes two assumptions:
@@ -32,20 +52,31 @@ pub struct VisualCue;
 /// loosen either of those assumptions.
 pub fn propagate_visual_cues(
     mut commands: Commands,
-    new_cues: Query<Entity, Or<(Added<VisualCue>, (With<VisualCue>, Changed<Children>))>>,
+    new_cues: Query<(Entity, &VisualCue), Or<(Changed<VisualCue>, Changed<Children>)>>,
     children: Query<&Children>,
+    existing_cues: Query<&VisualCue>,
 ) {
-    for e in &new_cues {
-        let mut queue = SmallVec::<[Entity; 5]>::new();
-        queue.push(e);
-        while let Some(top) = queue.pop() {
+    for (e, root_cue) in &new_cues {
+        let mut queue = SmallVec::<[(Entity, VisualCue); 5]>::new();
+        queue.push((e, *root_cue));
+        while let Some((top, top_cue)) = queue.pop() {
             commands
                 .entity(top)
-                .insert(VisualCue)
+                .insert(top_cue)
                 .insert(RenderLayers::layer(VISUAL_CUE_RENDER_LAYER));
+
             if let Ok(children) = children.get(top) {
                 for child in children {
-                    queue.push(*child);
+                    let child_cue = if let Ok(existing_cue) = existing_cues.get(*child) {
+                        if existing_cue.inherited {
+                            VisualCue::inherit(top_cue)
+                        } else {
+                            *existing_cue
+                        }
+                    } else {
+                        VisualCue::inherit(top_cue)
+                    };
+                    queue.push((*child, child_cue));
                 }
             }
         }

--- a/rmf_site_editor/src/interaction/visual_cue.rs
+++ b/rmf_site_editor/src/interaction/visual_cue.rs
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::{
+    prelude::*,
+    render::view::visibility::RenderLayers,
+};
+use smallvec::SmallVec;
+use crate::interaction::VISUAL_CUE_RENDER_LAYER;
+
+/// A unit component to tag entities that are only meant to be visual cues and
+/// should be excluded from visualization or analysis of physical objects.
+#[derive(Component, Debug)]
+pub struct VisualCue;
+
+/// This system propagates visual cue tags and the correct RenderLayer to all
+/// entities that are meant to be visual cues. This system makes two assumptions:
+/// 1. Any entity that is a VisualCue will be a VisualCue forever
+/// 2. Any descendents of a VisualCue should also be VisualCues.
+/// We will need to change the implementation of this system if we ever want to
+/// loosen either of those assumptions.
+pub fn propagate_visual_cues(
+    mut commands: Commands,
+    new_cues: Query<Entity, Or<(Added<VisualCue>, (With<VisualCue>, Changed<Children>))>>,
+    children: Query<&Children>,
+) {
+    for e in &new_cues {
+        let mut queue = SmallVec::<[Entity; 5]>::new();
+        queue.push(e);
+        while let Some(top) = queue.pop() {
+            commands.entity(top)
+                .insert(VisualCue)
+                .insert(RenderLayers::layer(VISUAL_CUE_RENDER_LAYER));
+            if let Ok(children) = children.get(top) {
+                for child in children {
+                    queue.push(*child);
+                }
+            }
+        }
+    }
+}

--- a/rmf_site_editor/src/site/location.rs
+++ b/rmf_site_editor/src/site/location.rs
@@ -15,11 +15,7 @@
  *
 */
 
-use crate::{
-    animate::Spinning,
-    site::*,
-    interaction::VisualCue,
-};
+use crate::{animate::Spinning, interaction::VisualCue, site::*};
 use bevy::prelude::*;
 
 // TODO(MXG): Refactor this implementation with should_display_lane using traits and generics

--- a/rmf_site_editor/src/site/location.rs
+++ b/rmf_site_editor/src/site/location.rs
@@ -78,7 +78,7 @@ pub fn add_location_visuals(
             })
             .insert(Spinning::new(-10.0))
             .insert(Category::Location)
-            .insert(VisualCue);
+            .insert(VisualCue::outline());
     }
 }
 

--- a/rmf_site_editor/src/site/location.rs
+++ b/rmf_site_editor/src/site/location.rs
@@ -15,7 +15,11 @@
  *
 */
 
-use crate::{animate::Spinning, site::*};
+use crate::{
+    animate::Spinning,
+    site::*,
+    interaction::VisualCue,
+};
 use bevy::prelude::*;
 
 // TODO(MXG): Refactor this implementation with should_display_lane using traits and generics
@@ -77,7 +81,8 @@ pub fn add_location_visuals(
                 ..default()
             })
             .insert(Spinning::new(-10.0))
-            .insert(Category::Location);
+            .insert(Category::Location)
+            .insert(VisualCue);
     }
 }
 

--- a/rmf_site_format/src/category.rs
+++ b/rmf_site_format/src/category.rs
@@ -67,6 +67,8 @@ impl Category {
 
     /// Returns true if the category of this element has a physical presence.
     /// Returns false if the category of this element is conceptual.
+    // TODO(MXG): Consider whether all non-physical entities should automatically
+    // be assigned the VisualCue component.
     pub fn is_physical(&self) -> bool {
         match self {
             Self::Door | Self::Wall | Self::Floor | Self::Lift | Self::Model => true,


### PR DESCRIPTION
Until now we've allowed visual cues that are meant for the user (e.g. visualizations of lanes and anchors) to appear in the physical camera preview image. That behavior is not desirable since it means the physical camera preview is incorrect.

This PR eliminates that problem using bevy's `RenderLayers` feature. The `RenderLayers` component allows us to control what entities get rendered in which camera views. The non-physical entities are put into their own render layer which only gets rendered by the user-camera.

In order to prevent the user interaction highlights from showing in the physical cameras, I needed to tweak the upstream implementation of `bevy_mod_outline`. I've [opened an issue](https://github.com/komadori/bevy_mod_outline/issues/8) to ask the maintainer to open a branch for `v0.2` so I can open a PR for the changes.