### PR TITLE
Use assets from Fuel instead of the previous static server

### DIFF
--- a/rmf_site_editor/src/site/assets.rs
+++ b/rmf_site_editor/src/site/assets.rs
@@ -54,7 +54,7 @@ pub struct SiteAssets {
 impl FromWorld for SiteAssets {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.get_resource::<AssetServer>().unwrap();
-        let wall_texture = asset_server.load(&String::from(&AssetSource::Remote(
+        let wall_texture = asset_server.load(&String::from(&AssetSource::Bundled(
             "textures/default.png".to_string(),
         )));
 

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -49,6 +49,7 @@ pub fn add_drawing_visuals(
             )),
             AssetSource::Remote(_) => source.clone(),
             AssetSource::Search(_) => source.clone(),
+            AssetSource::Bundled(_) => source.clone(),
         };
         let texture_handle: Handle<Image> = asset_server.load(&String::from(&asset_source));
         loading_drawings
@@ -121,6 +122,7 @@ pub fn update_drawing_asset_source(
             )),
             AssetSource::Remote(_) => source.clone(),
             AssetSource::Search(_) => source.clone(),
+            AssetSource::Bundled(_) => source.clone(),
         };
         let texture_handle: Handle<Image> = asset_server.load(&String::from(&asset_source));
         loading_drawings

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -83,6 +83,9 @@ pub fn update_model_scenes(
             AssetSource::Search(name) => {
                 AssetSource::Search(name.to_owned() + &".glb#Scene0".to_string())
             }
+            AssetSource::Bundled(name) => {
+                AssetSource::Bundled(name.to_owned() + &".glb#Scene0".to_string())
+            }
         };
         let scene: Handle<Scene> = asset_server.load(&String::from(&asset_source));
         loading_models.insert(e, scene.clone());

--- a/rmf_site_editor/src/site_asset_io.rs
+++ b/rmf_site_editor/src/site_asset_io.rs
@@ -71,39 +71,56 @@ impl SiteAssetIo {
         let name_no_suffix = match name.strip_suffix(".glb") {
             Some(s) => s,
             None => {
-                return Err(AssetIoError::Io(io::Error::new(io::ErrorKind::Other, format!("Unable to parse into org/model names: {name}"))));
+                return Err(AssetIoError::Io(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Unable to parse into org/model names: {name}"),
+                )));
             }
         };
         let mut tokens = name_no_suffix.split("/");
         let org_name = match tokens.next() {
             Some(token) => token,
             None => {
-                return Err(AssetIoError::Io(io::Error::new(io::ErrorKind::Other, format!("Unable to parse into org/model names: {name}"))));
+                return Err(AssetIoError::Io(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Unable to parse into org/model names: {name}"),
+                )));
             }
         };
         let model_name = match tokens.next() {
             Some(token) => token,
             None => {
-                return Err(AssetIoError::Io(io::Error::new(io::ErrorKind::Other, format!("Unable to parse into org/model names: {name}"))));
+                return Err(AssetIoError::Io(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Unable to parse into org/model names: {name}"),
+                )));
             }
         };
-        let uri = format!("{0}/{1}/models/{2}/1/files/meshes/{2}.glb",
-            FUEL_BASE_URI,
-            org_name,
-            model_name);
+        let uri = format!(
+            "{0}/{1}/models/{2}/1/files/meshes/{2}.glb",
+            FUEL_BASE_URI, org_name, model_name
+        );
         println!("generated fuel URI: {name} -> {uri}");
         return Ok(uri);
     }
 
     fn add_bundled_assets(&mut self) {
-        self.bundled_assets.insert("textures/default.png".to_string(),
-            include_bytes!("../../assets/textures/default.png").to_vec());
-        self.bundled_assets.insert("textures/select.png".to_string(),
-            include_bytes!("../../assets/textures/select.png").to_vec());
-        self.bundled_assets.insert("textures/trash.png".to_string(),
-            include_bytes!("../../assets/textures/trash.png").to_vec());
-        self.bundled_assets.insert("textures/edit.png".to_string(),
-            include_bytes!("../../assets/textures/edit.png").to_vec());
+        self.bundled_assets.insert(
+            "textures/default.png".to_string(),
+            include_bytes!("../../assets/textures/default.png").to_vec(),
+        );
+        self.bundled_assets.insert(
+            "textures/select.png".to_string(),
+            include_bytes!("../../assets/textures/select.png").to_vec(),
+        );
+        self.bundled_assets.insert(
+            "textures/trash.png".to_string(),
+            include_bytes!("../../assets/textures/trash.png").to_vec(),
+        );
+        self.bundled_assets.insert(
+            "textures/edit.png".to_string(),
+            include_bytes!("../../assets/textures/edit.png").to_vec(),
+        );
     }
 }
 
