### PR TITLE
Remove SimulationState struct

### DIFF
--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -37,7 +37,6 @@ mod site;
 // mod warehouse_generator;
 mod interaction;
 
-mod simulation_state;
 mod site_asset_io;
 
 use aabb::AabbUpdatePlugin;

--- a/rmf_site_editor/src/simulation_state.rs
+++ b/rmf_site_editor/src/simulation_state.rs
@@ -1,4 +1,0 @@
-#[derive(Default)]
-pub struct SimulationState {
-    pub paused: bool,
-}


### PR DESCRIPTION
This struct is currently unused. It is a vestige from an earlier time.
