### PR TITLE
Add support for spawning robots in locations

### DIFF
--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -234,6 +234,7 @@ impl Plugin for SitePlugin {
                     .with_system(update_floor_visibility)
                     .with_system(add_lane_visuals)
                     .with_system(add_location_visuals)
+                    .with_system(add_robot_to_spawn_location)
                     .with_system(update_level_visibility)
                     .with_system(update_changed_lane)
                     .with_system(update_lane_for_moved_anchor)

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -260,7 +260,10 @@ pub fn update_model_scenes(
 
 pub fn update_model_tentative_formats(
     mut commands: Commands,
-    changed_models: Query<Entity, (Changed<AssetSource>, With<ModelMarker>)>,
+    changed_models: Query<
+        (Entity, &AssetSource, Option<&ModelScene>),
+        (Changed<AssetSource>, With<ModelMarker>),
+    >,
     mut loading_models: Query<
         (
             Entity,
@@ -272,9 +275,11 @@ pub fn update_model_tentative_formats(
     >,
     asset_server: Res<AssetServer>,
 ) {
-    for e in changed_models.iter() {
+    for (e, source, scene) in changed_models.iter() {
         // Reset to the first format
-        commands.entity(e).insert(TentativeModelFormat::default());
+        if !scene.is_some_and(|r| &r.source == source) {
+            commands.entity(e).insert(TentativeModelFormat::default());
+        }
     }
     // Check from the asset server if any format failed, if it did try the next
     for (e, mut tentative_format, h, source) in loading_models.iter_mut() {

--- a/rmf_site_format/src/legacy/vertex.rs
+++ b/rmf_site_format/src/legacy/vertex.rs
@@ -60,7 +60,7 @@ impl Vertex {
         if !me.spawn_robot_name.is_empty() && !me.spawn_robot_type.is_empty() {
             tags.push(LocationTag::SpawnRobot(Model {
                 name: NameInSite(me.spawn_robot_name.1.clone()),
-                source: AssetSource::Search(me.spawn_robot_type.1.clone()),
+                source: AssetSource::Search("OpenRobotics/".to_string() + &me.spawn_robot_type.1),
                 pose: Pose::default(),
                 is_static: IsStatic(false),
                 constraints: ConstraintDependents::default(),


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Spawn a robot visual in locations with a `spawn_robot_name` and `spawn_robot_type` property

### Implementation description

The implementation is quite naive and currently just spawns a single static model in spawning locations, there is a TODO in place for future plans when robot behavior is added to the site editor, including making it non static and / or adding other components to distinguish models from robots.


While working on it I noticed that querying for whether a Location has a `SpawnRobot` tag is not terribly ergonomic since all tags are contained in a `LocationTags` component that is a `Vec<LocationTag>`, so each system dealing with location behavior will need to query for components with `LocationTags`, iterate over the whole vector and verify whether the location has the tag it needs (as is done here for `SpawnRobot`).

On the other hand, if each tag was a different component it would be possible to filter relevant entities at the query level, improving both performance and code simplicity.

Still, I kept this out of this PR since it would be quite a large refactor and didn't want to get into it in case it's not a good idea.