@@ -153,7 +170,12 @@ impl AssetIo for SiteAssetIo {
                 if self.bundled_assets.contains_key(&filename) {
                     return Box::pin(async move { Ok(self.bundled_assets[&filename].clone()) });
                 } else {
-                    return Box::pin(async move { Err(AssetIoError::Io(io::Error::new(io::ErrorKind::Other, format!("Bundled asset not found: {filename}")))) });
+                    return Box::pin(async move {
+                        Err(AssetIoError::Io(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("Bundled asset not found: {filename}"),
+                        )))
+                    });
                 }
             }
             AssetSource::Search(name) => {
@@ -187,7 +209,7 @@ impl AssetIo for SiteAssetIo {
 
                 let uri = match self.generate_asset_uri(&name) {
                     Ok(uri) => uri,
-                    Err(e) => return Box::pin(async move {Err(e)}),
+                    Err(e) => return Box::pin(async move { Err(e) }),
                 };
 
                 // Fetch from remote server
@@ -262,7 +284,10 @@ impl Plugin for SiteAssetIoPlugin {
     fn build(&self, app: &mut App) {
         let mut asset_io = {
             let default_io = AssetPlugin::default().create_platform_default_asset_io();
-            SiteAssetIo { default_io, bundled_assets: HashMap::new() }
+            SiteAssetIo {
+                default_io,
+                bundled_assets: HashMap::new(),
+            }
         };
         asset_io.add_bundled_assets();
 

--- a/rmf_site_editor/src/site_asset_io.rs
+++ b/rmf_site_editor/src/site_asset_io.rs
@@ -4,12 +4,12 @@ use bevy::{
     utils::{BoxedFuture, HashMap},
 };
 use dirs;
+use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
-use serde::Deserialize;
 
 use rmf_site_format::AssetSource;
 
@@ -58,9 +58,12 @@ impl SiteAssetIo {
         asset_name: String,
     ) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
         Box::pin(async move {
-            let bytes = surf::get(remote_url.clone()).recv_bytes().await.map_err(|e| {
-                AssetIoError::Io(io::Error::new(io::ErrorKind::Other, e.to_string()))
-            })?;
+            let bytes = surf::get(remote_url.clone())
+                .recv_bytes()
+                .await
+                .map_err(|e| {
+                    AssetIoError::Io(io::Error::new(io::ErrorKind::Other, e.to_string()))
+                })?;
 
             match serde_json::from_slice::<FuelErrorMsg>(&bytes) {
                 Ok(error) => {
@@ -68,9 +71,7 @@ impl SiteAssetIo {
                         io::ErrorKind::NotFound,
                         format!(
                             "Failed to fetch asset from fuel {} [errcode {}]: {}",
-                            remote_url,
-                            error.errcode,
-                            error.msg,
+                            remote_url, error.errcode, error.msg,
                         ),
                     )));
                 }

--- a/rmf_site_editor/src/site_asset_io.rs
+++ b/rmf_site_editor/src/site_asset_io.rs
@@ -198,10 +198,11 @@ impl AssetIo for SiteAssetIo {
                     })?;
 
                     /*
-                    TODO: Fuel will return a JSON object if it can't find the asset.
-                    We need to look at the returned object and see if it's JSON and
-                    has an errcode key. If so, we shouldn't cache the JSON error as
-                    if it were GLB
+                    TODO: handle HTTP 404 correctly from Fuel
+
+                    Somehow at the moment the HTTP 404 is being turned into a JSON
+                    object and saved to disk, which results in a later failure when
+                    that is attempted to be parsed as GLB
                     */
 
                     #[cfg(not(target_arch = "wasm32"))]

--- a/rmf_site_editor/src/widgets/icons.rs
+++ b/rmf_site_editor/src/widgets/icons.rs
@@ -32,13 +32,13 @@ pub struct Icons {
 impl FromWorld for Icons {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.get_resource::<AssetServer>().unwrap();
-        let bevy_select = asset_server.load(&String::from(&AssetSource::Remote(
+        let bevy_select = asset_server.load(&String::from(&AssetSource::Bundled(
             "textures/select.png".to_string(),
         )));
-        let bevy_edit = asset_server.load(&String::from(&AssetSource::Remote(
+        let bevy_edit = asset_server.load(&String::from(&AssetSource::Bundled(
             "textures/edit.png".to_string(),
         )));
-        let bevy_trash = asset_server.load(&String::from(&AssetSource::Remote(
+        let bevy_trash = asset_server.load(&String::from(&AssetSource::Bundled(
             "textures/trash.png".to_string(),
         )));
 

--- a/rmf_site_editor/src/widgets/inspector/inspect_asset_source.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_asset_source.rs
@@ -38,6 +38,7 @@ impl<'a> InspectAssetSource<'a> {
             AssetSource::Local(filename) => filename,
             AssetSource::Remote(uri) => uri,
             AssetSource::Search(name) => name,
+            AssetSource::Bundled(name) => name,
         };
         ui.horizontal(|ui| {
             ui.label("Source");
@@ -48,6 +49,7 @@ impl<'a> InspectAssetSource<'a> {
                         AssetSource::Local(assumed_source.clone()),
                         AssetSource::Remote(assumed_source.clone()),
                         AssetSource::Search(assumed_source.clone()),
+                        AssetSource::Bundled(assumed_source.clone()),
                     ] {
                         ui.selectable_value(&mut new_source, variant.clone(), variant.label());
                     }
@@ -74,6 +76,9 @@ impl<'a> InspectAssetSource<'a> {
                 ui.text_edit_singleline(uri);
             }
             AssetSource::Search(name) => {
+                ui.text_edit_singleline(name);
+            }
+            AssetSource::Bundled(name) => {
                 ui.text_edit_singleline(name);
             }
         }

--- a/rmf_site_format/src/asset_source.rs
+++ b/rmf_site_format/src/asset_source.rs
@@ -27,6 +27,7 @@ pub enum AssetSource {
     Local(String),
     Remote(String),
     Search(String),
+    Bundled(String),
 }
 
 impl AssetSource {
@@ -35,6 +36,7 @@ impl AssetSource {
             Self::Local(_) => "Local",
             Self::Remote(_) => "Remote",
             Self::Search(_) => "Search",
+            Self::Bundled(_) => "Bundled",
         }
     }
 }
@@ -62,6 +64,9 @@ impl From<&Path> for AssetSource {
         } else if path.starts_with("search://") {
             let without_prefix = path.to_str().unwrap().strip_prefix("search://").unwrap();
             return AssetSource::Search(String::from(without_prefix));
+        } else if path.starts_with("bundled://") {
+            let without_prefix = path.to_str().unwrap().strip_prefix("bundled://").unwrap();
+            return AssetSource::Bundled(String::from(without_prefix));
         }
         AssetSource::default()
     }
@@ -73,6 +78,7 @@ impl From<&AssetSource> for String {
             AssetSource::Remote(uri) => String::from("rmf-server://") + &uri,
             AssetSource::Local(filename) => String::from("file://") + &filename,
             AssetSource::Search(name) => String::from("search://") + &name,
+            AssetSource::Bundled(name) => String::from("bundled://") + &name,
         }
     }
 }
@@ -83,6 +89,7 @@ pub struct RecallAssetSource {
     pub filename: Option<String>,
     pub remote_uri: Option<String>,
     pub search_name: Option<String>,
+    pub bundled_name: Option<String>,
 }
 
 impl Recall for RecallAssetSource {
@@ -98,6 +105,9 @@ impl Recall for RecallAssetSource {
             }
             AssetSource::Search(name) => {
                 self.search_name = Some(name.clone());
+            }
+            AssetSource::Bundled(name) => {
+                self.bundled_name = Some(name.clone());
             }
         }
     }


### PR DESCRIPTION
The static server that was previously used to host assets is no longer around :skull: . This PR will migrate those asset requests to [Fuel](https://app.gazebosim.org/dashboard)

Because the static server was used for non-asset things, like icons and wall textures, we need another solution for those types of assets. For lack of a better idea, I added a "Bundled" asset type, and manually bundle the icons and default wall texture at build time.

Currently this PR does not encode any error handling from Fuel. This needs to be added before this will behave as expected.