### PR TITLE
POC fix for legacy lifts

### DIFF
--- a/rmf_site_format/src/legacy/lift.rs
+++ b/rmf_site_format/src/legacy/lift.rs
@@ -45,8 +45,8 @@ impl Lift {
         // TODO(MXG): Rewrite this with glam now that we've accepted it as a dependency
         let x = self.x as f32;
         let y = self.y as f32;
-        let d = self.depth as f32 / 2.0;
-        let w = self.width as f32 / 2.0;
+        let d = self.width as f32 / 2.0;
+        let w = self.depth as f32 / 2.0;
         let theta = self.yaw as f32;
         let rotate = |x, y| {
             (
@@ -95,8 +95,8 @@ impl Lift {
 
             let dx = door.x as f32;
             let dy = door.y as f32;
-            let half_width = self.width as f32 / 2.0;
-            let half_depth = self.depth as f32 / 2.0;
+            let half_width = self.depth as f32 / 2.0;
+            let half_depth = self.width as f32 / 2.0;
 
             let cabin_face = if dx.abs() < 1e-3 {
                 // Very small x value means the door must be on the left or right face
@@ -208,8 +208,8 @@ impl Lift {
             }
         }
 
-        let width = self.width as f32;
-        let depth = self.depth as f32;
+        let width = self.depth as f32;
+        let depth = self.width as f32;
         let cabin = RectangularLiftCabin {
             width,
             depth,

--- a/rmf_site_format/src/legacy/lift.rs
+++ b/rmf_site_format/src/legacy/lift.rs
@@ -45,6 +45,12 @@ impl Lift {
         // TODO(MXG): Rewrite this with glam now that we've accepted it as a dependency
         let x = self.x as f32;
         let y = self.y as f32;
+        // NOTE: Coordinate axes changed between the legacy format and the
+        // new format. Width used to be along the local x axis, and depth
+        // used to be along the local y axis, but now that is flipped to
+        // better align with the robotics convention of the local x axis
+        // being forward/backward while the local y axis is the lateral
+        // direction (side-to-side).
         let d = self.width as f32 / 2.0;
         let w = self.depth as f32 / 2.0;
         let theta = self.yaw as f32;
@@ -95,6 +101,12 @@ impl Lift {
 
             let dx = door.x as f32;
             let dy = door.y as f32;
+            // NOTE: Coordinate axes changed between the legacy format and the
+            // new format. Width used to be along the local x axis, and depth
+            // used to be along the local y axis, but now that is flipped to
+            // better align with the robotics convention of the local x axis
+            // being forward/backward while the local y axis is the lateral
+            // direction (side-to-side).
             let half_width = self.depth as f32 / 2.0;
             let half_depth = self.width as f32 / 2.0;
 
@@ -208,6 +220,12 @@ impl Lift {
             }
         }
 
+        // NOTE: Coordinate axes changed between the legacy format and the
+        // new format. Width used to be along the local x axis, and depth
+        // used to be along the local y axis, but now that is flipped to
+        // better align with the robotics convention of the local x axis
+        // being forward/backward while the local y axis is the lateral
+        // direction (side-to-side).
         let width = self.depth as f32;
         let depth = self.width as f32;
         let cabin = RectangularLiftCabin {


### PR DESCRIPTION
## Bug fix

### Fixed bug

When importing projects containing lifts with rectangular shapes, things can go quite wrong, from swapped widths and depths to failure in importing the project.
This PR is little more than a bug report, it's a "hacky fix that seems to work", there might be a better fix but I'm not familiar with how lifts are stored and parsed in the site editor.

### Fix applied

I just swapped widths and depths in the legacy lift importing code path, not sure how the coordinate system is supposed to be but this seems to fix all the scenarios I could find.

Test it!

* Create a world with a rectangular lift, for example change [this line](https://github.com/open-rmf/rmf_demos/blob/3f29a858ae64f2702696c5b1e5481c969c8f08a4/rmf_demos_maps/maps/hotel/hotel.building.yaml#L1046) to a large number like 10.0
* Open the map in traffic editor to see what it looks like.
* Try to open the map in site editor `main` branch, import should  fail: `Failed converting to site InvalidLiftCabinDoorPlacement { lift: "Lift1", door: "lift1_door" }`
* Try the PR, import should be successful and the lift should match its traffic editor rendering