### PR TITLE
Add components for opening / closing doors and door behavior preview

### DIFF
--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -172,7 +172,8 @@ impl Plugin for InteractionPlugin {
                             .after(update_gizmo_release),
                     )
                     .with_system(handle_lift_doormat_clicks.after(update_gizmo_click_start))
-                    .with_system(manage_previews)
+                    .with_system(make_new_entities_previewable)
+                    .with_system(manage_camera_previews)
                     .with_system(update_physical_camera_preview)
                     .with_system(dirty_changed_lifts)
                     .with_system(handle_preview_window_close),

--- a/rmf_site_editor/src/interaction/preview.rs
+++ b/rmf_site_editor/src/interaction/preview.rs
@@ -24,8 +24,9 @@ use bevy::{
     window::{CreateWindow, PresentMode, WindowClosed, WindowId, Windows},
 };
 
-use rmf_site_format::{NameInSite, PhysicalCameraProperties};
+use rmf_site_format::{DoorMarker, NameInSite, PhysicalCameraProperties};
 
+// TODO(luca) consider moving this module in site instead of interaction
 /// Marker component for previewable entities
 #[derive(Component, Clone, Copy, Debug, Default)]
 pub struct PreviewableMarker;
@@ -169,9 +170,9 @@ pub fn handle_preview_window_close(
 
 pub fn make_new_entities_previewable(
     mut commands: Commands,
-    new_cameras: Query<Entity, Added<PhysicalCameraProperties>>,
+    new_entities: Query<Entity, Or<(Added<PhysicalCameraProperties>, Added<DoorMarker>)>>,
 ) {
-    for e in &new_cameras {
+    for e in &new_entities {
         commands.entity(e).insert(PreviewableMarker);
     }
 }

--- a/rmf_site_editor/src/site/door.rs
+++ b/rmf_site_editor/src/site/door.rs
@@ -356,7 +356,8 @@ pub fn add_door_visuals(
                 cue_outline,
             })
             .insert(Category::Door)
-            .insert(DoorState::Closed)
+            .insert(DoorState::Open)
+            .insert(DoorCommand::Open)
             .insert(EdgeLabels::LeftRight);
 
         for anchor in edge.array() {

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -191,7 +191,10 @@ impl Plugin for SitePlugin {
                 CoreStage::PreUpdate,
                 SystemSet::on_update(SiteState::Display)
                     .after(SiteUpdateLabel::ProcessChanges)
-                    .with_system(update_door_state)
+                    // TODO(luca) These are here so they don't conflict with animation systems,
+                    // refactor animation systems into a separate stage when migrating to bevy 0.11
+                    .with_system(update_changed_door)
+                    .with_system(update_door_for_moved_anchors)
                     .with_system(update_lift_cabin)
                     .with_system(update_lift_edge)
                     .with_system(update_model_tentative_formats)
@@ -227,10 +230,9 @@ impl Plugin for SitePlugin {
                     .after(VisibilitySystems::VisibilityPropagate)
                     .with_system(update_anchor_transforms)
                     .with_system(add_door_visuals)
-                    .with_system(update_changed_door)
-                    .with_system(update_door_for_moved_anchors)
                     .with_system(manage_door_previews)
                     .with_system(control_doors)
+                    .with_system(update_door_state)
                     .with_system(add_floor_visuals)
                     .with_system(update_changed_floor)
                     .with_system(update_floor_for_moved_anchors)

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -191,6 +191,7 @@ impl Plugin for SitePlugin {
                 CoreStage::PreUpdate,
                 SystemSet::on_update(SiteState::Display)
                     .after(SiteUpdateLabel::ProcessChanges)
+                    .with_system(update_door_state)
                     .with_system(update_lift_cabin)
                     .with_system(update_lift_edge)
                     .with_system(update_model_tentative_formats)
@@ -228,6 +229,8 @@ impl Plugin for SitePlugin {
                     .with_system(add_door_visuals)
                     .with_system(update_changed_door)
                     .with_system(update_door_for_moved_anchors)
+                    .with_system(manage_door_previews)
+                    .with_system(control_doors)
                     .with_system(add_floor_visuals)
                     .with_system(update_changed_floor)
                     .with_system(update_floor_for_moved_anchors)

--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -478,7 +478,6 @@ fn generate_levels(
                         name: name.clone(),
                         pose: pose.clone(),
                         properties: properties.clone(),
-                        previewable: PreviewableMarker,
                     },
                 );
             }

--- a/rmf_site_editor/src/widgets/inspector/inspect_door.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_door.rs
@@ -58,7 +58,7 @@ impl<'a> InspectDoorType<'a> {
                 )
                 .on_hover_text("(Left Door Length)/(Right Door Length)");
             });
-        };
+        }
 
         match &mut new_kind {
             DoorType::SingleSliding(door) => {

--- a/rmf_site_editor/src/widgets/inspector/inspect_door.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_door.rs
@@ -48,7 +48,7 @@ impl<'a> InspectDoorType<'a> {
                 });
         });
 
