### PR TITLE
Undo move functionality

### DIFF
--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -92,12 +92,37 @@ pub fn remove_interaction_for_subordinate_anchors(
 }
 
 pub fn move_anchor(
-    mut anchors: Query<&mut Anchor, Without<Subordinate>>,
+    mut anchors: Query<(&mut Anchor, &Parent), Without<Subordinate>>,
+    categories: Query<&Category>,
     mut move_to: EventReader<MoveTo>,
+    mut undo_stack: ResMut<UndoStack>
 ) {
     for move_to in move_to.iter() {
-        if let Ok(mut anchor) = anchors.get_mut(move_to.entity) {
-            anchor.move_to(&move_to.transform);
+        if let Ok((mut anchor, parent)) = anchors.get_mut(move_to.entity) {
+            if let Ok(category) = categories.get(parent.get()) {
+                
+                if let Some(undo_event) = undo_stack.actions.front()
+                {
+                    if let UndoEvent::MoveAnchor(entity, _transform) = undo_event
+                    {
+                        if *entity != move_to.entity {
+                            undo_stack.actions.push_front(UndoEvent::MoveAnchor(
+                                move_to.entity, anchor.local_transform(*category)));
+                        }
+                    }
+                    else
+                    {
+                        undo_stack.actions.push_front(UndoEvent::MoveAnchor(
+                            move_to.entity, anchor.local_transform(*category)));
+                    }
+                }
+                else {
+                    undo_stack.actions.push_front(UndoEvent::MoveAnchor(
+                        move_to.entity, anchor.local_transform(*category)));
+                }
+               
+                anchor.move_to(&move_to.transform);
+            }
         }
     }
 }

--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -95,32 +95,32 @@ pub fn move_anchor(
     mut anchors: Query<(&mut Anchor, &Parent), Without<Subordinate>>,
     categories: Query<&Category>,
     mut move_to: EventReader<MoveTo>,
-    mut undo_stack: ResMut<UndoStack>
+    mut undo_stack: ResMut<UndoStack>,
 ) {
     for move_to in move_to.iter() {
         if let Ok((mut anchor, parent)) = anchors.get_mut(move_to.entity) {
             if let Ok(category) = categories.get(parent.get()) {
-                
-                if let Some(undo_event) = undo_stack.actions.front()
-                {
-                    if let UndoEvent::MoveAnchor(entity, _transform) = undo_event
-                    {
+                if let Some(undo_event) = undo_stack.actions.front() {
+                    if let UndoEvent::MoveAnchor(entity, _transform) = undo_event {
                         if *entity != move_to.entity {
                             undo_stack.actions.push_front(UndoEvent::MoveAnchor(
-                                move_to.entity, anchor.local_transform(*category)));
+                                move_to.entity,
+                                anchor.local_transform(*category),
+                            ));
                         }
-                    }
-                    else
-                    {
+                    } else {
                         undo_stack.actions.push_front(UndoEvent::MoveAnchor(
-                            move_to.entity, anchor.local_transform(*category)));
+                            move_to.entity,
+                            anchor.local_transform(*category),
+                        ));
                     }
-                }
-                else {
+                } else {
                     undo_stack.actions.push_front(UndoEvent::MoveAnchor(
-                        move_to.entity, anchor.local_transform(*category)));
+                        move_to.entity,
+                        anchor.local_transform(*category),
+                    ));
                 }
-               
+
                 anchor.move_to(&move_to.transform);
             }
         }

--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -456,31 +456,31 @@ pub fn update_drag_motions(
     }
 }
 
