### PR TITLE
Fix panic when updating model sources

### DIFF
--- a/rmf_site_editor/src/aabb.rs
+++ b/rmf_site_editor/src/aabb.rs
@@ -88,7 +88,7 @@ pub fn update_bounds(
     meshes: Res<Assets<Mesh>>,
     mut mesh_reassigned: Query<(Entity, &Handle<Mesh>, &mut Aabb), Changed<Handle<Mesh>>>,
     mut entity_mesh_map: ResMut<EntityMeshMap>,
-    mut mesh_events: EventReader<AssetEvent<Mesh>>,
+    //mut mesh_events: EventReader<AssetEvent<Mesh>>,
     entities_lost_mesh: RemovedComponents<Handle<Mesh>>,
 ) {
     for entity in entities_lost_mesh.iter() {
@@ -105,6 +105,15 @@ pub fn update_bounds(
         }
     }
 
+    // Note (luca) This has been removed since entity despawns are not caught to cleanup the
+    // entity_mesh_map and there is a possibility of panic in case we try to add an aabb to an
+    // entity that has since been despawned (i.e. when updating models' AssetSource and their scene
+    // is despawned).
+    // Tracking issue here with the details https://github.com/open-rmf/rmf_site/issues/145
+    // It seems we don't currently change meshes themselves outside of the model systems that cause
+    // the panic, with the general pattern in the editor being to reassign new handles
+    // so this event is never created anyway
+    /*
     let to_update = |event: &AssetEvent<Mesh>| {
         let handle = match event {
             AssetEvent::Modified { handle } => handle,
@@ -120,6 +129,7 @@ pub fn update_bounds(
             commands.entity(*entity).insert(aabb.clone());
         }
     }
+    */
 }
 
 pub struct AabbUpdatePlugin;


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes #145.

### Fix applied

The fix is sadly to just comment out, with a note explaining why, the code that causes the panic.
It seems the only place where we use the pattern of accessing a mesh by its handle, mutating it, and the event being caught by this system is in the model logic, specifically [here](https://github.com/open-rmf/rmf_site/blob/369766219e0c9e58debe872ec959f5b292db7028/rmf_site_editor/src/site/model.rs#L340-L349). Now this is also the section that causes the panic in the first place since the missing cleanup issue is there. Furthermore in this specific case:

* The aabb doesn't really change because we are only mutating the mesh to add outline normals.
* It's not necessary to propagate to all the meshes that share the same handle, since this is done for each newly spawned mesh anyway.

The workflow that might have worked before but will not after this PR is:

* Create a mesh handle.
* Access the mesh data through its handle.
* Change the mesh in a way that would change its bounding box.
* Bounding box for all the entities that use that mesh handle *was* updated, it won't be anymore.

But again we only use this pattern in the one case that causes a panic so it is too brittle anyway.

An alternative fix could be to avoid using `despawn_recursive` throughout the codebase and sending `Delete` events, together with having the aabb systems track the Delete events to do the cleanup, but this would also be a bit brittle if deletion was to fail for any reason.
Another way could be to despawn in two steps, removing the `Handle<Mesh>` components first, making the `RemovedComponent<Handle<Mesh>>` query behave as expected, but this would be quite clunky.
A proper fix would involve having a way to catch despawn events, but I am not aware of any way to do this.