### PR TITLE
Upgrade to bevy 0.9

### DIFF
--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -12,10 +12,10 @@ path = "src/main.rs"
 name = "rmf_site_editor"
 
 [dependencies]
-bevy_egui = "0.15"
-bevy_mod_picking = "0.8"
-bevy_mod_raycast = "0.6"
-bevy_mod_outline = "0.2.5"
+bevy_egui = "0.19"
+bevy_mod_picking = "0.10"
+bevy_mod_raycast = "0.7"
+bevy_mod_outline = "0.3.2"
 smallvec = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.23"
@@ -23,7 +23,7 @@ serde_json = "1.0"
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3.56", features = ["console"] }
 futures-lite = "1.12.0"
-bevy = "0.8"
+bevy = "0.9"
 dirs = "4.0"
 thread_local = "*"
 lyon = "1"
@@ -34,7 +34,7 @@ bitfield = "*"
 
 # only enable the 'dynamic' feature if we're not building for web or windows
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))'.dependencies]
-bevy = { version = "0.8", features = ["dynamic"] }
+bevy = { version = "0.9", features = ["dynamic"] }
 surf = { version = "2.3" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -43,7 +43,7 @@ clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "su
 
 # windows doesnt work well with dynamic feature yet
 [target.'cfg(target_os = "windows")'.dependencies]
-bevy = "0.8"
+bevy = "0.9"
 surf = { version = "2.3" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/rmf_site_editor/src/aabb.rs
+++ b/rmf_site_editor/src/aabb.rs
@@ -21,7 +21,7 @@ use smallvec::SmallVec;
 /// recomputes `Aabb`s for entities whose mesh has been mutated. These mutations are visible via
 /// [`AssetEvent<Mesh>`](AssetEvent) which tells us which mesh was changed but not which entities
 /// have that mesh.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Resource)]
 pub struct EntityMeshMap {
     entities_with_mesh: HashMap<Handle<Mesh>, SmallVec<[Entity; 1]>>,
     mesh_for_entity: HashMap<Entity, Handle<Mesh>>,

--- a/rmf_site_editor/src/animate.rs
+++ b/rmf_site_editor/src/animate.rs
@@ -87,7 +87,7 @@ pub fn update_spinning_animations(
     for (mut tf, spin, visibility) in &mut spinners {
         if visibility.is_visible_in_view() {
             let angle =
-                2. * std::f32::consts::PI * now.seconds_since_startup() as f32 / spin.period;
+                2. * std::f32::consts::PI * now.elapsed_seconds() / spin.period;
             tf.as_mut().rotation = Quat::from_rotation_z(angle);
         }
     }
@@ -99,7 +99,7 @@ pub fn update_bobbing_animations(
 ) {
     for (mut tf, bob, visibility) in &mut bobbers {
         if visibility.is_visible_in_view() {
-            let theta = 2. * std::f32::consts::PI * now.seconds_since_startup() as f32 / bob.period;
+            let theta = 2. * std::f32::consts::PI * now.elapsed_seconds() / bob.period;
             let dh = bob.heights.1 - bob.heights.0;
             tf.as_mut().translation[2] = dh * (1. - theta.cos()) / 2.0 + bob.heights.0;
         }

--- a/rmf_site_editor/src/animate.rs
+++ b/rmf_site_editor/src/animate.rs
@@ -86,8 +86,7 @@ pub fn update_spinning_animations(
 ) {
     for (mut tf, spin, visibility) in &mut spinners {
         if visibility.is_visible_in_view() {
-            let angle =
-                2. * std::f32::consts::PI * now.elapsed_seconds() / spin.period;
+            let angle = 2. * std::f32::consts::PI * now.elapsed_seconds() / spin.period;
             tf.as_mut().rotation = Quat::from_rotation_z(angle);
         }
     }

--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -46,14 +46,14 @@ pub fn add_anchor_visual_cues(
 
         let mut commands = commands.entity(e);
         let body = commands.add_children(|parent| {
-            let mut body = parent.spawn_bundle(PbrBundle {
+            let mut body = parent.spawn(PbrBundle {
                 mesh: body_mesh,
                 material: site_assets.passive_anchor_material.clone(),
                 ..default()
             });
             body.insert(Selectable::new(e));
             if subordinate.is_none() {
-                body.insert_bundle(DragPlaneBundle::new(e, Vec3::Z));
+                body.insert(DragPlaneBundle::new(e, Vec3::Z));
             }
             let body = body.id();
 

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -18,7 +18,7 @@
 use crate::{interaction::*, shapes::*};
 use bevy::{math::Affine3A, prelude::*};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct InteractionAssets {
     pub dagger_mesh: Handle<Mesh>,
     pub dagger_material: Handle<StandardMaterial>,
@@ -56,7 +56,7 @@ impl InteractionAssets {
     ) -> Entity {
         return command.entity(parent).add_children(|parent| {
             parent
-                .spawn_bundle(PbrBundle {
+                .spawn(PbrBundle {
                     transform: Transform::from_rotation(rotation)
                         .with_translation(offset)
                         .with_scale(Vec3::splat(scale)),
@@ -64,7 +64,7 @@ impl InteractionAssets {
                     material: material_set.passive.clone(),
                     ..default()
                 })
-                .insert_bundle(
+                .insert(
                     DragAxisBundle::new(for_entity, Vec3::Z).with_materials(material_set),
                 )
                 .id()
@@ -79,7 +79,7 @@ impl InteractionAssets {
     ) {
         let drag_parent = command.entity(anchor).add_children(|parent| {
             parent
-                .spawn_bundle(SpatialBundle::default())
+                .spawn(SpatialBundle::default())
                 .insert(VisualCue::no_outline())
                 .id()
         });

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -64,9 +64,7 @@ impl InteractionAssets {
                     material: material_set.passive.clone(),
                     ..default()
                 })
-                .insert(
-                    DragAxisBundle::new(for_entity, Vec3::Z).with_materials(material_set),
-                )
+                .insert(DragAxisBundle::new(for_entity, Vec3::Z).with_materials(material_set))
                 .id()
         });
     }

--- a/rmf_site_editor/src/interaction/camera_controls.rs
+++ b/rmf_site_editor/src/interaction/camera_controls.rs
@@ -50,6 +50,7 @@ pub const HOVERED_OUTLINE_LAYER: u8 = 4;
 /// above anything that would be obstructing them.
 pub const XRAY_RENDER_LAYER: u8 = 5;
 
+#[derive(Resource)]
 struct MouseLocation {
     previous: Vec2,
 }
@@ -61,7 +62,7 @@ impl Default for MouseLocation {
         }
     }
 }
-#[derive(PartialEq, Debug, Copy, Clone, Reflect)]
+#[derive(PartialEq, Debug, Copy, Clone, Reflect, Resource)]
 pub enum ProjectionMode {
     Perspective,
     Orthographic,
@@ -77,7 +78,7 @@ impl ProjectionMode {
     }
 }
 
-#[derive(Debug, Clone, Reflect)]
+#[derive(Debug, Clone, Reflect, Resource)]
 pub struct CameraControls {
     mode: ProjectionMode,
     pub perspective_camera_entities: [Entity; 4],
@@ -91,7 +92,7 @@ pub struct CameraControls {
 }
 
 /// True/false for whether the headlight should be on or off
-#[derive(Clone, Copy, PartialEq, Eq, Deref, DerefMut)]
+#[derive(Clone, Copy, PartialEq, Eq, Deref, DerefMut, Resource)]
 pub struct HeadlightToggle(pub bool);
 
 impl Default for HeadlightToggle {
@@ -176,8 +177,7 @@ impl CameraControls {
 impl FromWorld for CameraControls {
     fn from_world(world: &mut World) -> Self {
         let perspective_headlight = world
-            .spawn()
-            .insert_bundle(DirectionalLightBundle {
+            .spawn(DirectionalLightBundle {
                 directional_light: DirectionalLight {
                     shadows_enabled: false,
                     illuminance: 20000.,
@@ -194,8 +194,7 @@ impl FromWorld for CameraControls {
         ]
         .map(|(priority, layer)| {
             world
-                .spawn()
-                .insert_bundle(Camera3dBundle {
+                .spawn(Camera3dBundle {
                     projection: Projection::Perspective(Default::default()),
                     camera: Camera {
                         priority,
@@ -207,20 +206,19 @@ impl FromWorld for CameraControls {
                     },
                     ..default()
                 })
-                .insert(Visibility::visible())
+                .insert(Visibility::VISIBLE)
                 .insert(ComputedVisibility::default())
                 .insert(RenderLayers::layer(layer))
                 .id()
         });
 
         let perspective_base_camera = world
-            .spawn()
-            .insert_bundle(Camera3dBundle {
+            .spawn(Camera3dBundle {
                 transform: Transform::from_xyz(-10., -10., 10.).looking_at(Vec3::ZERO, Vec3::Z),
                 projection: Projection::Perspective(Default::default()),
                 ..default()
             })
-            .insert(Visibility::visible())
+            .insert(Visibility::VISIBLE)
             .insert(ComputedVisibility::default())
             .insert(RenderLayers::from_layers(&[
                 GENERAL_RENDER_LAYER,
@@ -231,8 +229,7 @@ impl FromWorld for CameraControls {
             .id();
 
         let orthographic_headlight = world
-            .spawn()
-            .insert_bundle(DirectionalLightBundle {
+            .spawn(DirectionalLightBundle {
                 transform: Transform::from_rotation(Quat::from_axis_angle(
                     Vec3::new(1., 1., 0.).normalize(),
                     35_f32.to_radians(),
@@ -260,8 +257,7 @@ impl FromWorld for CameraControls {
         ]
         .map(|(priority, layer)| {
             world
-                .spawn()
-                .insert_bundle(Camera3dBundle {
+                .spawn(Camera3dBundle {
                     camera: Camera {
                         is_active: false,
                         priority,
@@ -274,15 +270,14 @@ impl FromWorld for CameraControls {
                     projection: Projection::Orthographic(ortho_projection.clone()),
                     ..default()
                 })
-                .insert(Visibility::visible())
+                .insert(Visibility::VISIBLE)
                 .insert(ComputedVisibility::default())
                 .insert(RenderLayers::layer(XRAY_RENDER_LAYER))
                 .id()
         });
 
         let orthographic_camera_entity = world
-            .spawn()
-            .insert_bundle(Camera3dBundle {
+            .spawn(Camera3dBundle {
                 camera: Camera {
                     is_active: false,
                     ..default()
@@ -291,7 +286,7 @@ impl FromWorld for CameraControls {
                 projection: Projection::Orthographic(ortho_projection),
                 ..default()
             })
-            .insert(Visibility::visible())
+            .insert(Visibility::VISIBLE)
             .insert(ComputedVisibility::default())
             .insert(RenderLayers::from_layers(&[
                 GENERAL_RENDER_LAYER,

--- a/rmf_site_editor/src/interaction/cursor.rs
+++ b/rmf_site_editor/src/interaction/cursor.rs
@@ -28,7 +28,7 @@ use std::collections::HashSet;
 
 /// A resource that keeps track of the unique entities that play a role in
 /// displaying the 3D cursor
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Resource)]
 pub struct Cursor {
     pub frame: Entity,
     pub halo: Entity,
@@ -125,8 +125,7 @@ impl FromWorld for Cursor {
         let preview_anchor_material = site_assets.preview_anchor_material.clone();
 
         let halo = world
-            .spawn()
-            .insert_bundle(PbrBundle {
+            .spawn(PbrBundle {
                 transform: Transform::from_scale([0.2, 0.2, 1.].into()),
                 mesh: halo_mesh,
                 material: halo_material,
@@ -138,8 +137,7 @@ impl FromWorld for Cursor {
             .id();
 
         let dagger = world
-            .spawn()
-            .insert_bundle(PbrBundle {
+            .spawn(PbrBundle {
                 mesh: dagger_mesh,
                 material: dagger_material,
                 visibility: Visibility { is_visible: true },
@@ -151,13 +149,12 @@ impl FromWorld for Cursor {
             .id();
 
         let level_anchor_placement = world
-            .spawn()
-            .insert_bundle(AnchorBundle::new([0., 0.].into()).visible(false))
+            .spawn(AnchorBundle::new([0., 0.].into()).visible(false))
             .insert(Pending)
             .insert(Preview)
             .insert(VisualCue::no_outline())
             .with_children(|parent| {
-                parent.spawn_bundle(PbrBundle {
+                parent.spawn(PbrBundle {
                     mesh: level_anchor_mesh,
                     material: preview_anchor_material.clone(),
                     ..default()
@@ -166,13 +163,12 @@ impl FromWorld for Cursor {
             .id();
 
         let site_anchor_placement = world
-            .spawn()
-            .insert_bundle(AnchorBundle::new([0., 0.].into()).visible(false))
+            .spawn(AnchorBundle::new([0., 0.].into()).visible(false))
             .insert(Pending)
             .insert(Preview)
             .insert(VisualCue::no_outline())
             .with_children(|parent| {
-                parent.spawn_bundle(PbrBundle {
+                parent.spawn(PbrBundle {
                     mesh: site_anchor_mesh,
                     material: preview_anchor_material,
                     ..default()
@@ -181,10 +177,9 @@ impl FromWorld for Cursor {
             .id();
 
         let cursor = world
-            .spawn()
+            .spawn(VisualCue::no_outline())
             .push_children(&[halo, dagger, level_anchor_placement, site_anchor_placement])
-            .insert(VisualCue::no_outline())
-            .insert_bundle(SpatialBundle {
+            .insert(SpatialBundle {
                 visibility: Visibility { is_visible: false },
                 ..default()
             })

--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -190,7 +190,7 @@ impl DragPlaneBundle {
 }
 
 /// Used as a resource to keep track of which draggable is currently hovered
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Resource)]
 pub enum GizmoState {
     Dragging(Entity),
     Hovering(Entity),
@@ -219,7 +219,7 @@ pub struct MoveTo {
 
 pub fn make_gizmos_pickable(mut commands: Commands, new_gizmos: Query<Entity, Added<Gizmo>>) {
     for e in &new_gizmos {
-        commands.entity(e).insert_bundle(PickableBundle::default());
+        commands.entity(e).insert(PickableBundle::default());
     }
 }
 

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -70,7 +70,7 @@ pub fn add_physical_light_visual_cues(
             .insert(light_material.clone())
             .add_children(|parent| {
                 let point = parent
-                    .spawn_bundle(SpatialBundle {
+                    .spawn(SpatialBundle {
                         visibility: Visibility {
                             is_visible: kind.is_point(),
                         },
@@ -78,74 +78,74 @@ pub fn add_physical_light_visual_cues(
                     })
                     .with_children(|point| {
                         point
-                            .spawn_bundle(PbrBundle {
+                            .spawn(PbrBundle {
                                 mesh: assets.point_light_socket_mesh.clone(),
                                 material: assets.physical_light_cover_material.clone(),
                                 ..default()
                             })
                             .insert(Selectable::new(e))
-                            .insert_bundle(DragPlaneBundle::new(e, Vec3::Z).globally());
+                            .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
 
                         point
-                            .spawn_bundle(PbrBundle {
+                            .spawn(PbrBundle {
                                 mesh: assets.point_light_shine_mesh.clone(),
                                 material: light_material.clone(),
                                 ..default()
                             })
                             .insert(Selectable::new(e))
-                            .insert_bundle(DragPlaneBundle::new(e, Vec3::Z).globally());
+                            .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
                     })
                     .id();
 
                 let spot = parent
-                    .spawn_bundle(SpatialBundle {
+                    .spawn(SpatialBundle {
                         visibility: Visibility {
                             is_visible: kind.is_spot(),
                         },
                         ..default()
                     })
                     .with_children(|spot| {
-                        spot.spawn_bundle(PbrBundle {
+                        spot.spawn(PbrBundle {
                             mesh: assets.spot_light_cover_mesh.clone(),
                             material: assets.physical_light_cover_material.clone(),
                             ..default()
                         })
                         .insert(Selectable::new(e))
-                        .insert_bundle(DragPlaneBundle::new(e, Vec3::Z).globally());
+                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
 
-                        spot.spawn_bundle(PbrBundle {
+                        spot.spawn(PbrBundle {
                             mesh: assets.spot_light_shine_mesh.clone(),
                             material: light_material.clone(),
                             ..default()
                         })
                         .insert(Selectable::new(e))
-                        .insert_bundle(DragPlaneBundle::new(e, Vec3::Z).globally());
+                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
                     })
                     .id();
 
                 let directional = parent
-                    .spawn_bundle(SpatialBundle {
+                    .spawn(SpatialBundle {
                         visibility: Visibility {
                             is_visible: kind.is_directional(),
                         },
                         ..default()
                     })
                     .with_children(|dir| {
-                        dir.spawn_bundle(PbrBundle {
+                        dir.spawn(PbrBundle {
                             mesh: assets.directional_light_cover_mesh.clone(),
                             material: assets.direction_light_cover_material.clone(),
                             ..default()
                         })
                         .insert(Selectable::new(e))
-                        .insert_bundle(DragPlaneBundle::new(e, Vec3::Z).globally());
+                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
 
-                        dir.spawn_bundle(PbrBundle {
+                        dir.spawn(PbrBundle {
                             mesh: assets.directional_light_shine_mesh.clone(),
                             material: light_material.clone(),
                             ..default()
                         })
                         .insert(Selectable::new(e))
-                        .insert_bundle(DragPlaneBundle::new(e, Vec3::Z).globally());
+                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
                     })
                     .id();
 

--- a/rmf_site_editor/src/interaction/mode.rs
+++ b/rmf_site_editor/src/interaction/mode.rs
@@ -20,7 +20,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 
 /// Used as a resource to indicate what type of interaction we are currently
 /// expecting from the user.
-#[derive(Clone)]
+#[derive(Clone, Resource)]
 pub enum InteractionMode {
     /// The user may hover/select any item in the scene. This is the default
     /// interaction mode.

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -17,7 +17,7 @@
 
 use crate::interaction::*;
 use bevy::render::view::RenderLayers;
-use bevy_mod_outline::{Outline, OutlineBundle, OutlineRenderLayers, OutlineStencil};
+use bevy_mod_outline::{OutlineVolume, OutlineBundle, OutlineRenderLayers};
 use rmf_site_format::{
     DoorType, FloorMarker, LiftCabin, LightKind, LocationTags, MeasurementMarker, ModelMarker,
     PhysicalCameraProperties, WallMarker,
@@ -134,20 +134,19 @@ pub fn update_outline_visualization(
                 if let Some(color) = color {
                     commands
                         .entity(top)
-                        .insert_bundle(OutlineBundle {
-                            outline: Outline {
+                        .insert(OutlineBundle {
+                            outline: OutlineVolume {
                                 visible: true,
                                 width: 3.0,
                                 colour: color,
                             },
-                            stencil: OutlineStencil,
+                            ..default()
                         })
                         .insert(layers);
                 } else {
                     commands
                         .entity(top)
-                        .remove::<Outline>()
-                        .remove::<OutlineStencil>();
+                        .remove::<OutlineBundle>();
                 }
 
                 if let Some(children) = children {

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -17,7 +17,7 @@
 
 use crate::interaction::*;
 use bevy::render::view::RenderLayers;
-use bevy_mod_outline::{OutlineVolume, OutlineBundle, OutlineRenderLayers};
+use bevy_mod_outline::{OutlineBundle, OutlineRenderLayers, OutlineVolume};
 use rmf_site_format::{
     DoorType, FloorMarker, LiftCabin, LightKind, LocationTags, MeasurementMarker, ModelMarker,
     PhysicalCameraProperties, WallMarker,
@@ -144,9 +144,7 @@ pub fn update_outline_visualization(
                         })
                         .insert(layers);
                 } else {
-                    commands
-                        .entity(top)
-                        .remove::<OutlineBundle>();
+                    commands.entity(top).remove::<OutlineBundle>();
                 }
 
                 if let Some(children) = children {

--- a/rmf_site_editor/src/interaction/select.rs
+++ b/rmf_site_editor/src/interaction/select.rs
@@ -134,9 +134,7 @@ pub fn make_selectable_entities_pickable(
     targets: Query<(Option<&Hovered>, Option<&Selected>)>,
 ) {
     for (entity, selectable) in &new_selectables {
-        commands
-            .entity(entity)
-            .insert(PickableBundle::default());
+        commands.entity(entity).insert(PickableBundle::default());
 
         if let Ok((hovered, selected)) = targets.get(selectable.element) {
             if hovered.is_none() {

--- a/rmf_site_editor/src/interaction/select.rs
+++ b/rmf_site_editor/src/interaction/select.rs
@@ -88,11 +88,11 @@ impl Default for Hovered {
 }
 
 /// Used as a resource to keep track of which entity is currently selected.
-#[derive(Default, Debug, Clone, Copy, Deref, DerefMut)]
+#[derive(Default, Debug, Clone, Copy, Deref, DerefMut, Resource)]
 pub struct Selection(pub Option<Entity>);
 
 /// Used as a resource to keep track of which entity is currently hovered.
-#[derive(Default, Debug, Clone, Copy, Deref, DerefMut)]
+#[derive(Default, Debug, Clone, Copy, Deref, DerefMut, Resource)]
 pub struct Hovering(pub Option<Entity>);
 
 /// Used as an event to command a change in the selected entity.
@@ -105,6 +105,7 @@ pub struct Hover(pub Option<Entity>);
 
 /// A resource to track what kind of blockers are preventing the selection
 /// behavior from being active
+#[derive(Resource)]
 pub struct SelectionBlockers {
     /// An entity is being dragged
     pub dragging: bool,
@@ -135,7 +136,7 @@ pub fn make_selectable_entities_pickable(
     for (entity, selectable) in &new_selectables {
         commands
             .entity(entity)
-            .insert_bundle(PickableBundle::default());
+            .insert(PickableBundle::default());
 
         if let Ok((hovered, selected)) = targets.get(selectable.element) {
             if hovered.is_none() {

--- a/rmf_site_editor/src/interaction/select_anchor.rs
+++ b/rmf_site_editor/src/interaction/select_anchor.rs
@@ -359,11 +359,7 @@ impl EdgePlacement {
             create: Arc::new(
                 |params: &mut SelectAnchorPlacementParams, edge: Edge<Entity>| {
                     let new_bundle: T = edge.into();
-                    params
-                        .commands
-                        .spawn(new_bundle)
-                        .insert(Pending)
-                        .id()
+                    params.commands.spawn(new_bundle).insert(Pending).id()
                 },
             ),
             finalize: Arc::new(|params: &mut SelectAnchorPlacementParams, entity: Entity| {
@@ -645,11 +641,7 @@ impl PointPlacement {
             create: Arc::new(
                 |params: &mut SelectAnchorPlacementParams, point: Point<Entity>| {
                     let new_bundle: T = point.into();
-                    params
-                        .commands
-                        .spawn(new_bundle)
-                        .insert(Pending)
-                        .id()
+                    params.commands.spawn(new_bundle).insert(Pending).id()
                 },
             ),
             finalize: Arc::new(|params: &mut SelectAnchorPlacementParams, entity: Entity| {
@@ -798,11 +790,7 @@ impl PathPlacement {
             create: Arc::new(
                 |params: &mut SelectAnchorPlacementParams, path: Path<Entity>| {
                     let new_bundle: T = path.into();
-                    params
-                        .commands
-                        .spawn(new_bundle)
-                        .insert(Pending)
-                        .id()
+                    params.commands.spawn(new_bundle).insert(Pending).id()
                 },
             ),
             finalize: Arc::new(|params: &mut SelectAnchorPlacementParams, entity: Entity| {
@@ -1716,10 +1704,7 @@ pub fn handle_select_anchor_mode(
                 }
             };
 
-            let new_anchor = params
-                .commands
-                .spawn(AnchorBundle::at_transform(tf))
-                .id();
+            let new_anchor = params.commands.spawn(AnchorBundle::at_transform(tf)).id();
             if request.scope.is_site() {
                 if let Some(site) = site.0 {
                     params.commands.entity(site).add_child(new_anchor);

--- a/rmf_site_editor/src/interaction/select_anchor.rs
+++ b/rmf_site_editor/src/interaction/select_anchor.rs
@@ -361,8 +361,7 @@ impl EdgePlacement {
                     let new_bundle: T = edge.into();
                     params
                         .commands
-                        .spawn()
-                        .insert_bundle(new_bundle)
+                        .spawn(new_bundle)
                         .insert(Pending)
                         .id()
                 },
@@ -648,8 +647,7 @@ impl PointPlacement {
                     let new_bundle: T = point.into();
                     params
                         .commands
-                        .spawn()
-                        .insert_bundle(new_bundle)
+                        .spawn(new_bundle)
                         .insert(Pending)
                         .id()
                 },
@@ -802,8 +800,7 @@ impl PathPlacement {
                     let new_bundle: T = path.into();
                     params
                         .commands
-                        .spawn()
-                        .insert_bundle(new_bundle)
+                        .spawn(new_bundle)
                         .insert(Pending)
                         .id()
                 },
@@ -1721,7 +1718,7 @@ pub fn handle_select_anchor_mode(
 
             let new_anchor = params
                 .commands
-                .spawn_bundle(AnchorBundle::at_transform(tf))
+                .spawn(AnchorBundle::at_transform(tf))
                 .id();
             if request.scope.is_site() {
                 if let Some(site) = site.0 {

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -25,7 +25,7 @@ use crate::{
 use bevy::prelude::*;
 use bevy_egui::EguiContext;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Resource)]
 pub struct DebugMode(pub bool);
 
 impl FromWorld for DebugMode {

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -106,14 +106,17 @@ pub fn run(command_line_args: Vec<String>) {
 
     #[cfg(target_arch = "wasm32")]
     {
-        app.add_plugins(DefaultPlugins.set(WindowPlugin {
-            window: WindowDescriptor {
-                title: "RMF Site Editor".to_owned(),
-                canvas: Some(String::from("#rmf_site_editor_canvas")),
-                ..default()
-            },
-        })
-        .add_before::<bevy::asset::AssetPlugin, _>(SiteAssetIoPlugin))
+        app.add_plugins(
+            DefaultPlugins
+                .set(WindowPlugin {
+                    window: WindowDescriptor {
+                        title: "RMF Site Editor".to_owned(),
+                        canvas: Some(String::from("#rmf_site_editor_canvas")),
+                        ..default()
+                    },
+                })
+                .add_before::<bevy::asset::AssetPlugin, _>(SiteAssetIoPlugin),
+        )
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(0.5))
@@ -123,16 +126,19 @@ pub fn run(command_line_args: Vec<String>) {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        app.add_plugins(DefaultPlugins.set(WindowPlugin {
-            window: WindowDescriptor {
-                title: "RMF Site Editor".to_owned(),
-                width: 1600.,
-                height: 900.,
-                ..default()
-            },
-            ..default()
-        })
-        .add_before::<bevy::asset::AssetPlugin, _>(SiteAssetIoPlugin));
+        app.add_plugins(
+            DefaultPlugins
+                .set(WindowPlugin {
+                    window: WindowDescriptor {
+                        title: "RMF Site Editor".to_owned(),
+                        width: 1600.,
+                        height: 900.,
+                        ..default()
+                    },
+                    ..default()
+                })
+                .add_before::<bevy::asset::AssetPlugin, _>(SiteAssetIoPlugin),
+        );
     }
 
     app.init_resource::<Settings>()

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -1,4 +1,4 @@
-use bevy::{pbr::DirectionalLightShadowMap, prelude::*, render::render_resource::WgpuAdapterInfo};
+use bevy::{pbr::DirectionalLightShadowMap, prelude::*, render::renderer::RenderAdapterInfo};
 use bevy_egui::EguiPlugin;
 use main_menu::MainMenuPlugin;
 // use warehouse_generator::WarehouseGeneratorPlugin;
@@ -75,7 +75,7 @@ fn check_browser_window_size(mut windows: ResMut<Windows>) {
     }
 }
 
-fn init_settings(mut settings: ResMut<Settings>, adapter_info: Res<WgpuAdapterInfo>) {
+fn init_settings(mut settings: ResMut<Settings>, adapter_info: Res<RenderAdapterInfo>) {
     // todo: be more sophisticated
     let is_elite = adapter_info.name.contains("NVIDIA");
     if is_elite {
@@ -106,12 +106,14 @@ pub fn run(command_line_args: Vec<String>) {
 
     #[cfg(target_arch = "wasm32")]
     {
-        app.insert_resource(WindowDescriptor {
-            title: "RMF Site Editor".to_owned(),
-            canvas: Some(String::from("#rmf_site_editor_canvas")),
-            //vsync: false,
-            ..Default::default()
+        app.add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                title: "RMF Site Editor".to_owned(),
+                canvas: Some(String::from("#rmf_site_editor_canvas")),
+                ..default()
+            },
         })
+        .add_before::<bevy::asset::AssetPlugin, _>(SiteAssetIoPlugin))
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(0.5))
@@ -121,21 +123,21 @@ pub fn run(command_line_args: Vec<String>) {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        app.insert_resource(WindowDescriptor {
-            title: "RMF Site Editor".to_owned(),
-            width: 1600.,
-            height: 900.,
-            //vsync: false,
-            ..Default::default()
-        });
+        app.add_plugins(DefaultPlugins.set(WindowPlugin {
+            window: WindowDescriptor {
+                title: "RMF Site Editor".to_owned(),
+                width: 1600.,
+                height: 900.,
+                ..default()
+            },
+            ..default()
+        })
+        .add_before::<bevy::asset::AssetPlugin, _>(SiteAssetIoPlugin));
     }
 
     app.init_resource::<Settings>()
         .add_startup_system(init_settings)
         .insert_resource(DirectionalLightShadowMap { size: 2048 })
-        .add_plugins_with(DefaultPlugins, |group| {
-            group.add_before::<bevy::asset::AssetPlugin, _>(SiteAssetIoPlugin)
-        })
         .add_plugin(AabbUpdatePlugin)
         .add_plugin(EguiPlugin)
         .add_plugin(KeyboardInputPlugin)

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -34,6 +34,7 @@ struct LoadSiteFileResult(Option<OpenedMapFile>, Site);
 #[derive(Component)]
 struct LoadSiteFileTask(Task<Option<LoadSiteFileResult>>);
 
+#[derive(Resource)]
 pub struct Autoload {
     pub filename: Option<PathBuf>,
     pub import: Option<PathBuf>,
@@ -80,7 +81,7 @@ fn egui_ui(
                     let site = load_site_file(&FileHandle::wrap(filename.clone())).await?;
                     Some(LoadSiteFileResult(Some(OpenedMapFile(filename)), site))
                 });
-                _commands.spawn().insert(LoadSiteFileTask(future));
+                _commands.spawn(LoadSiteFileTask(future));
             }
             autoload.filename = None;
         }
@@ -119,7 +120,7 @@ fn egui_ui(
                             };
                             Some(LoadSiteFileResult(None, site))
                         });
-                        _commands.spawn().insert(LoadSiteFileTask(future));
+                        _commands.spawn(LoadSiteFileTask(future));
                     }
 
                     // on web, we don't have a handy thread pool, so we'll
@@ -178,7 +179,7 @@ fn egui_ui(
                                 site,
                             ))
                         });
-                        _commands.spawn().insert(LoadSiteFileTask(future));
+                        _commands.spawn(LoadSiteFileTask(future));
                     }
                 }
 
@@ -194,7 +195,7 @@ fn egui_ui(
             {
                 ui.add_space(20.);
                 ui.horizontal(|ui| {
-                    ui.with_layout(egui::Layout::right_to_left(), |ui| {
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         if ui.button("Exit").clicked() {
                             _exit.send(AppExit);
                         }

--- a/rmf_site_editor/src/occupancy.rs
+++ b/rmf_site_editor/src/occupancy.rs
@@ -278,7 +278,7 @@ fn calculate_grid(
 
             commands.entity(level).add_children(|level| {
                 level
-                    .spawn_bundle(PbrBundle {
+                    .spawn(PbrBundle {
                         mesh: meshes.add(mesh.into()),
                         material: assets.occupied_material.clone(),
                         ..default()

--- a/rmf_site_editor/src/settings.rs
+++ b/rmf_site_editor/src/settings.rs
@@ -1,3 +1,6 @@
+use bevy::prelude::Resource;
+
+#[derive(Resource)]
 pub struct Settings {
     pub graphics_quality: GraphicsQuality,
 }

--- a/rmf_site_editor/src/site/anchor.rs
+++ b/rmf_site_editor/src/site/anchor.rs
@@ -166,8 +166,7 @@ pub fn assign_orphan_anchors_to_parent(
         } else {
             // No level is currently assigned, so we should create one.
             let new_level_id = commands
-                .spawn()
-                .insert(LevelProperties {
+                .spawn(LevelProperties {
                     name: "<Unnamed>".to_string(),
                     elevation: 0.,
                 })

--- a/rmf_site_editor/src/site/assets.rs
+++ b/rmf_site_editor/src/site/assets.rs
@@ -18,6 +18,7 @@
 use crate::{shapes::*, site::*};
 use bevy::{math::Affine3A, prelude::*};
 
+#[derive(Resource)]
 pub struct SiteAssets {
     pub default_floor_material: Handle<StandardMaterial>,
     pub lane_mid_mesh: Handle<Mesh>,

--- a/rmf_site_editor/src/site/deletion.rs
+++ b/rmf_site_editor/src/site/deletion.rs
@@ -314,7 +314,7 @@ fn perform_deletions(all_to_delete: HashSet<Entity>, params: &mut DeletionParams
                 // level because all the existing levels are being deleted.
                 let new_level = params
                     .commands
-                    .spawn_bundle(SpatialBundle::default())
+                    .spawn(SpatialBundle::default())
                     .insert(LevelProperties {
                         elevation: 0.0,
                         name: "<Unnamed>".to_string(),

--- a/rmf_site_editor/src/site/door.rs
+++ b/rmf_site_editor/src/site/door.rs
@@ -185,7 +185,7 @@ pub fn add_door_visuals(
         let mut commands = commands.entity(e);
         let (body, cue_inner, cue_outline) = commands.add_children(|parent| {
             let body = parent
-                .spawn_bundle(PbrBundle {
+                .spawn(PbrBundle {
                     mesh: assets.box_mesh.clone(),
                     material: assets.door_body_material.clone(),
                     transform: shape_tf,
@@ -195,7 +195,7 @@ pub fn add_door_visuals(
                 .id();
 
             let cue_inner = parent
-                .spawn_bundle(PbrBundle {
+                .spawn(PbrBundle {
                     mesh: meshes.add(cue_inner_mesh),
                     material: assets.translucent_white.clone(),
                     ..default()
@@ -203,7 +203,7 @@ pub fn add_door_visuals(
                 .id();
 
             let cue_outline = parent
-                .spawn_bundle(PbrBundle {
+                .spawn(PbrBundle {
                     mesh: meshes.add(cue_outline_mesh),
                     material: assets.translucent_black.clone(),
                     ..default()
@@ -223,7 +223,7 @@ pub fn add_door_visuals(
         };
 
         commands
-            .insert_bundle(SpatialBundle {
+            .insert(SpatialBundle {
                 transform: pose_tf,
                 visibility: Visibility { is_visible },
                 ..default()

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -25,7 +25,7 @@ use rmf_site_format::{AssetSource, DrawingMarker, PixelsPerMeter, Pose};
 
 // We need to keep track of the drawing data until the image is loaded
 // since we will need to scale the mesh according to the size of the image
-#[derive(Default)]
+#[derive(Default, Resource)]
 pub struct LoadingDrawings(pub HashMap<Handle<Image>, (Entity, Pose, PixelsPerMeter)>);
 
 pub fn add_drawing_visuals(
@@ -86,7 +86,7 @@ pub fn handle_loaded_drawing(
 
                 commands
                     .entity(entity.clone())
-                    .insert_bundle(PbrBundle {
+                    .insert(PbrBundle {
                         mesh: meshes.add(mesh.into()),
                         material: materials.add(StandardMaterial {
                             base_color_texture: Some(handle.clone()),

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -168,7 +168,7 @@ pub fn add_floor_visuals(
         let mesh = make_floor_mesh(e, new_floor, &anchors);
         commands
             .entity(e)
-            .insert_bundle(PbrBundle {
+            .insert(PbrBundle {
                 mesh: meshes.add(mesh),
                 // TODO(MXG): load the user-specified texture when one is given
                 material: assets.default_floor_material.clone(),

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -176,7 +176,7 @@ pub fn add_lane_visuals(
             .unwrap();
         let mut commands = commands.entity(e);
         let (start, mid, end, outlines) = commands.add_children(|parent| {
-            let mut start = parent.spawn_bundle(PbrBundle {
+            let mut start = parent.spawn(PbrBundle {
                 mesh: assets.lane_end_mesh.clone(),
                 material: lane_material.clone(),
                 transform: Transform::from_translation(start_anchor),
@@ -184,7 +184,7 @@ pub fn add_lane_visuals(
             });
             let start_outline = start.add_children(|start| {
                 start
-                    .spawn_bundle(PbrBundle {
+                    .spawn(PbrBundle {
                         mesh: assets.lane_end_outline.clone(),
                         transform: Transform::from_translation(-0.000_5 * Vec3::Z),
                         visibility: Visibility { is_visible: false },
@@ -194,14 +194,14 @@ pub fn add_lane_visuals(
             });
             let start = start.id();
 
-            let mut mid = parent.spawn_bundle(PbrBundle {
+            let mut mid = parent.spawn(PbrBundle {
                 mesh: assets.lane_mid_mesh.clone(),
                 material: lane_material.clone(),
                 transform: line_stroke_transform(&start_anchor, &end_anchor, LANE_WIDTH),
                 ..default()
             });
             let mid_outline = mid.add_children(|mid| {
-                mid.spawn_bundle(PbrBundle {
+                mid.spawn(PbrBundle {
                     mesh: assets.lane_mid_outline.clone(),
                     transform: Transform::from_translation(-0.000_5 * Vec3::Z),
                     visibility: Visibility { is_visible: false },
@@ -211,14 +211,14 @@ pub fn add_lane_visuals(
             });
             let mid = mid.id();
 
-            let mut end = parent.spawn_bundle(PbrBundle {
+            let mut end = parent.spawn(PbrBundle {
                 mesh: assets.lane_end_mesh.clone(),
                 material: lane_material.clone(),
                 transform: Transform::from_translation(end_anchor),
                 ..default()
             });
             let end_outline = end.add_children(|end| {
-                end.spawn_bundle(PbrBundle {
+                end.spawn(PbrBundle {
                     mesh: assets.lane_end_outline.clone(),
                     transform: Transform::from_translation(-0.000_5 * Vec3::Z),
                     visibility: Visibility { is_visible: false },
@@ -238,7 +238,7 @@ pub fn add_lane_visuals(
                 end,
                 outlines,
             })
-            .insert_bundle(SpatialBundle {
+            .insert(SpatialBundle {
                 transform: Transform::from_translation([0., 0., PASSIVE_LANE_HEIGHT].into()),
                 visibility: Visibility { is_visible },
                 ..default()

--- a/rmf_site_editor/src/site/lift.rs
+++ b/rmf_site_editor/src/site/lift.rs
@@ -116,7 +116,7 @@ pub fn add_tags_to_lift(
     for (e, edge) in &new_lifts {
         let mut lift_cmds = commands.entity(e);
         lift_cmds
-            .insert_bundle(SpatialBundle::default())
+            .insert(SpatialBundle::default())
             .insert(EdgeLabels::LeftRight)
             .insert(Category::Lift);
 
@@ -190,10 +190,10 @@ pub fn update_lift_cabin(
                     .into();
 
                 let cabin_entity = commands
-                    .spawn_bundle(SpatialBundle::from_transform(cabin_tf))
+                    .spawn(SpatialBundle::from_transform(cabin_tf))
                     .with_children(|parent| {
                         parent
-                            .spawn_bundle(PbrBundle {
+                            .spawn(PbrBundle {
                                 mesh: meshes.add(floor_mesh),
                                 material: assets.default_floor_material.clone(),
                                 ..default()
@@ -201,7 +201,7 @@ pub fn update_lift_cabin(
                             .insert(Selectable::new(e));
 
                         parent
-                            .spawn_bundle(PbrBundle {
+                            .spawn(PbrBundle {
                                 mesh: meshes.add(wall_mesh),
                                 material: assets.lift_wall_material.clone(),
                                 ..default()
@@ -226,7 +226,7 @@ pub fn update_lift_cabin(
                                 aabb.center.z = PASSIVE_LANE_HEIGHT / 2.0;
                                 let mesh = make_flat_mesh_for_aabb(aabb);
                                 parent
-                                    .spawn_bundle(PbrBundle {
+                                    .spawn(PbrBundle {
                                         mesh: meshes.add(mesh.into()),
                                         // Doormats are not visible by default.
                                         // Other plugins should make them visible
@@ -294,8 +294,8 @@ pub fn update_lift_cabin(
             }
             None => {
                 let group = commands.entity(e).add_children(|p| {
-                    p.spawn_bundle(SpatialBundle::from_transform(cabin_tf))
-                        .insert_bundle(CabinAnchorGroupBundle::default())
+                    p.spawn(SpatialBundle::from_transform(cabin_tf))
+                        .insert(CabinAnchorGroupBundle::default())
                         .id()
                 });
                 commands.entity(e).insert(ChildCabinAnchorGroup(group));
@@ -386,7 +386,7 @@ pub fn update_lift_door_availability(
                                 old_cabin_door.door
                             } else {
                                 // Create a new door with new anchors
-                                let new_door = commands.spawn().id();
+                                let new_door = commands.spawn_empty().id();
                                 *params.door_mut(face) = Some(LiftCabinDoorPlacement::new(
                                     new_door,
                                     params.width.min(params.depth) / 2.0,
@@ -394,7 +394,7 @@ pub fn update_lift_door_availability(
                                 let anchors =
                                     params.level_door_anchors(face).unwrap().map(|anchor| {
                                         commands
-                                            .spawn_bundle(AnchorBundle::new(anchor))
+                                            .spawn(AnchorBundle::new(anchor))
                                             .insert(Subordinate(Some(toggle.for_lift)))
                                             .id()
                                     });
@@ -405,7 +405,7 @@ pub fn update_lift_door_availability(
 
                                 commands
                                     .entity(new_door)
-                                    .insert_bundle(LiftCabinDoor {
+                                    .insert(LiftCabinDoor {
                                         kind: DoorType::DoubleSliding(DoubleSlidingDoor::default()),
                                         reference_anchors: anchors.into(),
                                         visits: LevelVisits(BTreeSet::from_iter([toggle.on_level])),

--- a/rmf_site_editor/src/site/light.rs
+++ b/rmf_site_editor/src/site/light.rs
@@ -32,7 +32,7 @@ use std::collections::{BTreeMap, HashMap};
 
 /// True/false for whether the physical lights of an environment should be
 /// rendered.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Resource)]
 pub struct PhysicalLightToggle(pub bool);
 
 impl Default for PhysicalLightToggle {

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -47,18 +47,17 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
         }
     };
 
-    let mut site = commands.spawn();
-    site.insert_bundle(SpatialBundle {
+    let mut binding = commands.spawn(SpatialBundle {
         visibility: Visibility { is_visible: false },
         ..default()
-    })
+    });
+    let mut site = binding
     .insert(Category::Site)
     .insert(site_data.properties.clone())
     .with_children(|site| {
         for (anchor_id, anchor) in &site_data.anchors {
             let anchor_entity = site
-                .spawn()
-                .insert_bundle(AnchorBundle::new(anchor.clone()))
+                .spawn(AnchorBundle::new(anchor.clone()))
                 .insert(SiteID(*anchor_id))
                 .id();
             id_to_entity.insert(*anchor_id, anchor_entity);
@@ -67,7 +66,7 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
         for (level_id, level_data) in &site_data.levels {
             let level_entity = site
-                .spawn_bundle(SpatialBundle {
+                .spawn(SpatialBundle {
                     visibility: Visibility { is_visible: false },
                     ..default()
                 })
@@ -77,8 +76,7 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
                 .with_children(|level| {
                     for (anchor_id, anchor) in &level_data.anchors {
                         let anchor_entity = level
-                            .spawn()
-                            .insert_bundle(AnchorBundle::new(anchor.clone()))
+                            .spawn(AnchorBundle::new(anchor.clone()))
                             .insert(SiteID(*anchor_id))
                             .id();
                         id_to_entity.insert(*anchor_id, anchor_entity);
@@ -87,8 +85,7 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
                     for (door_id, door) in &level_data.doors {
                         let door_entity = level
-                            .spawn()
-                            .insert_bundle(door.to_ecs(&id_to_entity))
+                            .spawn(door.to_ecs(&id_to_entity))
                             .insert(SiteID(*door_id))
                             .id();
                         id_to_entity.insert(*door_id, door_entity);
@@ -97,64 +94,56 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
                     for (drawing_id, drawing) in &level_data.drawings {
                         level
-                            .spawn()
-                            .insert_bundle(drawing.clone())
+                            .spawn(drawing.clone())
                             .insert(SiteID(*drawing_id));
                         consider_id(*drawing_id);
                     }
 
                     for (fiducial_id, fiducial) in &level_data.fiducials {
                         level
-                            .spawn()
-                            .insert_bundle(fiducial.to_ecs(&id_to_entity))
+                            .spawn(fiducial.to_ecs(&id_to_entity))
                             .insert(SiteID(*fiducial_id));
                         consider_id(*fiducial_id);
                     }
 
                     for (floor_id, floor) in &level_data.floors {
                         level
-                            .spawn()
-                            .insert_bundle(floor.to_ecs(&id_to_entity))
+                            .spawn(floor.to_ecs(&id_to_entity))
                             .insert(SiteID(*floor_id));
                         consider_id(*floor_id);
                     }
 
                     for (light_id, light) in &level_data.lights {
                         level
-                            .spawn()
-                            .insert_bundle(light.clone())
+                            .spawn(light.clone())
                             .insert(SiteID(*light_id));
                         consider_id(*light_id);
                     }
 
                     for (measurement_id, measurement) in &level_data.measurements {
                         level
-                            .spawn()
-                            .insert_bundle(measurement.to_ecs(&id_to_entity))
+                            .spawn(measurement.to_ecs(&id_to_entity))
                             .insert(SiteID(*measurement_id));
                         consider_id(*measurement_id);
                     }
 
                     for (model_id, model) in &level_data.models {
                         level
-                            .spawn()
-                            .insert_bundle(model.clone())
+                            .spawn(model.clone())
                             .insert(SiteID(*model_id));
                         consider_id(*model_id);
                     }
 
                     for (physical_camera_id, physical_camera) in &level_data.physical_cameras {
                         level
-                            .spawn()
-                            .insert_bundle(physical_camera.clone())
+                            .spawn(physical_camera.clone())
                             .insert(SiteID(*physical_camera_id));
                         consider_id(*physical_camera_id);
                     }
 
                     for (wall_id, wall) in &level_data.walls {
                         level
-                            .spawn()
-                            .insert_bundle(wall.to_ecs(&id_to_entity))
+                            .spawn(wall.to_ecs(&id_to_entity))
                             .insert(SiteID(*wall_id));
                         consider_id(*wall_id);
                     }
@@ -166,18 +155,16 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
         for (lift_id, lift_data) in &site_data.lifts {
             let lift = site
-                .spawn()
-                .insert(SiteID(*lift_id))
+                .spawn(SiteID(*lift_id))
                 .insert(Category::Lift)
                 .with_children(|lift| {
                     let lift_entity = lift.parent_entity();
-                    lift.spawn_bundle(SpatialBundle::default())
-                        .insert_bundle(CabinAnchorGroupBundle::default())
+                    lift.spawn(SpatialBundle::default())
+                        .insert(CabinAnchorGroupBundle::default())
                         .with_children(|anchor_group| {
                             for (anchor_id, anchor) in &lift_data.cabin_anchors {
                                 let anchor_entity = anchor_group
-                                    .spawn()
-                                    .insert_bundle(AnchorBundle::new(anchor.clone()))
+                                    .spawn(AnchorBundle::new(anchor.clone()))
                                     .insert(SiteID(*anchor_id))
                                     .id();
                                 id_to_entity.insert(*anchor_id, anchor_entity);
@@ -187,15 +174,14 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
                     for (door_id, door) in &lift_data.cabin_doors {
                         let door_entity = lift
-                            .spawn()
-                            .insert_bundle(door.to_ecs(&id_to_entity))
+                            .spawn(door.to_ecs(&id_to_entity))
                             .insert(Dependents::single(lift_entity))
                             .id();
                         id_to_entity.insert(*door_id, door_entity);
                         consider_id(*door_id);
                     }
                 })
-                .insert_bundle(lift_data.properties.to_ecs(&id_to_entity))
+                .insert(lift_data.properties.to_ecs(&id_to_entity))
                 .id();
             id_to_entity.insert(*lift_id, lift);
             consider_id(*lift_id);
@@ -203,8 +189,8 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
         for (nav_graph_id, nav_graph_data) in &site_data.navigation.guided.graphs {
             let nav_graph = site
-                .spawn_bundle(SpatialBundle::default())
-                .insert_bundle(nav_graph_data.clone())
+                .spawn(SpatialBundle::default())
+                .insert(nav_graph_data.clone())
                 .insert(SiteID(*nav_graph_id))
                 .id();
             id_to_entity.insert(*nav_graph_id, nav_graph);
@@ -213,7 +199,7 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
         for (lane_id, lane_data) in &site_data.navigation.guided.lanes {
             let lane = site
-                .spawn_bundle(lane_data.to_ecs(&id_to_entity))
+                .spawn(lane_data.to_ecs(&id_to_entity))
                 .insert(SiteID(*lane_id))
                 .id();
             id_to_entity.insert(*lane_id, lane);
@@ -222,7 +208,7 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
 
         for (location_id, location_data) in &site_data.navigation.guided.locations {
             let location = site
-                .spawn_bundle(location_data.to_ecs(&id_to_entity))
+                .spawn(location_data.to_ecs(&id_to_entity))
                 .insert(SiteID(*location_id))
                 .id();
             id_to_entity.insert(*location_id, location);
@@ -404,7 +390,7 @@ fn generate_imported_nav_graphs(
             }
             if !already_existing {
                 params.commands.entity(anchor_group).add_children(|group| {
-                    let e_anchor = group.spawn_bundle(AnchorBundle::new(anchor.clone())).id();
+                    let e_anchor = group.spawn(AnchorBundle::new(anchor.clone())).id();
                     id_to_entity.insert(*anchor_id, e_anchor);
                 });
             }
@@ -432,7 +418,7 @@ fn generate_imported_nav_graphs(
             }
             if !already_existing {
                 params.commands.entity(level_e).add_children(|level| {
-                    let e_anchor = level.spawn_bundle(AnchorBundle::new(anchor.clone())).id();
+                    let e_anchor = level.spawn(AnchorBundle::new(anchor.clone())).id();
                     id_to_entity.insert(*anchor_id, e_anchor);
                 });
             }
@@ -455,7 +441,7 @@ fn generate_imported_nav_graphs(
             }
             if !already_existing {
                 params.commands.entity(into_site).add_children(|site| {
-                    let e_anchor = site.spawn_bundle(AnchorBundle::new(anchor.clone())).id();
+                    let e_anchor = site.spawn(AnchorBundle::new(anchor.clone())).id();
                     id_to_entity.insert(*anchor_id, e_anchor);
                 });
             }
@@ -465,8 +451,8 @@ fn generate_imported_nav_graphs(
     for (nav_graph_id, nav_graph_data) in &from_site_data.navigation.guided.graphs {
         params.commands.entity(into_site).add_children(|site| {
             let e = site
-                .spawn_bundle(SpatialBundle::default())
-                .insert_bundle(nav_graph_data.clone())
+                .spawn(SpatialBundle::default())
+                .insert(nav_graph_data.clone())
                 .id();
             id_to_entity.insert(*nav_graph_id, e);
         });
@@ -474,14 +460,14 @@ fn generate_imported_nav_graphs(
 
     for (lane_id, lane_data) in &from_site_data.navigation.guided.lanes {
         params.commands.entity(into_site).add_children(|site| {
-            let e = site.spawn_bundle(lane_data.to_ecs(&id_to_entity)).id();
+            let e = site.spawn(lane_data.to_ecs(&id_to_entity)).id();
             id_to_entity.insert(*lane_id, e);
         });
     }
 
     for (location_id, location_data) in &from_site_data.navigation.guided.locations {
         params.commands.entity(into_site).add_children(|site| {
-            let e = site.spawn_bundle(location_data.to_ecs(&id_to_entity)).id();
+            let e = site.spawn(location_data.to_ecs(&id_to_entity)).id();
             id_to_entity.insert(*location_id, e);
         });
     }

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -52,169 +52,163 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
         ..default()
     });
     let mut site = binding
-    .insert(Category::Site)
-    .insert(site_data.properties.clone())
-    .with_children(|site| {
-        for (anchor_id, anchor) in &site_data.anchors {
-            let anchor_entity = site
-                .spawn(AnchorBundle::new(anchor.clone()))
-                .insert(SiteID(*anchor_id))
-                .id();
-            id_to_entity.insert(*anchor_id, anchor_entity);
-            consider_id(*anchor_id);
-        }
+        .insert(Category::Site)
+        .insert(site_data.properties.clone())
+        .with_children(|site| {
+            for (anchor_id, anchor) in &site_data.anchors {
+                let anchor_entity = site
+                    .spawn(AnchorBundle::new(anchor.clone()))
+                    .insert(SiteID(*anchor_id))
+                    .id();
+                id_to_entity.insert(*anchor_id, anchor_entity);
+                consider_id(*anchor_id);
+            }
 
-        for (level_id, level_data) in &site_data.levels {
-            let level_entity = site
-                .spawn(SpatialBundle {
-                    visibility: Visibility { is_visible: false },
-                    ..default()
-                })
-                .insert(level_data.properties.clone())
-                .insert(SiteID(*level_id))
-                .insert(Category::Level)
-                .with_children(|level| {
-                    for (anchor_id, anchor) in &level_data.anchors {
-                        let anchor_entity = level
-                            .spawn(AnchorBundle::new(anchor.clone()))
-                            .insert(SiteID(*anchor_id))
-                            .id();
-                        id_to_entity.insert(*anchor_id, anchor_entity);
-                        consider_id(*anchor_id);
-                    }
+            for (level_id, level_data) in &site_data.levels {
+                let level_entity = site
+                    .spawn(SpatialBundle {
+                        visibility: Visibility { is_visible: false },
+                        ..default()
+                    })
+                    .insert(level_data.properties.clone())
+                    .insert(SiteID(*level_id))
+                    .insert(Category::Level)
+                    .with_children(|level| {
+                        for (anchor_id, anchor) in &level_data.anchors {
+                            let anchor_entity = level
+                                .spawn(AnchorBundle::new(anchor.clone()))
+                                .insert(SiteID(*anchor_id))
+                                .id();
+                            id_to_entity.insert(*anchor_id, anchor_entity);
+                            consider_id(*anchor_id);
+                        }
 
-                    for (door_id, door) in &level_data.doors {
-                        let door_entity = level
-                            .spawn(door.to_ecs(&id_to_entity))
-                            .insert(SiteID(*door_id))
-                            .id();
-                        id_to_entity.insert(*door_id, door_entity);
-                        consider_id(*door_id);
-                    }
+                        for (door_id, door) in &level_data.doors {
+                            let door_entity = level
+                                .spawn(door.to_ecs(&id_to_entity))
+                                .insert(SiteID(*door_id))
+                                .id();
+                            id_to_entity.insert(*door_id, door_entity);
+                            consider_id(*door_id);
+                        }
 
-                    for (drawing_id, drawing) in &level_data.drawings {
-                        level
-                            .spawn(drawing.clone())
-                            .insert(SiteID(*drawing_id));
-                        consider_id(*drawing_id);
-                    }
+                        for (drawing_id, drawing) in &level_data.drawings {
+                            level.spawn(drawing.clone()).insert(SiteID(*drawing_id));
+                            consider_id(*drawing_id);
+                        }
 
-                    for (fiducial_id, fiducial) in &level_data.fiducials {
-                        level
-                            .spawn(fiducial.to_ecs(&id_to_entity))
-                            .insert(SiteID(*fiducial_id));
-                        consider_id(*fiducial_id);
-                    }
+                        for (fiducial_id, fiducial) in &level_data.fiducials {
+                            level
+                                .spawn(fiducial.to_ecs(&id_to_entity))
+                                .insert(SiteID(*fiducial_id));
+                            consider_id(*fiducial_id);
+                        }
 
-                    for (floor_id, floor) in &level_data.floors {
-                        level
-                            .spawn(floor.to_ecs(&id_to_entity))
-                            .insert(SiteID(*floor_id));
-                        consider_id(*floor_id);
-                    }
+                        for (floor_id, floor) in &level_data.floors {
+                            level
+                                .spawn(floor.to_ecs(&id_to_entity))
+                                .insert(SiteID(*floor_id));
+                            consider_id(*floor_id);
+                        }
 
-                    for (light_id, light) in &level_data.lights {
-                        level
-                            .spawn(light.clone())
-                            .insert(SiteID(*light_id));
-                        consider_id(*light_id);
-                    }
+                        for (light_id, light) in &level_data.lights {
+                            level.spawn(light.clone()).insert(SiteID(*light_id));
+                            consider_id(*light_id);
+                        }
 
-                    for (measurement_id, measurement) in &level_data.measurements {
-                        level
-                            .spawn(measurement.to_ecs(&id_to_entity))
-                            .insert(SiteID(*measurement_id));
-                        consider_id(*measurement_id);
-                    }
+                        for (measurement_id, measurement) in &level_data.measurements {
+                            level
+                                .spawn(measurement.to_ecs(&id_to_entity))
+                                .insert(SiteID(*measurement_id));
+                            consider_id(*measurement_id);
+                        }
 
-                    for (model_id, model) in &level_data.models {
-                        level
-                            .spawn(model.clone())
-                            .insert(SiteID(*model_id));
-                        consider_id(*model_id);
-                    }
+                        for (model_id, model) in &level_data.models {
+                            level.spawn(model.clone()).insert(SiteID(*model_id));
+                            consider_id(*model_id);
+                        }
 
-                    for (physical_camera_id, physical_camera) in &level_data.physical_cameras {
-                        level
-                            .spawn(physical_camera.clone())
-                            .insert(SiteID(*physical_camera_id));
-                        consider_id(*physical_camera_id);
-                    }
+                        for (physical_camera_id, physical_camera) in &level_data.physical_cameras {
+                            level
+                                .spawn(physical_camera.clone())
+                                .insert(SiteID(*physical_camera_id));
+                            consider_id(*physical_camera_id);
+                        }
 
-                    for (wall_id, wall) in &level_data.walls {
-                        level
-                            .spawn(wall.to_ecs(&id_to_entity))
-                            .insert(SiteID(*wall_id));
-                        consider_id(*wall_id);
-                    }
-                })
-                .id();
-            id_to_entity.insert(*level_id, level_entity);
-            consider_id(*level_id);
-        }
+                        for (wall_id, wall) in &level_data.walls {
+                            level
+                                .spawn(wall.to_ecs(&id_to_entity))
+                                .insert(SiteID(*wall_id));
+                            consider_id(*wall_id);
+                        }
+                    })
+                    .id();
+                id_to_entity.insert(*level_id, level_entity);
+                consider_id(*level_id);
+            }
 
-        for (lift_id, lift_data) in &site_data.lifts {
-            let lift = site
-                .spawn(SiteID(*lift_id))
-                .insert(Category::Lift)
-                .with_children(|lift| {
-                    let lift_entity = lift.parent_entity();
-                    lift.spawn(SpatialBundle::default())
-                        .insert(CabinAnchorGroupBundle::default())
-                        .with_children(|anchor_group| {
-                            for (anchor_id, anchor) in &lift_data.cabin_anchors {
-                                let anchor_entity = anchor_group
-                                    .spawn(AnchorBundle::new(anchor.clone()))
-                                    .insert(SiteID(*anchor_id))
-                                    .id();
-                                id_to_entity.insert(*anchor_id, anchor_entity);
-                                consider_id(*anchor_id);
-                            }
-                        });
+            for (lift_id, lift_data) in &site_data.lifts {
+                let lift = site
+                    .spawn(SiteID(*lift_id))
+                    .insert(Category::Lift)
+                    .with_children(|lift| {
+                        let lift_entity = lift.parent_entity();
+                        lift.spawn(SpatialBundle::default())
+                            .insert(CabinAnchorGroupBundle::default())
+                            .with_children(|anchor_group| {
+                                for (anchor_id, anchor) in &lift_data.cabin_anchors {
+                                    let anchor_entity = anchor_group
+                                        .spawn(AnchorBundle::new(anchor.clone()))
+                                        .insert(SiteID(*anchor_id))
+                                        .id();
+                                    id_to_entity.insert(*anchor_id, anchor_entity);
+                                    consider_id(*anchor_id);
+                                }
+                            });
 
-                    for (door_id, door) in &lift_data.cabin_doors {
-                        let door_entity = lift
-                            .spawn(door.to_ecs(&id_to_entity))
-                            .insert(Dependents::single(lift_entity))
-                            .id();
-                        id_to_entity.insert(*door_id, door_entity);
-                        consider_id(*door_id);
-                    }
-                })
-                .insert(lift_data.properties.to_ecs(&id_to_entity))
-                .id();
-            id_to_entity.insert(*lift_id, lift);
-            consider_id(*lift_id);
-        }
+                        for (door_id, door) in &lift_data.cabin_doors {
+                            let door_entity = lift
+                                .spawn(door.to_ecs(&id_to_entity))
+                                .insert(Dependents::single(lift_entity))
+                                .id();
+                            id_to_entity.insert(*door_id, door_entity);
+                            consider_id(*door_id);
+                        }
+                    })
+                    .insert(lift_data.properties.to_ecs(&id_to_entity))
+                    .id();
+                id_to_entity.insert(*lift_id, lift);
+                consider_id(*lift_id);
+            }
 
-        for (nav_graph_id, nav_graph_data) in &site_data.navigation.guided.graphs {
-            let nav_graph = site
-                .spawn(SpatialBundle::default())
-                .insert(nav_graph_data.clone())
-                .insert(SiteID(*nav_graph_id))
-                .id();
-            id_to_entity.insert(*nav_graph_id, nav_graph);
-            consider_id(*nav_graph_id);
-        }
+            for (nav_graph_id, nav_graph_data) in &site_data.navigation.guided.graphs {
+                let nav_graph = site
+                    .spawn(SpatialBundle::default())
+                    .insert(nav_graph_data.clone())
+                    .insert(SiteID(*nav_graph_id))
+                    .id();
+                id_to_entity.insert(*nav_graph_id, nav_graph);
+                consider_id(*nav_graph_id);
+            }
 
-        for (lane_id, lane_data) in &site_data.navigation.guided.lanes {
-            let lane = site
-                .spawn(lane_data.to_ecs(&id_to_entity))
-                .insert(SiteID(*lane_id))
-                .id();
-            id_to_entity.insert(*lane_id, lane);
-            consider_id(*lane_id);
-        }
+            for (lane_id, lane_data) in &site_data.navigation.guided.lanes {
+                let lane = site
+                    .spawn(lane_data.to_ecs(&id_to_entity))
+                    .insert(SiteID(*lane_id))
+                    .id();
+                id_to_entity.insert(*lane_id, lane);
+                consider_id(*lane_id);
+            }
 
-        for (location_id, location_data) in &site_data.navigation.guided.locations {
-            let location = site
-                .spawn(location_data.to_ecs(&id_to_entity))
-                .insert(SiteID(*location_id))
-                .id();
-            id_to_entity.insert(*location_id, location);
-            consider_id(*location_id);
-        }
-    });
+            for (location_id, location_data) in &site_data.navigation.guided.locations {
+                let location = site
+                    .spawn(location_data.to_ecs(&id_to_entity))
+                    .insert(SiteID(*location_id))
+                    .id();
+                id_to_entity.insert(*location_id, location);
+                consider_id(*location_id);
+            }
+        });
 
     site.insert(NextSiteID(highest_id + 1));
     let site_id = site.id();

--- a/rmf_site_editor/src/site/location.rs
+++ b/rmf_site_editor/src/site/location.rs
@@ -69,7 +69,7 @@ pub fn add_location_visuals(
         // TODO(MXG): Put icons on the different visual squares based on the location tags
         commands
             .entity(e)
-            .insert_bundle(PbrBundle {
+            .insert(PbrBundle {
                 mesh: assets.location_mesh.clone(),
                 transform: Transform::from_translation(position),
                 material: location_material,

--- a/rmf_site_editor/src/site/measurement.rs
+++ b/rmf_site_editor/src/site/measurement.rs
@@ -29,7 +29,7 @@ pub fn add_measurement_visuals(
     for (e, edge) in &measurements {
         commands
             .entity(e)
-            .insert_bundle(PbrBundle {
+            .insert(PbrBundle {
                 mesh: assets.lane_mid_mesh.clone(),
                 material: assets.measurement_material.clone(),
                 transform: line_stroke_transform(

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -187,8 +187,8 @@ impl Plugin for SitePlugin {
             )
             .add_system_set(
                 SystemSet::on_update(SiteState::Display)
-                    .with_system(save_site.exclusive_system())
-                    .with_system(save_nav_graphs.exclusive_system())
+                    .with_system(save_site)
+                    .with_system(save_nav_graphs)
                     .with_system(change_site),
             )
             .add_system_set_to_stage(

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -24,10 +24,10 @@ use rmf_site_format::{AssetSource, ModelMarker, Pose};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 
-#[derive(Default, Debug, Clone, Deref, DerefMut)]
+#[derive(Default, Debug, Clone, Deref, DerefMut, Resource)]
 pub struct LoadingModels(pub HashMap<Entity, Handle<Scene>>);
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Resource)]
 pub struct SpawnedModels(Vec<Entity>);
 
 #[derive(Component, Debug, Clone)]
@@ -65,7 +65,7 @@ pub fn update_model_scenes(
                 source: source.clone(),
                 scene_entity: None,
             })
-            .insert_bundle(SpatialBundle {
+            .insert(SpatialBundle {
                 transform: pose.transform(),
                 ..default()
             })
@@ -108,7 +108,7 @@ pub fn update_model_scenes(
         if asset_server.get_load_state(h) == LoadState::Loaded {
             let model_scene_id = commands.entity(*e).add_children(|parent| {
                 parent
-                    .spawn_bundle(SceneBundle {
+                    .spawn(SceneBundle {
                         scene: h.clone(),
                         ..default()
                     })
@@ -181,7 +181,7 @@ pub fn make_models_selectable(
             commands
                 .entity(e)
                 .insert(selectable.clone())
-                .insert_bundle(DragPlaneBundle::new(selectable.element, Vec3::Z));
+                .insert(DragPlaneBundle::new(selectable.element, Vec3::Z));
 
             if let Ok(children) = all_children.get(e) {
                 for child in children {

--- a/rmf_site_editor/src/site/physical_camera.rs
+++ b/rmf_site_editor/src/site/physical_camera.rs
@@ -27,7 +27,7 @@ pub fn add_physical_camera_visuals(
     for (e, pose) in &physical_cameras {
         commands
             .entity(e)
-            .insert_bundle(PbrBundle {
+            .insert(PbrBundle {
                 mesh: assets.physical_camera_mesh.clone(),
                 material: assets.physical_camera_material.clone(),
                 transform: pose.transform(),
@@ -45,7 +45,7 @@ pub fn add_physical_camera_visuals(
             ]),
         };
         let child = commands
-            .spawn_bundle(Camera3dBundle {
+            .spawn(Camera3dBundle {
                 transform: camera_sensor_transform.transform(),
                 camera: Camera {
                     is_active: false,

--- a/rmf_site_editor/src/site/site.rs
+++ b/rmf_site_editor/src/site/site.rs
@@ -20,7 +20,7 @@ use rmf_site_format::{LevelProperties, SiteProperties};
 use std::collections::HashMap;
 
 /// Used as a resource that keeps track of the current site entity
-#[derive(Clone, Copy, Debug, Default, Deref, DerefMut)]
+#[derive(Clone, Copy, Debug, Default, Deref, DerefMut, Resource)]
 pub struct CurrentSite(pub Option<Entity>);
 
 /// Used as an event to command that a new site should be made the current one
@@ -33,16 +33,16 @@ pub struct ChangeCurrentSite {
 }
 
 /// Used as a resource that keeps track of the current level entity
-#[derive(Clone, Copy, Debug, Default, Deref, DerefMut)]
+#[derive(Clone, Copy, Debug, Default, Deref, DerefMut, Resource)]
 pub struct CurrentLevel(pub Option<Entity>);
 
 /// Used as a resource that maps from the site entity to the level entity which
 /// was most recently selected for it.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Resource)]
 pub struct CachedLevels(pub HashMap<Entity, Entity>);
 
 /// Used as a resource to keep track of all currently opened sites
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Resource)]
 pub struct OpenSites(pub Vec<Entity>);
 
 /// This component is placed on the Site entity to keep track of what the next
@@ -130,7 +130,7 @@ pub fn change_site(
                     if !found_level {
                         // Create a new blank level for the user
                         let new_level = commands.entity(cmd.site).add_children(|site| {
-                            site.spawn_bundle(SpatialBundle::default())
+                            site.spawn(SpatialBundle::default())
                                 .insert(LevelProperties {
                                     name: "<unnamed level>".to_string(),
                                     elevation: 0.,

--- a/rmf_site_editor/src/site/wall.rs
+++ b/rmf_site_editor/src/site/wall.rs
@@ -52,7 +52,7 @@ pub fn add_wall_visual(
         if let Some(mesh) = make_wall(e, edge, &anchors) {
             commands
                 .entity(e)
-                .insert_bundle(PbrBundle {
+                .insert(PbrBundle {
                     mesh: meshes.add(mesh),
                     // TODO(MXG): load the user-specified texture when one is given
                     material: assets.wall_material.clone(),

--- a/rmf_site_editor/src/site_asset_io.rs
+++ b/rmf_site_editor/src/site_asset_io.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::{AssetIo, AssetIoError, FileType, Metadata},
+    asset::{AssetIo, AssetIoError, AssetPlugin, FileType, Metadata},
     prelude::*,
     utils::BoxedFuture,
 };
@@ -191,7 +191,7 @@ pub struct SiteAssetIoPlugin;
 impl Plugin for SiteAssetIoPlugin {
     fn build(&self, app: &mut App) {
         let asset_io = {
-            let default_io = bevy::asset::create_platform_default_asset_io(app);
+            let default_io = AssetPlugin::default().create_platform_default_asset_io();
             SiteAssetIo { default_io }
         };
 

--- a/rmf_site_editor/src/warehouse_generator.rs
+++ b/rmf_site_editor/src/warehouse_generator.rs
@@ -206,7 +206,7 @@ fn warehouse_generator(
             .insert(String::from("concrete_floor"), concrete_floor_handle);
     }
 
-    commands.spawn_bundle(PbrBundle {
+    commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Plane { size: width as f32 })),
         material: material_map
             .materials

--- a/rmf_site_editor/src/widgets/icons.rs
+++ b/rmf_site_editor/src/widgets/icons.rs
@@ -19,7 +19,7 @@ use bevy::prelude::*;
 use bevy_egui::{egui, EguiContext};
 use rmf_site_format::AssetSource;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct Icons {
     pub bevy_select: Handle<Image>,
     pub egui_select: egui::TextureId,

--- a/rmf_site_editor/src/widgets/view_levels.rs
+++ b/rmf_site_editor/src/widgets/view_levels.rs
@@ -23,6 +23,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_egui::egui::{DragValue, ImageButton, Ui};
 use std::cmp::{Ordering, Reverse};
 
+#[derive(Resource)]
 pub struct LevelDisplay {
     pub new_elevation: f32,
     pub new_name: String,
@@ -74,7 +75,7 @@ impl<'a, 'w1, 's1, 'w2, 's2> ViewLevels<'a, 'w1, 's1, 'w2, 's2> {
                 let new_level = self
                     .events
                     .commands
-                    .spawn_bundle(SpatialBundle::default())
+                    .spawn(SpatialBundle::default())
                     .insert(LevelProperties {
                         elevation: show_elevation,
                         name: show_name.clone(),

--- a/rmf_site_editor/src/widgets/view_lights.rs
+++ b/rmf_site_editor/src/widgets/view_lights.rs
@@ -39,6 +39,7 @@ use rfd::AsyncFileDialog;
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
+#[derive(Resource)]
 pub struct LightDisplay {
     pub pose: Pose,
     pub kind: LightKind,
@@ -165,7 +166,7 @@ impl<'a, 'w1, 's1, 'w2, 's2> ViewLights<'a, 'w1, 's1, 'w2, 's2> {
             let new_light = self
                 .events
                 .commands
-                .spawn_bundle(Light {
+                .spawn(Light {
                     pose: self.events.display.light.pose,
                     kind: self.events.display.light.kind,
                 })

--- a/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -35,6 +35,7 @@ use smallvec::SmallVec;
 #[cfg(not(target_arch = "wasm32"))]
 use rfd::AsyncFileDialog;
 
+#[derive(Resource)]
 pub struct NavGraphDisplay {
     pub color: Option<[f32; 4]>,
     pub name: String,
@@ -179,8 +180,8 @@ impl<'a, 'w1, 's1, 'w2, 's2> ViewNavGraphs<'a, 'w1, 's1, 'w2, 's2> {
             if add {
                 self.events
                     .commands
-                    .spawn_bundle(SpatialBundle::default())
-                    .insert_bundle(NavGraph {
+                    .spawn(SpatialBundle::default())
+                    .insert(NavGraph {
                         name: NameInSite(self.events.display.nav_graph.name.clone()),
                         color: DisplayColor(self.events.display.nav_graph.color.unwrap().clone()),
                         marker: Default::default(),

--- a/rmf_site_editor/src/widgets/view_occupancy.rs
+++ b/rmf_site_editor/src/widgets/view_occupancy.rs
@@ -15,8 +15,8 @@
  *
 */
 
-use bevy::prelude::Resource;
 use crate::{occupancy::CalculateGrid, widgets::AppEvents};
+use bevy::prelude::Resource;
 use bevy_egui::egui::{DragValue, Ui};
 
 #[derive(Resource)]

--- a/rmf_site_editor/src/widgets/view_occupancy.rs
+++ b/rmf_site_editor/src/widgets/view_occupancy.rs
@@ -15,9 +15,11 @@
  *
 */
 
+use bevy::prelude::Resource;
 use crate::{occupancy::CalculateGrid, widgets::AppEvents};
 use bevy_egui::egui::{DragValue, Ui};
 
+#[derive(Resource)]
 pub struct OccupancyDisplay {
     pub cell_size: f32,
 }

--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -16,7 +16,7 @@ ron = "0.7"
 thiserror = "*"
 glam = "0.21"
 # add features=["bevy"] to a dependent Cargo.toml to get the bevy-related features
-bevy = { version = "0.8", optional = true }
+bevy = { version = "0.9", optional = true }
 
 [target.'cfg(target_arch = "wasm")'.dependencies]
 optimization_engine = { version = "0.7", features = ["wasm"] }

--- a/rmf_site_format/src/anchor.rs
+++ b/rmf_site_format/src/anchor.rs
@@ -19,9 +19,8 @@ use crate::{Categorized, Category};
 #[cfg(feature = "bevy")]
 use bevy::{
     ecs::{query::QueryEntityError, system::SystemParam},
-    prelude::{Component, Entity, GlobalTransform, Parent, Query, Transform},
+    prelude::{Component, Entity, GlobalTransform, Parent, Query, Transform, Vec2, Vec3},
 };
-use glam::{Vec2, Vec3};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/rmf_site_format/src/lift.rs
+++ b/rmf_site_format/src/lift.rs
@@ -19,10 +19,9 @@ use crate::*;
 #[cfg(feature = "bevy")]
 use bevy::{
     math::Vec3A,
-    prelude::{Bundle, Component, Deref, DerefMut, Entity, Query, With, Without},
+    prelude::{Bundle, Component, Deref, DerefMut, Entity, Query, Vec2, Vec3, With, Without},
     render::primitives::Aabb,
 };
-use glam::{Vec2, Vec3};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/rmf_site_format/src/misc.rs
+++ b/rmf_site_format/src/misc.rs
@@ -18,7 +18,6 @@
 use crate::Recall;
 #[cfg(feature = "bevy")]
 use bevy::prelude::*;
-use glam::{Quat, Vec2, Vec3};
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_LEVEL_HEIGHT: f32 = 3.0;


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR upgrades bevy from 0.8 to 0.9, it seems 0.10 is already behind the corner!

### Implementation description

The bulk of the changelog is due to the deprecation of `spawn_bundle` / `insert_bundle` into `spawn / insert`, and the fact that resources need to be explicitly derived now.

Two main changes / regressions:

* `rmf_site_format` was changed to use `bevy::prelude` vectors instead of `glam`. I believe this might not be ideal since now the crate will depend on `bevy`. However I found a lot of very cryptic errors when mixing bevy and glam vectors when upgrading the dependency (even though from what I understand they are pretty much the same behind the scenes).
* Outline for floors is not displayed anymore, this I'm very puzzled about since there weren't too many changes in the outline file, I wonder if a change somewhere else in the stack (including in the `bevy_mod_outline` crate) might have caused it.