-pub fn move_pose(mut poses: Query<&mut Pose>,
+pub fn move_pose(
+    mut poses: Query<&mut Pose>,
     mut move_to: EventReader<MoveTo>,
-    mut undo_stack: ResMut<UndoStack>) {
+    mut undo_stack: ResMut<UndoStack>,
+) {
     for move_to in move_to.iter() {
-        if let Ok(mut pose) = poses.get_mut(move_to.entity) {     
+        if let Ok(mut pose) = poses.get_mut(move_to.entity) {
             let old_transform = pose.transform();
-            
-            if let Some(undo_event) = undo_stack.actions.front()
-            {
-                if let UndoEvent::MovePoseObject(entity, _transform) = undo_event
-                {
+
+            if let Some(undo_event) = undo_stack.actions.front() {
+                if let UndoEvent::MovePoseObject(entity, _transform) = undo_event {
                     if *entity != move_to.entity {
-                        undo_stack.actions.push_front(UndoEvent::MovePoseObject(
-                            move_to.entity, old_transform));
+                        undo_stack
+                            .actions
+                            .push_front(UndoEvent::MovePoseObject(move_to.entity, old_transform));
                     }
+                } else {
+                    undo_stack
+                        .actions
+                        .push_front(UndoEvent::MovePoseObject(move_to.entity, old_transform));
                 }
-                else
-                {
-                    undo_stack.actions.push_front(UndoEvent::MovePoseObject(
-                        move_to.entity, old_transform));
-                }
-            }
-            else {
-                undo_stack.actions.push_front(UndoEvent::MovePoseObject(
-                    move_to.entity, old_transform));
+            } else {
+                undo_stack
+                    .actions
+                    .push_front(UndoEvent::MovePoseObject(move_to.entity, old_transform));
             }
             pose.align_with(&move_to.transform);
         }

--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -456,9 +456,32 @@ pub fn update_drag_motions(
     }
 }
 
-pub fn move_pose(mut poses: Query<&mut Pose>, mut move_to: EventReader<MoveTo>) {
+pub fn move_pose(mut poses: Query<&mut Pose>,
+    mut move_to: EventReader<MoveTo>,
+    mut undo_stack: ResMut<UndoStack>) {
     for move_to in move_to.iter() {
-        if let Ok(mut pose) = poses.get_mut(move_to.entity) {
+        if let Ok(mut pose) = poses.get_mut(move_to.entity) {     
+            let old_transform = pose.transform();
+            
+            if let Some(undo_event) = undo_stack.actions.front()
+            {
+                if let UndoEvent::MovePoseObject(entity, _transform) = undo_event
+                {
+                    if *entity != move_to.entity {
+                        undo_stack.actions.push_front(UndoEvent::MovePoseObject(
+                            move_to.entity, old_transform));
+                    }
+                }
+                else
+                {
+                    undo_stack.actions.push_front(UndoEvent::MovePoseObject(
+                        move_to.entity, old_transform));
+                }
+            }
+            else {
+                undo_stack.actions.push_front(UndoEvent::MovePoseObject(
+                    move_to.entity, old_transform));
+            }
             pose.align_with(&move_to.transform);
         }
     }

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -71,6 +71,9 @@ pub use select_anchor::*;
 pub mod visual_cue;
 pub use visual_cue::*;
 
+pub mod undostack;
+pub use undostack::*;
+
 use bevy::prelude::*;
 use bevy_mod_outline::OutlinePlugin;
 use bevy_mod_picking::{PickingPlugin, PickingSystem};
@@ -127,6 +130,7 @@ impl Plugin for InteractionPlugin {
             .init_resource::<Hovering>()
             .init_resource::<GizmoState>()
             .init_resource::<InteractionMode>()
+            .init_resource::<UndoStack>()
             .add_event::<ChangePick>()
             .add_event::<Select>()
             .add_event::<Hover>()
@@ -134,6 +138,7 @@ impl Plugin for InteractionPlugin {
             .add_event::<ChangeMode>()
             .add_event::<GizmoClicked>()
             .add_event::<SpawnPreview>()
+            .add_event::<TriggerUndo>()
             .add_plugin(PickingPlugin)
             .add_plugin(OutlinePlugin)
             .add_plugin(CameraControlsPlugin)
@@ -200,7 +205,9 @@ impl Plugin for InteractionPlugin {
                 SystemSet::on_update(InteractionState::Enable)
                     .with_system(move_anchor.before(update_anchor_transforms))
                     .with_system(move_pose)
-                    .with_system(make_gizmos_pickable),
+                    .with_system(make_gizmos_pickable)
+                    // TODO(arjo): Move to Last?
+                    .with_system(perform_undo),
             )
             .add_system_set_to_stage(
                 CoreStage::First,

--- a/rmf_site_editor/src/interaction/undostack.rs
+++ b/rmf_site_editor/src/interaction/undostack.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*};
-use rmf_site_format::Anchor;
+use rmf_site_format::{Anchor, Pose};
 use std::collections::VecDeque;
 
 use crate::site::Subordinate;
@@ -23,6 +23,7 @@ pub fn perform_undo(
     mut ev_trigger_undo: EventReader<TriggerUndo>,
     mut undo_stack: ResMut<UndoStack>,
     mut anchors: Query<&mut Anchor, Without<Subordinate>>,
+    mut poses: Query<&mut Pose>,
 )
 {
     for _undo in ev_trigger_undo.iter() {
@@ -32,7 +33,12 @@ pub fn perform_undo(
                     if let Ok(mut anchor) = anchors.get_mut(entity) {
                         anchor.move_to(&old_pose);
                     }
-                }
+                },
+                UndoEvent::MovePoseObject(entity, old_pose) => {
+                    if let Ok(mut pose) = poses.get_mut(entity) {
+                        pose.align_with(&old_pose);
+                    }
+                },
                 _ => {}
             }
         }

--- a/rmf_site_editor/src/interaction/undostack.rs
+++ b/rmf_site_editor/src/interaction/undostack.rs
@@ -1,0 +1,40 @@
+use bevy::{prelude::*};
+use rmf_site_format::Anchor;
+use std::collections::VecDeque;
+
+use crate::site::Subordinate;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum UndoEvent {
+    MoveAnchor(Entity, Transform),
+    MovePoseObject(Entity, Transform),
+    OtherEvent
+}
+
+#[derive(Resource, Default)]
+pub struct UndoStack {
+    pub actions: VecDeque<UndoEvent>
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TriggerUndo {}
+
+pub fn perform_undo(
+    mut ev_trigger_undo: EventReader<TriggerUndo>,
+    mut undo_stack: ResMut<UndoStack>,
+    mut anchors: Query<&mut Anchor, Without<Subordinate>>,
+)
+{
+    for _undo in ev_trigger_undo.iter() {
+        if let Some(front) =  undo_stack.actions.pop_front() {
+            match front {
+                UndoEvent::MoveAnchor(entity, old_pose) => {
+                    if let Ok(mut anchor) = anchors.get_mut(entity) {
+                        anchor.move_to(&old_pose);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/rmf_site_editor/src/interaction/undostack.rs
+++ b/rmf_site_editor/src/interaction/undostack.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*};
+use bevy::prelude::*;
 use rmf_site_format::{Anchor, Pose};
 use std::collections::VecDeque;
 
@@ -8,12 +8,12 @@ use crate::site::Subordinate;
 pub enum UndoEvent {
     MoveAnchor(Entity, Transform),
     MovePoseObject(Entity, Transform),
-    OtherEvent
+    OtherEvent,
 }
 
 #[derive(Resource, Default)]
 pub struct UndoStack {
-    pub actions: VecDeque<UndoEvent>
+    pub actions: VecDeque<UndoEvent>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -24,21 +24,20 @@ pub fn perform_undo(
     mut undo_stack: ResMut<UndoStack>,
     mut anchors: Query<&mut Anchor, Without<Subordinate>>,
     mut poses: Query<&mut Pose>,
-)
-{
+) {
     for _undo in ev_trigger_undo.iter() {
-        if let Some(front) =  undo_stack.actions.pop_front() {
+        if let Some(front) = undo_stack.actions.pop_front() {
             match front {
                 UndoEvent::MoveAnchor(entity, old_pose) => {
                     if let Ok(mut anchor) = anchors.get_mut(entity) {
                         anchor.move_to(&old_pose);
                     }
-                },
+                }
                 UndoEvent::MovePoseObject(entity, old_pose) => {
                     if let Ok(mut pose) = poses.get_mut(entity) {
                         pose.align_with(&old_pose);
                     }
-                },
+                }
                 _ => {}
             }
         }

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -18,7 +18,7 @@
 use crate::{
     interaction::{
         camera_controls::{CameraControls, HeadlightToggle},
-        ChangeMode, InteractionMode, Selection,
+        ChangeMode, InteractionMode, Selection, TriggerUndo,
     },
     site::Delete,
     CreateNewWorkspace, LoadWorkspace, SaveWorkspace,
@@ -57,6 +57,7 @@ fn handle_keyboard_input(
     mut save_workspace: EventWriter<SaveWorkspace>,
     mut new_workspace: EventWriter<CreateNewWorkspace>,
     mut load_workspace: EventWriter<LoadWorkspace>,
+    mut undo_trigger: EventWriter<TriggerUndo>,
     headlight_toggle: Res<HeadlightToggle>,
     mut debug_mode: ResMut<DebugMode>,
 ) {
@@ -114,6 +115,10 @@ fn handle_keyboard_input(
 
         if keyboard_input.just_pressed(KeyCode::O) {
             load_workspace.send(LoadWorkspace::Dialog);
+        }
+
+        if keyboard_input.just_pressed(KeyCode::Z) {
+            undo_trigger.send(TriggerUndo{});
         }
     }
 }

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -118,7 +118,7 @@ fn handle_keyboard_input(
         }
 
         if keyboard_input.just_pressed(KeyCode::Z) {
-            undo_trigger.send(TriggerUndo{});
+            undo_trigger.send(TriggerUndo {});
         }
     }
 }

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     interaction::{
-        ChangeMode, HeadlightToggle, Hover, MoveTo, PickingBlockers, Select, SpawnPreview,
+        ChangeMode, HeadlightToggle, Hover, MoveTo, PickingBlockers, Select, SpawnPreview, TriggerUndo,
     },
     occupancy::CalculateGrid,
     recency::ChangeRank,
@@ -176,6 +176,7 @@ pub struct LayerEvents<'w, 's> {
 pub struct AppEvents<'w, 's> {
     pub commands: Commands<'w, 's>,
     pub change: ChangeEvents<'w, 's>,
+    pub undo_events: EventWriter<'w, 's, TriggerUndo>,
     pub workcell_change: WorkcellChangeEvents<'w, 's>,
     pub display: PanelResources<'w, 's>,
     pub request: Requests<'w, 's>,
@@ -285,6 +286,13 @@ fn site_ui_layout(
                         .file_events
                         .load_workspace
                         .send(LoadWorkspace::Dialog);
+                }
+            });
+
+            ui.menu_button("Edit", |ui| {
+                if ui.add(Button::new("Undo").shortcut_text("Ctrl+Z")).clicked() {
+                    events.undo_events.send(TriggerUndo {  });
+                    println!("Sending undo")
                 }
             });
         });

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -17,7 +17,8 @@
 
 use crate::{
     interaction::{
-        ChangeMode, HeadlightToggle, Hover, MoveTo, PickingBlockers, Select, SpawnPreview, TriggerUndo,
+        ChangeMode, HeadlightToggle, Hover, MoveTo, PickingBlockers, Select, SpawnPreview,
+        TriggerUndo,
     },
     occupancy::CalculateGrid,
     recency::ChangeRank,
@@ -290,8 +291,11 @@ fn site_ui_layout(
             });
 
             ui.menu_button("Edit", |ui| {
-                if ui.add(Button::new("Undo").shortcut_text("Ctrl+Z")).clicked() {
-                    events.undo_events.send(TriggerUndo {  });
+                if ui
+                    .add(Button::new("Undo").shortcut_text("Ctrl+Z"))
+                    .clicked()
+                {
+                    events.undo_events.send(TriggerUndo {});
                 }
             });
         });

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -292,7 +292,6 @@ fn site_ui_layout(
             ui.menu_button("Edit", |ui| {
                 if ui.add(Button::new("Undo").shortcut_text("Ctrl+Z")).clicked() {
                     events.undo_events.send(TriggerUndo {  });
-                    println!("Sending undo")
                 }
             });
         });


### PR DESCRIPTION
Supersedes #124.

## New feature implementation

### Implemented feature

This PR adds an undo feature to the editor. Currently it only reverts moves.

![undo](https://github.com/open-rmf/rmf_site/assets/542272/e93e6f0d-af2c-4015-a495-618a5bf33ccf)

### Implementation description

Currently, this uses an `enum` to dispatch various types of undo commands. In the future the hope is to use some type of trait system to provide a scalable dispatch.


