### PR TITLE
Allow models to be dragged

### DIFF
--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -179,7 +179,6 @@ pub fn update_anchor_visual_cues(
         ),
         Or<(Changed<Hovered>, Changed<Selected>, Changed<Dependents>)>,
     >,
-    mut bobbing: Query<&mut Bobbing>,
     mut visibility: Query<&mut Visibility>,
     mut materials: Query<&mut Handle<StandardMaterial>>,
     deps: Query<&Dependents>,

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-    interaction::Selectable,
+    interaction::{Selectable, DragPlaneBundle},
     site::{Category, PreventDeletion},
 };
 use bevy::{asset::LoadState, prelude::*};
@@ -174,11 +174,15 @@ pub fn make_models_selectable(
         // Use a small vec here to try to dodge heap allocation if possible.
         // TODO(MXG): Run some tests to see if an allocation of 32 is typically
         // sufficient.
-        let mut queue: SmallVec<[Entity; 32]> = SmallVec::new();
+        let mut queue: SmallVec<[Entity; 16]> = SmallVec::new();
         queue.push(model_scene_root);
 
         while let Some(e) = queue.pop() {
-            commands.entity(e).insert(selectable.clone());
+            commands
+                .entity(e)
+                .insert(selectable.clone())
+                .insert_bundle(DragPlaneBundle::new(selectable.element, Vec3::Z));
+
             if let Ok(children) = all_children.get(e) {
                 for child in children {
                     queue.push(*child);

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-    interaction::{Selectable, DragPlaneBundle},
+    interaction::{DragPlaneBundle, Selectable},
     site::{Category, PreventDeletion},
 };
 use bevy::{asset::LoadState, prelude::*};


### PR DESCRIPTION
Now models can be dragged around in the x/y plane by clicking and dragging.