### PR TITLE
Use stable toolchain for style CI checks

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -20,8 +20,6 @@ jobs:
 
     - name: rustfmt
       run: |
-        rustup toolchain install nightly
-        rustup default nightly
         rustup component add rustfmt
 
     - name: style


### PR DESCRIPTION
## Bug fix

### Fixed bug

Use stable toolchain for style checks. We target `stable` in all the CI checks anyway, `let else` format merged in nightly broke our style CI.