### PR TITLE
Add open empty site button on launch menu

### DIFF
--- a/assets/empty.site.ron
+++ b/assets/empty.site.ron
@@ -1,0 +1,15 @@
+(
+  format_version: "0.1",
+  properties: (
+    name: "new_site",
+  ),
+  levels: {
+    1: (
+      properties: (
+        name: "<unnamed level>",
+        elevation: 0.0,
+      ),
+      anchors: {},
+    ),
+  },
+)

--- a/rmf_site_editor/src/demo_world.rs
+++ b/rmf_site_editor/src/demo_world.rs
@@ -9,3 +9,9 @@ pub fn demo_workcell() -> Vec<u8> {
         .as_bytes()
         .to_vec();
 }
+
+pub fn empty_site() -> Vec<u8> {
+    return include_str!("../../assets/empty.site.ron")
+        .as_bytes()
+        .to_vec();
+}

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -66,14 +66,18 @@ fn egui_ui(
             ui.add_space(10.);
 
             ui.horizontal(|ui| {
-                if ui.button("View demo map").clicked() {
-                    _load_workspace.send(LoadWorkspace::Data(WorkspaceData::LegacyBuilding(
-                        demo_office(),
-                    )));
+                if ui.button("New site").clicked() {
+                    _load_workspace.send(LoadWorkspace::Data(WorkspaceData::Site(empty_site())));
                 }
 
                 if ui.button("Open a file").clicked() {
                     _load_workspace.send(LoadWorkspace::Dialog);
+                }
+
+                if ui.button("View demo map").clicked() {
+                    _load_workspace.send(LoadWorkspace::Data(WorkspaceData::LegacyBuilding(
+                        demo_office(),
+                    )));
                 }
 
                 // TODO(@mxgrey): Bring this back when we have finished developing


### PR DESCRIPTION
This adds a button that loads an empty site (which I added to the assets).

When debugging, I was finding myself wanting to work from an empty world so, I would load the demo world and then go File > New. Instead, I just added an empty world to be loaded from the menu. This might be nice for people to start new projects from.

Probably the more correct way to do this is to use `CreateNewWorkspace`, which I didn't see how to plumb through.