### PR TITLE
Adds a setting for default lane size

### DIFF
--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -181,5 +181,6 @@ pub fn run(command_line_args: Vec<String>) {
         .add_plugin(AnimationPlugin)
         .add_plugin(OccupancyPlugin)
         .add_plugin(WorkspacePlugin)
+        .add_plugin(PreferencePlugin)
         .run();
 }

--- a/rmf_site_editor/src/site/assets.rs
+++ b/rmf_site_editor/src/site/assets.rs
@@ -15,7 +15,11 @@
  *
 */
 
-use crate::{shapes::*, site::*};
+use crate::{
+    shapes::*,
+    site::*,
+    widgets::preferences::{self, PreferencePanel, PreferenceParameters},
+};
 use bevy::{math::Affine3A, prelude::*};
 
 #[derive(Resource)]
@@ -55,6 +59,10 @@ pub struct SiteAssets {
 impl FromWorld for SiteAssets {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.get_resource::<AssetServer>().unwrap();
+        let preferences = world
+            .get_resource::<PreferenceParameters>()
+            .unwrap_or(&PreferenceParameters::default())
+            .clone();
         let wall_texture = asset_server.load(&String::from(&AssetSource::Bundled(
             "textures/default.png".to_string(),
         )));
@@ -166,7 +174,7 @@ impl FromWorld for SiteAssets {
         let lane_end_mesh = meshes.add(
             make_flat_disk(
                 Circle {
-                    radius: LANE_WIDTH / 2.0,
+                    radius: preferences.default_lane_width / 2.0,
                     height: 0.0,
                 },
                 32,
@@ -176,7 +184,7 @@ impl FromWorld for SiteAssets {
         let lane_end_outline = meshes.add(
             make_flat_disk(
                 Circle {
-                    radius: 1.125 * LANE_WIDTH / 2.0,
+                    radius: 1.125 * preferences.default_lane_width / 2.0,
                     height: 0.0,
                 },
                 32,
@@ -190,7 +198,7 @@ impl FromWorld for SiteAssets {
         );
         let location_mesh = meshes.add(
             Mesh::from(
-                make_icon_halo(1.1 * LANE_WIDTH / 2.0, 0.01, 6)
+                make_icon_halo(1.1 * preferences.default_lane_width / 2.0, 0.01, 6)
                     .transform_by(Affine3A::from_translation(0.00125 * Vec3::Z)),
             )
             .with_generated_outline_normals()

--- a/rmf_site_editor/src/site/assets.rs
+++ b/rmf_site_editor/src/site/assets.rs
@@ -15,10 +15,7 @@
  *
 */
 
-use crate::{
-    shapes::*,
-    site::*,
-};
+use crate::{shapes::*, site::*};
 use bevy::{math::Affine3A, prelude::*};
 
 #[derive(Resource)]

--- a/rmf_site_editor/src/site/assets.rs
+++ b/rmf_site_editor/src/site/assets.rs
@@ -18,7 +18,6 @@
 use crate::{
     shapes::*,
     site::*,
-    widgets::preferences::{self, PreferencePanel, PreferenceParameters},
 };
 use bevy::{math::Affine3A, prelude::*};
 
@@ -59,10 +58,7 @@ pub struct SiteAssets {
 impl FromWorld for SiteAssets {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.get_resource::<AssetServer>().unwrap();
-        let preferences = world
-            .get_resource::<PreferenceParameters>()
-            .unwrap_or(&PreferenceParameters::default())
-            .clone();
+        let preferences = Preferences::default();
         let wall_texture = asset_server.load(&String::from(&AssetSource::Bundled(
             "textures/default.png".to_string(),
         )));

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -16,8 +16,6 @@
 */
 
 use crate::site::*;
-use crate::widgets::preferences;
-use crate::widgets::preferences::PreferenceParameters;
 use crate::CurrentWorkspace;
 use bevy::prelude::*;
 use rmf_site_format::{Edge, LaneMarker};
@@ -94,8 +92,11 @@ pub fn add_lane_visuals(
     mut dependents: Query<&mut Dependents, With<Anchor>>,
     assets: Res<SiteAssets>,
     current_level: Res<CurrentLevel>,
-    preferences: Res<PreferenceParameters>,
+    site_properties: Query<&SiteProperties>,
 ) {
+    // TODO(arjo): Refactor so no panics
+    let preferences = site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default();
+
     for (e, edge, associated_graphs) in &lanes {
         for anchor in &edge.array() {
             if let Ok(mut deps) = dependents.get_mut(*anchor) {
@@ -220,7 +221,7 @@ pub fn update_lane_visuals(
     edge: &Edge<Entity>,
     segments: &LaneSegments,
     anchors: &AnchorParams,
-    preferences: &Res<PreferenceParameters>,
+    preferences: &Preferences,
     transforms: &mut Query<&mut Transform>,
 ) {
     let start_anchor = anchors
@@ -258,8 +259,9 @@ pub fn update_changed_lane(
     graphs: GraphSelect,
     mut transforms: Query<&mut Transform>,
     current_level: Res<CurrentLevel>,
-    preferences: Res<PreferenceParameters>,
+    site_properties: Query<&SiteProperties>,
 ) {
+    let preferences = site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default();
     for (e, edge, associated, segments, mut visibility) in &mut lanes {
         update_lane_visuals(e, edge, segments, &anchors, &preferences, &mut transforms);
 
@@ -282,8 +284,9 @@ pub fn update_lane_for_moved_anchor(
         ),
     >,
     mut transforms: Query<&mut Transform>,
-    preferences: Res<PreferenceParameters>,
+    site_properties: Query<&SiteProperties>,
 ) {
+    let preferences = site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default();
     for dependents in &changed_anchors {
         for dependent in dependents.iter() {
             if let Ok((e, edge, segments)) = lanes.get(*dependent) {

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -95,7 +95,11 @@ pub fn add_lane_visuals(
     site_properties: Query<&SiteProperties>,
 ) {
     // TODO(arjo): Refactor so no panics
-    let preferences = site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default();
+    let preferences = site_properties
+        .get_single()
+        .unwrap_or(&Default::default())
+        .preferences
+        .unwrap_or_default();
 
     for (e, edge, associated_graphs) in &lanes {
         for anchor in &edge.array() {
@@ -261,7 +265,11 @@ pub fn update_changed_lane(
     current_level: Res<CurrentLevel>,
     site_properties: Query<&SiteProperties>,
 ) {
-    let preferences = site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default();
+    let preferences = site_properties
+        .get_single()
+        .unwrap_or(&Default::default())
+        .preferences
+        .unwrap_or_default();
     for (e, edge, associated, segments, mut visibility) in &mut lanes {
         update_lane_visuals(e, edge, segments, &anchors, &preferences, &mut transforms);
 
@@ -286,7 +294,11 @@ pub fn update_lane_for_moved_anchor(
     mut transforms: Query<&mut Transform>,
     site_properties: Query<&SiteProperties>,
 ) {
-    let preferences = site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default();
+    let preferences = site_properties
+        .get_single()
+        .unwrap_or(&Default::default())
+        .preferences
+        .unwrap_or_default();
     for dependents in &changed_anchors {
         for dependent in dependents.iter() {
             if let Ok((e, edge, segments)) = lanes.get(*dependent) {

--- a/rmf_site_editor/src/site/measurement.rs
+++ b/rmf_site_editor/src/site/measurement.rs
@@ -15,10 +15,7 @@
  *
 */
 
-use crate::{
-    interaction::Selectable,
-    site::*,
-};
+use crate::{interaction::Selectable, site::*};
 use bevy::prelude::*;
 use rmf_site_format::{Edge, MeasurementMarker};
 
@@ -43,7 +40,12 @@ pub fn add_measurement_visuals(
                     &anchors
                         .point_in_parent_frame_of(edge.end(), Category::Measurement, e)
                         .unwrap(),
-                    site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default().default_lane_width,
+                    site_properties
+                        .get_single()
+                        .unwrap_or(&Default::default())
+                        .preferences
+                        .unwrap_or_default()
+                        .default_lane_width,
                 ),
                 ..default()
             })
@@ -72,7 +74,16 @@ fn update_measurement_visual(
     let end_anchor = anchors
         .point_in_parent_frame_of(edge.end(), Category::Measurement, entity)
         .unwrap();
-    *transform = line_stroke_transform(&start_anchor, &end_anchor, site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default().default_lane_width);
+    *transform = line_stroke_transform(
+        &start_anchor,
+        &end_anchor,
+        site_properties
+            .get_single()
+            .unwrap_or(&Default::default())
+            .preferences
+            .unwrap_or_default()
+            .default_lane_width,
+    );
 }
 
 pub fn update_changed_measurement(

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -62,6 +62,9 @@ use inspector::{InspectorParams, InspectorWidget};
 pub mod move_layer;
 pub use move_layer::*;
 
+pub mod preferences;
+pub use preferences::*;
+
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 pub enum UiUpdateLabel {
     DrawUi,
@@ -131,6 +134,11 @@ pub struct FileEvents<'w, 's> {
 }
 
 #[derive(SystemParam)]
+pub struct EditEvents<'w, 's> {
+    pub preference: EventWriter<'w, 's, PreferenceEvent>,
+}
+
+#[derive(SystemParam)]
 pub struct PanelResources<'w, 's> {
     pub level: ResMut<'w, LevelDisplay>,
     pub nav_graph: ResMut<'w, NavGraphDisplay>,
@@ -180,6 +188,7 @@ pub struct AppEvents<'w, 's> {
     pub display: PanelResources<'w, 's>,
     pub request: Requests<'w, 's>,
     pub file_events: FileEvents<'w, 's>,
+    pub edit_events: EditEvents<'w, 's>,
     pub layers: LayerEvents<'w, 's>,
     pub app_state: Res<'w, State<AppState>>,
     pub pending_asset_sources:
@@ -285,6 +294,14 @@ fn site_ui_layout(
                         .file_events
                         .load_workspace
                         .send(LoadWorkspace::Dialog);
+                }
+            });
+            ui.menu_button("Edit", |ui| {
+                if ui
+                    .add(Button::new("Preferences..."))
+                    .clicked()
+                {
+                    events.edit_events.preference.send(PreferenceEvent)
                 }
             });
         });

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -297,10 +297,7 @@ fn site_ui_layout(
                 }
             });
             ui.menu_button("Edit", |ui| {
-                if ui
-                    .add(Button::new("Preferences..."))
-                    .clicked()
-                {
+                if ui.add(Button::new("Preferences...")).clicked() {
                     events.edit_events.preference.send(PreferenceEvent)
                 }
             });

--- a/rmf_site_editor/src/widgets/preferences.rs
+++ b/rmf_site_editor/src/widgets/preferences.rs
@@ -1,0 +1,116 @@
+use bevy::prelude::*;
+use bevy_egui::{
+    egui::{self, DragValue, Slider},
+    EguiContext,
+};
+use rmf_site_format::{AnchorParams, AssociatedGraphs, Edge};
+
+use crate::site::{should_display_lane, update_lane_visuals, LaneEnds, LaneSegments, SiteAssets};
+pub struct PreferenceEvent;
+
+const LANE_DEFAULT_SIZE: f32 = 0.5;
+
+#[derive(Debug, Clone, Resource)]
+pub struct PreferenceParameters {
+    pub default_lane_width: f32,
+    /// TODO(arjo): scale anchors as well.
+    pub default_anchor_size: f32,
+}
+
+impl PreferenceParameters {
+    pub fn scale_lane_ends_by(&self) -> f32 {
+        self.default_lane_width / LANE_DEFAULT_SIZE
+    }
+}
+
+impl Default for PreferenceParameters {
+    fn default() -> Self {
+        Self {
+            default_lane_width: LANE_DEFAULT_SIZE,
+            default_anchor_size: 0.25,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Resource, Default)]
+pub struct PreferencePanel {
+    enable: bool,
+}
+
+fn enable_preference_ui(
+    mut events: EventReader<PreferenceEvent>,
+    mut panel: ResMut<PreferencePanel>,
+) {
+    for event in events.iter() {
+        panel.enable = true;
+    }
+}
+
+struct RedrawLanes;
+
+fn draw_preference_ui(
+    mut panel: ResMut<PreferencePanel>,
+    mut preference_paramters: ResMut<PreferenceParameters>,
+    mut egui_context: ResMut<EguiContext>,
+    mut redraw_lanes: EventWriter<RedrawLanes>,
+) {
+    if !panel.enable {
+        return;
+    }
+
+    egui::Window::new("Preferences").show(egui_context.ctx_mut(), |ui| {
+        ui.horizontal(|ui| {
+            ui.label("Default Lane Width: ");
+            let lane_width_entry = DragValue::new(&mut preference_paramters.default_lane_width)
+                .clamp_range(0.0..=10000.0);
+            if ui.add(lane_width_entry).changed() {
+                redraw_lanes.send(RedrawLanes);
+            }
+        });
+        if ui.button("Done").clicked() {
+            panel.enable = false;
+            redraw_lanes.send(RedrawLanes);
+        }
+    });
+}
+
+fn redraw_lanes(
+    redraw_lanes: EventReader<RedrawLanes>,
+    mut lanes: Query<(Entity, &Edge<Entity>, &LaneSegments)>,
+    preferences: Res<PreferenceParameters>,
+    mut assets: ResMut<SiteAssets>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    anchors: AnchorParams,
+    mut transforms: Query<&mut Transform>,
+    lane_ends: Query<Entity, With<LaneEnds>>,
+) {
+    if redraw_lanes.len() == 0 {
+        return;
+    }
+
+    for (e, edge, segments) in &mut lanes {
+        update_lane_visuals(e, edge, segments, &anchors, &preferences, &mut transforms);
+    }
+
+    for entity in &lane_ends {
+        let mut transform = transforms.get_mut(entity);
+        if let Ok(mut transform) = transform {
+            transform.scale.x = preferences.default_lane_width / LANE_DEFAULT_SIZE;
+            transform.scale.y = preferences.default_lane_width / LANE_DEFAULT_SIZE;
+        }
+    }
+}
+
+pub struct PreferencePlugin;
+
+impl Plugin for PreferencePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<PreferenceEvent>()
+            .add_event::<RedrawLanes>()
+            .init_resource::<PreferencePanel>()
+            .init_resource::<PreferenceParameters>()
+            .add_system_to_stage(CoreStage::Update, enable_preference_ui)
+            .add_system_to_stage(CoreStage::PostUpdate, draw_preference_ui.label("ui"))
+            .add_system_to_stage(CoreStage::PostUpdate, redraw_lanes.after("ui"));
+    }
+}

--- a/rmf_site_editor/src/widgets/preferences.rs
+++ b/rmf_site_editor/src/widgets/preferences.rs
@@ -3,7 +3,7 @@ use bevy_egui::{
     egui::{self, DragValue, Slider},
     EguiContext,
 };
-use rmf_site_format::{AnchorParams, AssociatedGraphs, Edge, SiteProperties, Preferences};
+use rmf_site_format::{AnchorParams, AssociatedGraphs, Edge, Preferences, SiteProperties};
 
 use crate::site::{should_display_lane, update_lane_visuals, LaneEnds, LaneSegments, SiteAssets};
 pub struct PreferenceEvent;
@@ -34,9 +34,9 @@ fn draw_preference_ui(
     }
 
     let mut properties = site_properties.get_single_mut();
-    
+
     if let Ok(props) = properties.as_mut() {
-        // If SiteProperties doesn't exist it is probably because it has not loaded 
+        // If SiteProperties doesn't exist it is probably because it has not loaded
         if props.preferences.is_none() {
             props.preferences = Some(Default::default());
             println!("Setting default value");
@@ -57,9 +57,7 @@ fn draw_preference_ui(
                 }
             });
         }
-        
     }
-
 }
 
 fn redraw_lanes(
@@ -71,7 +69,11 @@ fn redraw_lanes(
     lane_ends: Query<Entity, With<LaneEnds>>,
 ) {
     // TODO(arjo): Refactor so no panics
-    let preferences = site_properties.get_single().unwrap_or(&Default::default()).preferences.unwrap_or_default();
+    let preferences = site_properties
+        .get_single()
+        .unwrap_or(&Default::default())
+        .preferences
+        .unwrap_or_default();
 
     if redraw_lanes.len() == 0 {
         return;

--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -7,6 +7,7 @@ use crate::{
     Navigation, OrientationConstraint, PixelsPerMeter, Pose, RankingsInLevel, ReverseLane,
     Rotation, Site, SiteProperties, DEFAULT_NAV_GRAPH_COLORS,
 };
+use bevy::prelude::default;
 use glam::{DAffine2, DMat3, DQuat, DVec2, DVec3, EulerRot};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -380,6 +381,7 @@ impl BuildingMap {
             anchors: site_anchors,
             properties: SiteProperties {
                 name: self.name.clone(),
+                ..default()
             },
             levels,
             lifts,

--- a/rmf_site_format/src/lib.rs
+++ b/rmf_site_format/src/lib.rs
@@ -106,6 +106,6 @@ mod is_default;
 pub(crate) use is_default::*;
 
 pub const CURRENT_MAJOR_VERSION: u32 = 0;
-pub const CURRENT_MINOR_VERSION: u32 = 1;
+pub const CURRENT_MINOR_VERSION: u32 = 2;
 
 pub mod legacy;

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -23,16 +23,42 @@ use std::{collections::BTreeMap, io};
 
 pub use ron::ser::PrettyConfig as Style;
 
+const LANE_DEFAULT_SIZE: f32 = 0.5;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct Preferences {
+    pub default_lane_width: f32
+}
+
+impl Default for Preferences {
+
+    fn default() -> Self {
+        Self {
+            default_lane_width: LANE_DEFAULT_SIZE
+        }
+    }
+}
+
+impl Preferences {
+    pub fn scale_lane_ends_by(&self) -> f32 {
+        self.default_lane_width / LANE_DEFAULT_SIZE
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "bevy", derive(Component))]
 pub struct SiteProperties {
     pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferences: Option<Preferences>
 }
 
 impl Default for SiteProperties {
     fn default() -> Self {
         Self {
             name: "new_site".to_string(),
+            preferences: None
         }
     }
 }

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -31,7 +31,6 @@ pub struct Preferences {
 }
 
 impl Default for Preferences {
-
     fn default() -> Self {
         Self {
             default_lane_width: LANE_DEFAULT_SIZE,

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -27,14 +27,14 @@ const LANE_DEFAULT_SIZE: f32 = 0.5;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct Preferences {
-    pub default_lane_width: f32
+    pub default_lane_width: f32,
 }
 
 impl Default for Preferences {
 
     fn default() -> Self {
         Self {
-            default_lane_width: LANE_DEFAULT_SIZE
+            default_lane_width: LANE_DEFAULT_SIZE,
         }
     }
 }
@@ -51,14 +51,14 @@ pub struct SiteProperties {
     pub name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preferences: Option<Preferences>
+    pub preferences: Option<Preferences>,
 }
 
 impl Default for SiteProperties {
     fn default() -> Self {
         Self {
             name: "new_site".to_string(),
-            preferences: None
+            preferences: None,
         }
     }
 }


### PR DESCRIPTION
This PR adds a setting for default lane size. It can be found by going to `Edit -> Preferences...`. We need to find a way to persist this. Note this setting does not change per-lane widths as those should be handled differently.