-        fn left_right_ratio_ui(ui: &mut Ui, mut ratio: &mut f32) {
+        fn left_right_ratio_ui(ui: &mut Ui, ratio: &mut f32) {
             ui.horizontal(|ui| {
                 ui.label("Left : Right");
                 ui.add(

--- a/rmf_site_editor/src/widgets/inspector/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/mod.rs
@@ -85,7 +85,7 @@ pub mod selection_widget;
 pub use selection_widget::*;
 
 use crate::{
-    interaction::{Selection, SpawnPreview},
+    interaction::{PreviewableMarker, Selection, SpawnPreview},
     site::{Category, Change, EdgeLabels, FloorVisibility, Original, SiteID},
     widgets::AppEvents,
 };

--- a/rmf_site_format/src/door.rs
+++ b/rmf_site_format/src/door.rs
@@ -315,7 +315,7 @@ impl RecallDoorType {
             .unwrap_or(
                 self.single_sliding
                     .as_ref()
-                    .map(|x| x.clone())
+                    .cloned()
                     .unwrap_or(SingleSlidingDoor::default().into()),
             )
     }
@@ -327,7 +327,7 @@ impl RecallDoorType {
             .unwrap_or(
                 self.double_sliding
                     .as_ref()
-                    .map(|x| x.clone())
+                    .cloned()
                     .unwrap_or(DoubleSlidingDoor::default().into()),
             )
     }
@@ -336,7 +336,7 @@ impl RecallDoorType {
         current.single_swing().map(|x| x.clone().into()).unwrap_or(
             self.single_swing
                 .as_ref()
-                .map(|x| x.clone())
+                .cloned()
                 .unwrap_or(SingleSwingDoor::default().into()),
         )
     }
@@ -345,7 +345,7 @@ impl RecallDoorType {
         current.double_swing().map(|x| x.clone().into()).unwrap_or(
             self.double_swing
                 .as_ref()
-                .map(|x| x.clone())
+                .cloned()
                 .unwrap_or(DoubleSwingDoor::default().into()),
         )
     }
@@ -354,7 +354,7 @@ impl RecallDoorType {
         current.model().map(|x| x.clone().into()).unwrap_or(
             self.model
                 .as_ref()
-                .map(|x| x.clone())
+                .cloned()
                 .unwrap_or(DoorType::Model(Model::default())),
         )
     }

--- a/rmf_site_format/src/door.rs
+++ b/rmf_site_format/src/door.rs
@@ -95,6 +95,26 @@ impl DoorType {
             Self::Model(_) => "Model",
         }
     }
+
+    /// Get the offset from the door center of the point where the doors
+    /// separate. A value of 0.0 means the doors are even. A negative value
+    /// means the left door is smaller while a positive value means the right
+    /// door is smaller.
+    /// Note that this only applies to double door, function returns None
+    /// for single / model doors
+    pub fn compute_offset(&self, door_width: f32) -> Option<f32> {
+        match self {
+            Self::DoubleSliding(door) => {
+                let l = door.left_right_ratio * door_width / (door.left_right_ratio + 1.0);
+                Some(door_width / 2.0 - l)
+            }
+            Self::DoubleSwing(door) => {
+                let l = door.left_right_ratio * door_width / (door.left_right_ratio + 1.0);
+                Some(door_width / 2.0 - l)
+            }
+            Self::SingleSliding(_) | Self::SingleSwing(_) | Self::Model(_) => None,
+        }
+    }
 }
 
 impl Default for DoorType {
@@ -129,17 +149,6 @@ impl From<SingleSlidingDoor> for DoorType {
 pub struct DoubleSlidingDoor {
     /// Length of the left door divided by the length of the right door
     pub left_right_ratio: f32,
-}
-
-impl DoubleSlidingDoor {
-    /// Get the offset from the door center of the point where the doors
-    /// separate. A value of 0.0 means the doors are even. A negative value
-    /// means the left door is smaller while a positive value means the right
-    /// door is smaller.
-    pub fn compute_offset(&self, door_width: f32) -> f32 {
-        let l = self.left_right_ratio * door_width / (self.left_right_ratio + 1.0);
-        return door_width / 2.0 - l;
-    }
 }
 
 impl Default for DoubleSlidingDoor {
@@ -187,17 +196,6 @@ pub struct DoubleSwingDoor {
     pub swing: Swing,
     /// Length of the left door divided by the length of the right door
     pub left_right_ratio: f32,
-}
-
-impl DoubleSwingDoor {
-    /// Get the offset from the door center of the point where the doors
-    /// separate. A value of 0.0 means the doors are even. A negative value
-    /// means the left door is smaller while a positive value means the right
-    /// door is smaller.
-    pub fn compute_offset(&self, door_width: f32) -> f32 {
-        let l = self.left_right_ratio * door_width / (self.left_right_ratio + 1.0);
-        return door_width / 2.0 - l;
-    }
 }
 
 impl Default for DoubleSwingDoor {

--- a/rmf_site_format/src/legacy/physical_camera.rs
+++ b/rmf_site_format/src/legacy/physical_camera.rs
@@ -1,6 +1,6 @@
 use crate::{
     Angle, NameInSite, PhysicalCamera as SitePhysicalCamera, PhysicalCameraProperties, Pose,
-    PreviewableMarker, Rotation,
+    Rotation,
 };
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
@@ -43,7 +43,6 @@ impl PhysicalCamera {
                 horizontal_fov: Angle::Rad(self.image_fov as f32),
                 frame_rate: self.update_rate as f32,
             },
-            previewable: PreviewableMarker,
         }
     }
 }

--- a/rmf_site_format/src/misc.rs
+++ b/rmf_site_format/src/misc.rs
@@ -416,11 +416,6 @@ impl Default for IsStatic {
     }
 }
 
-/// Marker component for previewable entities
-#[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "bevy", derive(Component))]
-pub struct PreviewableMarker;
-
 /// This component is applied to each site element that gets loaded in order to
 /// remember what its original ID within the Site file was.
 #[derive(Clone, Copy, Debug)]

--- a/rmf_site_format/src/physical_camera.rs
+++ b/rmf_site_format/src/physical_camera.rs
@@ -26,8 +26,6 @@ pub struct PhysicalCamera {
     pub name: NameInSite,
     pub pose: Pose,
     pub properties: PhysicalCameraProperties,
-    #[serde(skip)]
-    pub previewable: PreviewableMarker,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR builds on top of #138 and closes #76. The door behavior is currently more of a "teleport to destination" rather than smoothly open or close but doors can be commanded and their states read.

[Screencast from 2023-06-23 15-36-37.webm](https://github.com/open-rmf/rmf_site/assets/9111558/8f5b676a-f2c9-4039-b768-b3e73e1bb80d)

### Implementation description

To avoid dependency on physics engines the transforms for door opening / closing are currently done manually.
A `DoorComand` and `DoorState` component have been added, they are mostly the same but while `DoorCommand` is only `Open` or `Close`, `DoorState` has an additional `Moving` variant.
Since doors effectively teleport right now this state is never reached, however all the infrastructure is in place to populate that once a door's transform is detected to be neither fully open nor fully closed.
There are some TODOs in place for better system ordering, had to hack around to avoid off-by-one-frame glitches, however since we will need to pretty much rewrite our whole state / system pipeline when migrating to bevy 0.10+ I didn't put too much effort into creating new stages and setting them up.
Ideally there would be a new `Simulate` stage separate from the others so animation systems don't conflict with other update systems (i.e. a system that opens a door + a system that moves the door because its anchors' positions changed).

I have a feeling the `preview` model should not live in `interaction` anymore and each site module should manage its own preview, but I didn't do the refactor here to avoid making the diff explode with physical camera preview changes.