### PR TITLE
Ignore legacy crowdsim parsing

### DIFF
--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -1,4 +1,4 @@
-use super::{crowd_sim::CrowdSim, level::Level, lift::Lift, PortingError, Result};
+use super::{level::Level, lift::Lift, PortingError, Result};
 use crate::{
     legacy::optimization::align_building, Anchor, Angle, AssetSource, AssociatedGraphs,
     DisplayColor, Dock as SiteDock, Drawing as SiteDrawing, DrawingMarker,
@@ -30,8 +30,10 @@ pub struct BuildingMap {
     #[serde(default)]
     pub coordinate_system: CoordinateSystem,
     pub levels: BTreeMap<String, Level>,
-    #[serde(default)]
-    pub crowd_sim: CrowdSim,
+    // TODO(MXG): Consider parsing legacy crowdsim data and converting it to
+    // a format that will have future support.
+    // #[serde(default)]
+    // pub crowd_sim: CrowdSim,
     #[serde(default)]
     pub lifts: BTreeMap<String, Lift>,
 }


### PR DESCRIPTION
There are some parameters in the old crowdsim format that are not being parsed yet in the legacy parser of `rmf_site_format`. As a result loading some building files currently fails (e.g. the airport terminal demo world).

This PR simply has the legacy parser skip crowdsim entirely to side step this issue. We aren't using crowdsim data inside of the site editor yet anyway, so parsing it has no value at this time. We can revert this change in the future when we're ready to explore ways to migrate the legacy crowdsim data to a new format.