### PR TITLE
Introducing scenarios concept

### DIFF
--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -226,7 +226,6 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
                     .id();
                 id_to_entity.insert(*location_id, location);
                 consider_id(*location_id);
-
             }
 
             for (robot_id, robot) in &site_data.models.mobile_robots {

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -234,6 +234,7 @@ impl Plugin for SitePlugin {
                     .with_system(update_floor_visibility)
                     .with_system(add_lane_visuals)
                     .with_system(add_location_visuals)
+                    .with_system(add_robot_to_spawn_location)
                     .with_system(update_level_visibility)
                     .with_system(update_changed_lane)
                     .with_system(update_lane_for_moved_anchor)

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -63,6 +63,9 @@ pub use measurement::*;
 pub mod model;
 pub use model::*;
 
+pub mod models;
+pub use models::*;
+
 pub mod nav_graph;
 pub use nav_graph::*;
 
@@ -149,7 +152,7 @@ impl Plugin for SitePlugin {
             .add_event::<ToggleLiftDoorAvailability>()
             .add_event::<ExportLights>()
             .add_event::<ConsiderAssociatedGraph>()
-            .add_event::<ConsiderLocationTag>()
+            .add_plugin(ModelSourcePlugin)
             .add_plugin(ChangePlugin::<AssociatedGraphs<Entity>>::default())
             .add_plugin(RecallPlugin::<RecallAssociatedGraphs<Entity>>::default())
             .add_plugin(ChangePlugin::<Motion>::default())
@@ -234,7 +237,6 @@ impl Plugin for SitePlugin {
                     .with_system(update_floor_visibility)
                     .with_system(add_lane_visuals)
                     .with_system(add_location_visuals)
-                    .with_system(add_robot_to_spawn_location)
                     .with_system(update_level_visibility)
                     .with_system(update_changed_lane)
                     .with_system(update_lane_for_moved_anchor)
@@ -249,7 +251,6 @@ impl Plugin for SitePlugin {
                     .with_system(update_changed_location)
                     .with_system(update_location_for_moved_anchors)
                     .with_system(handle_consider_associated_graph)
-                    .with_system(handle_consider_location_tag)
                     .with_system(update_lift_for_moved_anchors)
                     .with_system(update_lift_door_availability)
                     .with_system(update_physical_lights)

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -260,7 +260,10 @@ pub fn update_model_scenes(
 
 pub fn update_model_tentative_formats(
     mut commands: Commands,
-    changed_models: Query<Entity, (Changed<AssetSource>, With<ModelMarker>)>,
+    changed_models: Query<
+        (Entity, &AssetSource, Option<&ModelScene>),
+        (Changed<AssetSource>, With<ModelMarker>),
+    >,
     mut loading_models: Query<
         (
             Entity,
@@ -272,9 +275,11 @@ pub fn update_model_tentative_formats(
     >,
     asset_server: Res<AssetServer>,
 ) {
-    for e in changed_models.iter() {
+    for (e, source, scene) in changed_models.iter() {
         // Reset to the first format
-        commands.entity(e).insert(TentativeModelFormat::default());
+        if !scene.is_some_and(|r| &r.source == source) {
+            commands.entity(e).insert(TentativeModelFormat::default());
+        }
     }
     // Check from the asset server if any format failed, if it did try the next
     for (e, mut tentative_format, h, source) in loading_models.iter_mut() {

--- a/rmf_site_editor/src/site/models.rs
+++ b/rmf_site_editor/src/site/models.rs
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use rmf_site_format::{AssetSource, Scale};
+use bevy::{
+    prelude::*,
+    ecs::system::{Command, EntityCommands},
+};
+
+#[derive(Component, Clone, Copy)]
+pub struct InScenario(pub Entity);
+
+#[derive(Component, Clone, Copy)]
+pub struct ModelSource(Entity);
+impl ModelSource {
+    pub fn get(&self) -> Entity {
+        self.0
+    }
+}
+
+#[derive(Component, Clone)]
+pub struct ModelInstances(Vec<Entity>);
+impl ModelInstances {
+    pub fn iter(&self) -> impl Iterator<Item=&Entity> {
+        self.0.iter()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ChangeModelSource {
+    instance: Entity,
+    source: Entity,
+}
+
+impl Command for ChangeModelSource {
+    fn write(self, world: &mut World) {
+        let mut previous_source = None;
+        if let Some(mut e) = world.get_entity_mut(self.instance) {
+            if let Some(previous) = e.get::<ModelSource>() {
+                if previous.0 == self.source {
+                    // No need to change anything
+                    return;
+                }
+
+                previous_source = Some(previous.0);
+            }
+            e.insert(ModelSource(self.source));
+        } else {
+            error!(
+                "Cannot change model source of instance {:?} because it no \
+                longer exists",
+                self.instance,
+            );
+            return;
+        }
+
+        if let Some(mut e) = world.get_entity_mut(self.source) {
+            if let Some(mut instances) = e.get_mut::<ModelInstances>() {
+                instances.0.push(self.instance);
+            } else {
+                e.insert(ModelInstances(vec![self.instance]));
+            }
+        } else {
+            error!(
+                "Cannot change model source of instance {:?} to {:?} because \
+                that source no longer exists",
+                self.instance,
+                self.source,
+            );
+
+            if let (Some(mut e), Some(prev)) = (
+                world.get_entity_mut(self.instance),
+                previous_source
+            ) {
+                e.insert(ModelSource(prev));
+            }
+            return;
+        }
+
+        if let Some(previous) = previous_source {
+            if let Some(mut e) = world.get_entity_mut(previous) {
+                if let Some(mut instances) = e.get_mut::<ModelInstances>() {
+                    instances.0.retain(|e| *e != self.instance);
+                }
+            }
+        }
+
+        world.send_event(self);
+    }
+}
+
+pub trait SetModelSourceExt {
+    fn set_model_source(&mut self, new_source: Entity) -> &mut Self;
+}
+
+impl<'w, 's, 'a> SetModelSourceExt for EntityCommands<'w, 's, 'a> {
+    fn set_model_source(&mut self, source: Entity) -> &mut Self {
+        let instance = self.id();
+        self.commands().add(ChangeModelSource { instance, source });
+        self
+    }
+}
+
+fn handle_changed_model_sources(
+    mut commands: Commands,
+    mut changed_instances: EventReader<ChangeModelSource>,
+    sources: Query<(&AssetSource, &Scale)>,
+    changed_sources: Query<
+        (&ModelInstances, &AssetSource, &Scale),
+        Or<(Changed<AssetSource>, Changed<Scale>)>,
+    >,
+) {
+    for change in changed_instances.iter() {
+        let Some(mut instance) = commands.get_entity(change.source) else { continue };
+        let Ok((source, scale)) = sources.get(change.source) else { continue };
+        instance
+            .insert(source.clone())
+            .insert(scale.clone());
+    }
+
+    for (instances, source, scale) in &changed_sources {
+        for instance in instances.iter() {
+            let Some(mut instance) = commands.get_entity(*instance) else { continue };
+            instance
+                .insert(source.clone())
+                .insert(scale.clone());
+        }
+    }
+}
+
+pub struct ModelSourcePlugin;
+impl Plugin for ModelSourcePlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .add_event::<ChangeModelSource>()
+            .add_system(handle_changed_model_sources);
+    }
+}

--- a/rmf_site_editor/src/site/models.rs
+++ b/rmf_site_editor/src/site/models.rs
@@ -15,11 +15,11 @@
  *
 */
 
-use rmf_site_format::{AssetSource, Scale};
 use bevy::{
-    prelude::*,
     ecs::system::{Command, EntityCommands},
+    prelude::*,
 };
+use rmf_site_format::{AssetSource, Scale};
 
 #[derive(Component, Clone, Copy)]
 pub struct InScenario(pub Entity);
@@ -35,7 +35,7 @@ impl ModelSource {
 #[derive(Component, Clone)]
 pub struct ModelInstances(Vec<Entity>);
 impl ModelInstances {
-    pub fn iter(&self) -> impl Iterator<Item=&Entity> {
+    pub fn iter(&self) -> impl Iterator<Item = &Entity> {
         self.0.iter()
     }
 }
@@ -78,14 +78,12 @@ impl Command for ChangeModelSource {
             error!(
                 "Cannot change model source of instance {:?} to {:?} because \
                 that source no longer exists",
-                self.instance,
-                self.source,
+                self.instance, self.source,
             );
 
-            if let (Some(mut e), Some(prev)) = (
-                world.get_entity_mut(self.instance),
-                previous_source
-            ) {
+            if let (Some(mut e), Some(prev)) =
+                (world.get_entity_mut(self.instance), previous_source)
+            {
                 e.insert(ModelSource(prev));
             }
             return;
@@ -127,17 +125,13 @@ fn handle_changed_model_sources(
     for change in changed_instances.iter() {
         let Some(mut instance) = commands.get_entity(change.source) else { continue };
         let Ok((source, scale)) = sources.get(change.source) else { continue };
-        instance
-            .insert(source.clone())
-            .insert(scale.clone());
+        instance.insert(source.clone()).insert(scale.clone());
     }
 
     for (instances, source, scale) in &changed_sources {
         for instance in instances.iter() {
             let Some(mut instance) = commands.get_entity(*instance) else { continue };
-            instance
-                .insert(source.clone())
-                .insert(scale.clone());
+            instance.insert(source.clone()).insert(scale.clone());
         }
     }
 }
@@ -145,8 +139,7 @@ fn handle_changed_model_sources(
 pub struct ModelSourcePlugin;
 impl Plugin for ModelSourcePlugin {
     fn build(&self, app: &mut App) {
-        app
-            .add_event::<ChangeModelSource>()
+        app.add_event::<ChangeModelSource>()
             .add_system(handle_changed_model_sources);
     }
 }

--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -860,24 +860,16 @@ fn generate_scenarios(
 ) -> Result<(BTreeMap<u32, Scenario>, Models), SiteGenerationError> {
     let models = {
         let mut state: SystemState<(
+            Query<(
+                &NameInSite,
+                &AssetSource,
+                &Scale,
+                &MobileRobotKinematics,
+                &SiteID,
+                &Parent,
+            )>,
             Query<
-                (
-                    &NameInSite,
-                    &AssetSource,
-                    &Scale,
-                    &MobileRobotKinematics,
-                    &SiteID,
-                    &Parent,
-                )
-            >,
-            Query<
-                (
-                    &NameInSite,
-                    &AssetSource,
-                    &Scale,
-                    &SiteID,
-                    &Parent,
-                ),
+                (&NameInSite, &AssetSource, &Scale, &SiteID, &Parent),
                 With<StationaryRobotMarker>,
             >,
         )> = SystemState::new(world);
@@ -889,12 +881,15 @@ fn generate_scenarios(
                 continue;
             }
 
-            models.mobile_robots.insert(site_id.0, MobileRobot {
-                model_name: model_name.clone(),
-                source: source.clone(),
-                scale: scale.clone(),
-                kinematics: kinematics.clone(),
-            });
+            models.mobile_robots.insert(
+                site_id.0,
+                MobileRobot {
+                    model_name: model_name.clone(),
+                    source: source.clone(),
+                    scale: scale.clone(),
+                    kinematics: kinematics.clone(),
+                },
+            );
         }
 
         for (model_name, source, scale, site_id, parent) in &q_stationary {
@@ -902,12 +897,15 @@ fn generate_scenarios(
                 continue;
             }
 
-            models.workcells.insert(site_id.0, StationaryRobot {
-                model_name: model_name.clone(),
-                source: source.clone(),
-                scale: scale.clone(),
-                marker: StationaryRobotMarker,
-            });
+            models.workcells.insert(
+                site_id.0,
+                StationaryRobot {
+                    model_name: model_name.clone(),
+                    source: source.clone(),
+                    scale: scale.clone(),
+                    marker: StationaryRobotMarker,
+                },
+            );
         }
 
         models
@@ -915,23 +913,15 @@ fn generate_scenarios(
 
     let scenarios = {
         let mut state: SystemState<(
-            Query<
-                (
-                    &ScenarioProperties,
-                    &SiteID,
-                    &Parent,
-                )
-            >,
-            Query<
-                (
-                    &NameInSite,
-                    &Pose,
-                    &Parent,
-                    &ModelSource,
-                    &InScenario,
-                    &SiteID,
-                )
-            >,
+            Query<(&ScenarioProperties, &SiteID, &Parent)>,
+            Query<(
+                &NameInSite,
+                &Pose,
+                &Parent,
+                &ModelSource,
+                &InScenario,
+                &SiteID,
+            )>,
             Query<&SiteID>,
         )> = SystemState::new(world);
 
@@ -943,10 +933,13 @@ fn generate_scenarios(
                 continue;
             }
 
-            scenarios.insert(site_id.0, Scenario {
-                properties: properties.clone(),
-                instances: BTreeMap::new(),
-            });
+            scenarios.insert(
+                site_id.0,
+                Scenario {
+                    properties: properties.clone(),
+                    instances: BTreeMap::new(),
+                },
+            );
         }
 
         for (name, pose, parent, model, in_scenario, site_id) in &q_instances {
@@ -984,14 +977,17 @@ fn generate_scenarios(
                 );
             }
 
-            scenario.instances.insert(site_id.0, Instance {
-                parent,
-                model,
-                bundle: InstanceBundle {
-                    name: name.clone(),
-                    pose: pose.clone()
+            scenario.instances.insert(
+                site_id.0,
+                Instance {
+                    parent,
+                    model,
+                    bundle: InstanceBundle {
+                        name: name.clone(),
+                        pose: pose.clone(),
+                    },
                 },
-            });
+            );
         }
 
         scenarios

--- a/rmf_site_editor/src/widgets/inspector/inspect_location.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_location.rs
@@ -53,30 +53,28 @@ impl<'a, 'w1, 'w2, 's2> InspectLocationWidget<'a, 'w1, 'w2, 's2> {
 
     pub fn show(self, ui: &mut Ui) -> Option<LocationTags> {
         ui.label(RichText::new("Location Tags").size(18.0));
-        let changed_charger = InspectOptionString::new(
-            "Charger",
-            &self.tags.charger,
-            &self.recall.recall_charger,
-        ).multiline().default("").show(ui);
-        let changed_parking = InspectOptionString::new(
-            "Parking",
-            &self.tags.parking,
-            &self.recall.recall_parking,
-        ).multiline().default("").show(ui);
-        let changed_holding = InspectOptionString::new(
-            "Holding",
-            &self.tags.holding,
-            &self.recall.recall_holding,
-        ).multiline().default("").show(ui);
+        let changed_charger =
+            InspectOptionString::new("Charger", &self.tags.charger, &self.recall.recall_charger)
+                .multiline()
+                .default("")
+                .show(ui);
+        let changed_parking =
+            InspectOptionString::new("Parking", &self.tags.parking, &self.recall.recall_parking)
+                .multiline()
+                .default("")
+                .show(ui);
+        let changed_holding =
+            InspectOptionString::new("Holding", &self.tags.holding, &self.recall.recall_holding)
+                .multiline()
+                .default("")
+                .show(ui);
 
         if changed_charger.is_some() || changed_parking.is_some() || changed_holding.is_some() {
-            return Some(
-                LocationTags {
-                    charger: changed_charger.unwrap_or_else(|| self.tags.charger.clone()),
-                    parking: changed_parking.unwrap_or_else(|| self.tags.parking.clone()),
-                    holding: changed_holding.unwrap_or_else(|| self.tags.holding.clone()),
-                }
-            )
+            return Some(LocationTags {
+                charger: changed_charger.unwrap_or_else(|| self.tags.charger.clone()),
+                parking: changed_parking.unwrap_or_else(|| self.tags.parking.clone()),
+                holding: changed_holding.unwrap_or_else(|| self.tags.holding.clone()),
+            });
         }
 
         return None;

--- a/rmf_site_editor/src/widgets/inspector/inspect_option_string.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_option_string.rs
@@ -21,6 +21,8 @@ pub struct InspectOptionString<'a> {
     title: &'a str,
     value: &'a Option<String>,
     recall: &'a Option<String>,
+    default: &'a str,
+    multiline: bool,
 }
 
 impl<'a> InspectOptionString<'a> {
@@ -29,7 +31,19 @@ impl<'a> InspectOptionString<'a> {
             title,
             value,
             recall,
+            default: "<undefined>",
+            multiline: false,
         }
+    }
+
+    pub fn multiline(mut self) -> Self {
+        self.multiline = true;
+        self
+    }
+
+    pub fn default(mut self, default: &'a str) -> Self {
+        self.default = default;
+        self
     }
 
     pub fn show(self, ui: &mut Ui) -> Option<Option<String>> {
@@ -42,9 +56,13 @@ impl<'a> InspectOptionString<'a> {
                         self.recall
                             .as_ref()
                             .map(|x| x.clone())
-                            .unwrap_or_else(|| "<undefined>".to_string())
+                            .unwrap_or_else(|| self.default.to_owned())
                     });
-                ui.text_edit_singleline(&mut assumed_value);
+                if self.multiline {
+                    ui.text_edit_multiline(&mut assumed_value);
+                } else {
+                    ui.text_edit_singleline(&mut assumed_value);
+                }
 
                 let new_value = Some(assumed_value);
                 if new_value != *self.value {

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -23,9 +23,8 @@ use crate::{
     occupancy::CalculateGrid,
     recency::ChangeRank,
     site::{
-        AssociatedGraphs, Change, ConsiderAssociatedGraph, CurrentLevel,
-        Delete, ExportLights, FloorVisibility, PhysicalLightToggle, SaveNavGraphs, SiteState,
-        ToggleLiftDoorAvailability,
+        AssociatedGraphs, Change, ConsiderAssociatedGraph, CurrentLevel, Delete, ExportLights,
+        FloorVisibility, PhysicalLightToggle, SaveNavGraphs, SiteState, ToggleLiftDoorAvailability,
     },
     AppState, CreateNewWorkspace, CurrentWorkspace, LoadWorkspace, SaveWorkspace,
 };

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     occupancy::CalculateGrid,
     recency::ChangeRank,
     site::{
-        AssociatedGraphs, Change, ConsiderAssociatedGraph, ConsiderLocationTag, CurrentLevel,
+        AssociatedGraphs, Change, ConsiderAssociatedGraph, CurrentLevel,
         Delete, ExportLights, FloorVisibility, PhysicalLightToggle, SaveNavGraphs, SiteState,
         ToggleLiftDoorAvailability,
     },
@@ -160,7 +160,6 @@ pub struct Requests<'w, 's> {
     pub export_lights: EventWriter<'w, 's, ExportLights>,
     pub save_nav_graphs: EventWriter<'w, 's, SaveNavGraphs>,
     pub calculate_grid: EventWriter<'w, 's, CalculateGrid>,
-    pub consider_tag: EventWriter<'w, 's, ConsiderLocationTag>,
     pub consider_graph: EventWriter<'w, 's, ConsiderAssociatedGraph>,
 }
 

--- a/rmf_site_format/src/instance.rs
+++ b/rmf_site_format/src/instance.rs
@@ -17,29 +17,23 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Component, Bundle};
+use bevy::prelude::Bundle;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Instance {
+    /// This may be the entity ID of a level or an anchor.
+    pub parent: u32,
+    /// The entity ID of the model (e.g. MobileRobot, StationaryRobot)
+    /// that this is instantiating.
+    pub model: u32,
+    #[serde(flatten)]
+    pub bundle: InstanceBundle,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]
-pub struct MobileRobot {
-    pub model_name: NameInSite,
-    pub source: AssetSource,
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub scale: Scale,
-    pub kinematics: MobileRobotKinematics,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[cfg_attr(feature = "bevy", derive(Component))]
-pub enum MobileRobotKinematics {
-    DifferentialDrive(DifferentialDrive),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DifferentialDrive {
-    pub translational_speed: f32,
-    pub rotational_speed: f32,
-    pub bidirectional: bool,
+pub struct InstanceBundle {
+    pub name: NameInSite,
+    pub pose: Pose,
 }

--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -2,11 +2,11 @@ use super::{level::Level, lift::Lift, PortingError, Result};
 use crate::{
     legacy::optimization::align_building, Anchor, Angle, AssetSource, AssociatedGraphs,
     DisplayColor, Dock as SiteDock, Drawing as SiteDrawing, DrawingMarker,
-    Fiducial as SiteFiducial, FiducialMarker, Guided, Label, Lane as SiteLane, LaneMarker,
-    Level as SiteLevel, LevelProperties as SiteLevelProperties, Motion, NameInSite, NavGraph,
-    Navigation, OrientationConstraint, PixelsPerMeter, Pose, RankingsInLevel, ReverseLane,
-    Rotation, Site, SiteProperties, DEFAULT_NAV_GRAPH_COLORS, Models, Instance,
-    Scenario, ScenarioProperties,
+    Fiducial as SiteFiducial, FiducialMarker, Guided, Instance, Label, Lane as SiteLane,
+    LaneMarker, Level as SiteLevel, LevelProperties as SiteLevelProperties, Models, Motion,
+    NameInSite, NavGraph, Navigation, OrientationConstraint, PixelsPerMeter, Pose, RankingsInLevel,
+    ReverseLane, Rotation, Scenario, ScenarioProperties, Site, SiteProperties,
+    DEFAULT_NAV_GRAPH_COLORS,
 };
 use glam::{DAffine2, DMat3, DQuat, DVec2, DVec3, EulerRot};
 use serde::{Deserialize, Serialize};
@@ -173,12 +173,9 @@ impl BuildingMap {
                     locations.insert(site_id.next().unwrap(), location);
                 }
 
-                if let Some(instance) = v.make_instance(
-                    &mut site_id,
-                    &mut model_source_map,
-                    &mut models,
-                    anchor_id,
-                ) {
+                if let Some(instance) =
+                    v.make_instance(&mut site_id, &mut model_source_map, &mut models, anchor_id)
+                {
                     let instance_id = site_id.next().unwrap();
                     instances.insert(instance_id, instance);
                 }
@@ -394,9 +391,11 @@ impl BuildingMap {
         scenarios.insert(
             default_scenario_id,
             Scenario {
-                properties: ScenarioProperties { name: "Default Scenario".to_owned() },
+                properties: ScenarioProperties {
+                    name: "Default Scenario".to_owned(),
+                },
                 instances,
-            }
+            },
         );
 
         Ok(Site {

--- a/rmf_site_format/src/legacy/nav_graph.rs
+++ b/rmf_site_format/src/legacy/nav_graph.rs
@@ -172,13 +172,9 @@ impl NavVertexProperties {
             None => return props,
         };
         props.name = location.name.0.clone();
-        props.is_charger = location.tags.iter().find(|t| t.is_charger()).is_some();
-        props.is_holding_point = location
-            .tags
-            .iter()
-            .find(|t| t.is_holding_point())
-            .is_some();
-        props.is_parking_spot = location.tags.iter().find(|t| t.is_parking_spot()).is_some();
+        props.is_charger = location.tags.charger.is_some();
+        props.is_holding_point = location.tags.holding.is_some();
+        props.is_parking_spot = location.tags.parking.is_some();
 
         props
     }

--- a/rmf_site_format/src/legacy/vertex.rs
+++ b/rmf_site_format/src/legacy/vertex.rs
@@ -60,7 +60,7 @@ impl Vertex {
         if !me.spawn_robot_name.is_empty() && !me.spawn_robot_type.is_empty() {
             tags.push(LocationTag::SpawnRobot(Model {
                 name: NameInSite(me.spawn_robot_name.1.clone()),
-                source: AssetSource::Search(me.spawn_robot_type.1.clone()),
+                source: AssetSource::Search("OpenRobotics/".to_string() + &me.spawn_robot_type.1),
                 pose: Pose::default(),
                 is_static: IsStatic(false),
                 constraints: ConstraintDependents::default(),

--- a/rmf_site_format/src/legacy/vertex.rs
+++ b/rmf_site_format/src/legacy/vertex.rs
@@ -1,10 +1,13 @@
 use super::rbmf::*;
 use crate::{
-    is_default, AssetSource, AssociatedGraphs, ConstraintDependents, IsStatic, Location,
-    LocationTag, LocationTags, Model, ModelMarker, NameInSite, Pose, Scale,
+    is_default, AssetSource, AssociatedGraphs, ConstraintDependents, IsStatic,
+    Location, LocationTags, Model, ModelMarker, NameInSite, Pose, Scale,
+    Instance, InstanceBundle, Models, MobileRobot, MobileRobotKinematics,
+    DifferentialDrive,
 };
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct VertexProperties {
@@ -43,30 +46,18 @@ impl Vertex {
     }
 
     pub fn make_location(&self, anchor: u32) -> Option<Location<u32>> {
-        let mut tags = Vec::new();
+        let mut tags = LocationTags::default();
         let me = &self.4;
         if me.is_charger.1 {
-            tags.push(LocationTag::Charger);
+            tags.charger = Some(String::new());
         }
 
         if me.is_parking_spot.1 {
-            tags.push(LocationTag::ParkingSpot);
+            tags.parking = Some(String::new());
         }
 
         if me.is_holding_point.1 {
-            tags.push(LocationTag::HoldingPoint);
-        }
-
-        if !me.spawn_robot_name.is_empty() && !me.spawn_robot_type.is_empty() {
-            tags.push(LocationTag::SpawnRobot(Model {
-                name: NameInSite(me.spawn_robot_name.1.clone()),
-                source: AssetSource::Search("OpenRobotics/".to_string() + &me.spawn_robot_type.1),
-                pose: Pose::default(),
-                is_static: IsStatic(false),
-                constraints: ConstraintDependents::default(),
-                scale: Scale::default(),
-                marker: ModelMarker,
-            }))
+            tags.holding = Some(String::new());
         }
 
         let name = if self.3.is_empty() {
@@ -80,10 +71,61 @@ impl Vertex {
         } else {
             return Some(Location {
                 anchor: anchor.into(),
-                tags: LocationTags(tags),
+                tags,
                 name: NameInSite(name.unwrap_or("<Unnamed>".to_string())),
                 graphs: AssociatedGraphs::All,
             });
         }
+    }
+
+    pub fn make_instance(
+        &self,
+        new_site_id: &mut std::ops::RangeFrom<u32>,
+        model_source_map: &mut HashMap<String, u32>,
+        models: &mut Models,
+        anchor: u32,
+    ) -> Option<Instance> {
+        let me = &self.4;
+        if !me.spawn_robot_name.is_empty() && !me.spawn_robot_type.is_empty() {
+            if let Some(model_id) = model_source_map.get(&me.spawn_robot_type.1) {
+                return Some(Instance {
+                    parent: anchor,
+                    model: *model_id,
+                    bundle: InstanceBundle {
+                        name: NameInSite(me.spawn_robot_name.1.clone()),
+                        pose: Pose::default(),
+                    }
+                });
+            }
+
+            // Create a new model for this asset source that we have not seen
+            // before.
+            let model_id = new_site_id.next().unwrap();
+            let mobile_robot = MobileRobot {
+                model_name: NameInSite(me.spawn_robot_type.1.clone()),
+                source: AssetSource::Search("OpenRobotics/".to_owned() + &me.spawn_robot_type.1.clone()),
+                scale: Scale::default(),
+                kinematics: MobileRobotKinematics::DifferentialDrive(
+                    DifferentialDrive {
+                        translational_speed: 0.5,
+                        rotational_speed: 0.6,
+                        bidirectional: false,
+                    }
+                )
+            };
+
+            models.mobile_robots.insert(model_id, mobile_robot);
+            model_source_map.insert(me.spawn_robot_type.1.clone(), model_id);
+            return Some(Instance {
+                parent: anchor,
+                model: model_id,
+                bundle: InstanceBundle {
+                    name: NameInSite(me.spawn_robot_name.1.clone()),
+                    pose: Pose::default(),
+                }
+            });
+        }
+
+        return None;
     }
 }

--- a/rmf_site_format/src/legacy/vertex.rs
+++ b/rmf_site_format/src/legacy/vertex.rs
@@ -1,9 +1,8 @@
 use super::rbmf::*;
 use crate::{
-    is_default, AssetSource, AssociatedGraphs, ConstraintDependents, IsStatic,
-    Location, LocationTags, Model, ModelMarker, NameInSite, Pose, Scale,
-    Instance, InstanceBundle, Models, MobileRobot, MobileRobotKinematics,
-    DifferentialDrive,
+    is_default, AssetSource, AssociatedGraphs, ConstraintDependents, DifferentialDrive, Instance,
+    InstanceBundle, IsStatic, Location, LocationTags, MobileRobot, MobileRobotKinematics, Model,
+    ModelMarker, Models, NameInSite, Pose, Scale,
 };
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
@@ -94,7 +93,7 @@ impl Vertex {
                     bundle: InstanceBundle {
                         name: NameInSite(me.spawn_robot_name.1.clone()),
                         pose: Pose::default(),
-                    }
+                    },
                 });
             }
 
@@ -103,15 +102,15 @@ impl Vertex {
             let model_id = new_site_id.next().unwrap();
             let mobile_robot = MobileRobot {
                 model_name: NameInSite(me.spawn_robot_type.1.clone()),
-                source: AssetSource::Search("OpenRobotics/".to_owned() + &me.spawn_robot_type.1.clone()),
+                source: AssetSource::Search(
+                    "OpenRobotics/".to_owned() + &me.spawn_robot_type.1.clone(),
+                ),
                 scale: Scale::default(),
-                kinematics: MobileRobotKinematics::DifferentialDrive(
-                    DifferentialDrive {
-                        translational_speed: 0.5,
-                        rotational_speed: 0.6,
-                        bidirectional: false,
-                    }
-                )
+                kinematics: MobileRobotKinematics::DifferentialDrive(DifferentialDrive {
+                    translational_speed: 0.5,
+                    rotational_speed: 0.6,
+                    bidirectional: false,
+                }),
             };
 
             models.mobile_robots.insert(model_id, mobile_robot);
@@ -122,7 +121,7 @@ impl Vertex {
                 bundle: InstanceBundle {
                     name: NameInSite(me.spawn_robot_name.1.clone()),
                     pose: Pose::default(),
-                }
+                },
             });
         }
 

--- a/rmf_site_format/src/lib.rs
+++ b/rmf_site_format/src/lib.rs
@@ -66,6 +66,9 @@ pub use measurement::*;
 pub mod misc;
 pub use misc::*;
 
+pub mod mobile_robot;
+pub use mobile_robot::*;
+
 pub mod model;
 pub use model::*;
 
@@ -86,6 +89,9 @@ pub use point::*;
 
 pub mod recall;
 pub use recall::*;
+
+pub mod scenario;
+pub use scenario::*;
 
 pub mod semver;
 pub use semver::*;

--- a/rmf_site_format/src/lib.rs
+++ b/rmf_site_format/src/lib.rs
@@ -45,6 +45,9 @@ pub use fiducial::*;
 pub mod floor;
 pub use floor::*;
 
+pub mod instance;
+pub use instance::*;
+
 pub mod lane;
 pub use lane::*;
 
@@ -98,6 +101,9 @@ pub use semver::*;
 
 pub mod site;
 pub use site::*;
+
+pub mod stationary_robot;
+pub use stationary_robot::*;
 
 pub mod texture;
 pub use texture::*;

--- a/rmf_site_format/src/location.rs
+++ b/rmf_site_format/src/location.rs
@@ -19,7 +19,7 @@ use crate::*;
 #[cfg(feature = "bevy")]
 use bevy::prelude::{Bundle, Component, Deref, DerefMut, Entity};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]

--- a/rmf_site_format/src/mobile_robot.rs
+++ b/rmf_site_format/src/mobile_robot.rs
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use crate::*;
+#[cfg(feature = "bevy")]
+use bevy::prelude::{Component, Entity};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub struct MobileRobot {
+    pub properties: MobileRobotProperties,
+    pub instances: BTreeMap<u32, MobileRobotInstance>,
+}
+
+pub struct MobileRobotProperties {
+    pub model_name: NameInSite,
+    pub source: AssetSource,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub scale: Scale,
+    pub kinematics: MobileRobotKinematics,
+}
+
+pub enum MobileRobotKinematics {
+    DifferentialDrive(DifferentialDrive),
+}
+
+pub struct DifferentialDrive {
+    pub translational_speed: f32,
+    pub rotational_speed: f32,
+    pub bidirectional: bool,
+}
+
+pub struct MobileRobotInstance<T: RefTrait> {
+    pub name: NameInSite,
+    pub pose: Pose,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anchor: Option<Point<T>>,
+}

--- a/rmf_site_format/src/mobile_robot.rs
+++ b/rmf_site_format/src/mobile_robot.rs
@@ -17,7 +17,7 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Component, Bundle};
+use bevy::prelude::{Bundle, Component};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/rmf_site_format/src/scenario.rs
+++ b/rmf_site_format/src/scenario.rs
@@ -35,14 +35,35 @@ impl Default for ScenarioProperties {
     }
 }
 
-#[derive(Serailize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Scenario {
     /// Basic properties of the scenario
     pub properties: ScenarioProperties,
+    /// Instances of models contained in the scenario
+    pub instances: BTreeMap<u32, Instance>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct Models {
     /// What mobile robots exist in the scenario
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub mobile_robots: BTreeMap<u32, MobileRobot>,
+    /// What workcells exist in the scenario
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub workcells: BTreeMap<u32, StationaryRobot>,
     /// What agents exist in the scenario
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub agents: BTreeMap<u32, Agent>,
+}
+
+impl Models {
+    pub fn is_empty(&self) -> bool {
+        self.mobile_robots.is_empty() && self.workcells.is_empty() && self.agents.is_empty()
+    }
+
+    pub fn contains_key(&self, key: &u32) -> bool {
+        self.mobile_robots.contains_key(key)
+        || self.workcells.contains_key(key)
+        || self.agents.contains_key(key)
+    }
 }

--- a/rmf_site_format/src/scenario.rs
+++ b/rmf_site_format/src/scenario.rs
@@ -63,7 +63,7 @@ impl Models {
 
     pub fn contains_key(&self, key: &u32) -> bool {
         self.mobile_robots.contains_key(key)
-        || self.workcells.contains_key(key)
-        || self.agents.contains_key(key)
+            || self.workcells.contains_key(key)
+            || self.agents.contains_key(key)
     }
 }

--- a/rmf_site_format/src/scenario.rs
+++ b/rmf_site_format/src/scenario.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use crate::*;
+#[cfg(feature = "bevy")]
+use bevy::prelude::{Component, Entity};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "bevy", derive(Component))]
+pub struct ScenarioProperties {
+    pub name: String,
+}
+
+impl Default for ScenarioProperties {
+    fn default() -> Self {
+        Self {
+            name: "new_scenario".to_owned(),
+        }
+    }
+}
+
+#[derive(Serailize, Deserialize, Debug, Clone, Default)]
+pub struct Scenario {
+    /// Basic properties of the scenario
+    pub properties: ScenarioProperties,
+    /// What mobile robots exist in the scenario
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub mobile_robots: BTreeMap<u32, MobileRobot>,
+    /// What agents exist in the scenario
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub agents: BTreeMap<u32, Agent>,
+}

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -57,6 +57,9 @@ pub struct Site {
     /// Data related to navigation
     #[serde(default, skip_serializing_if = "Navigation::is_empty")]
     pub navigation: Navigation,
+    /// Models associated with this site
+    #[serde(default, skip_serializing_if = "Models::is_empty")]
+    pub models: Models,
     /// Scenarios associated with this site
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub scenarios: BTreeMap<u32, Scenario>,

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -32,7 +32,7 @@ pub struct SiteProperties {
 impl Default for SiteProperties {
     fn default() -> Self {
         Self {
-            name: "new_site".to_string(),
+            name: "new_site".to_owned(),
         }
     }
 }
@@ -57,9 +57,9 @@ pub struct Site {
     /// Data related to navigation
     #[serde(default, skip_serializing_if = "Navigation::is_empty")]
     pub navigation: Navigation,
-    /// Properties that describe simulated agents in the site
+    /// Scenarios associated with this site
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub agents: BTreeMap<u32, Agent>,
+    pub scenarios: BTreeMap<u32, Scenario>,
 }
 
 fn default_style_config() -> Style {

--- a/rmf_site_format/src/stationary_robot.rs
+++ b/rmf_site_format/src/stationary_robot.rs
@@ -17,7 +17,7 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Component, Bundle};
+use bevy::prelude::{Bundle, Component};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/rmf_site_format/src/stationary_robot.rs
+++ b/rmf_site_format/src/stationary_robot.rs
@@ -23,23 +23,14 @@ use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]
-pub struct MobileRobot {
+pub struct StationaryRobot {
     pub model_name: NameInSite,
     pub source: AssetSource,
-    #[serde(default, skip_serializing_if = "is_default")]
     pub scale: Scale,
-    pub kinematics: MobileRobotKinematics,
+    #[serde(skip)]
+    pub marker: StationaryRobotMarker,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Component))]
-pub enum MobileRobotKinematics {
-    DifferentialDrive(DifferentialDrive),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DifferentialDrive {
-    pub translational_speed: f32,
-    pub rotational_speed: f32,
-    pub bidirectional: bool,
-}
+pub struct StationaryRobotMarker;


### PR DESCRIPTION
This PR introduces the concept of scenarios and begins moving the implementation of "models" in a new direction:
* A "model" is a blueprint for something that can exist in the world, e.g. mobile robot, workcell, or furnishings
* Each asset that is seen in the world is an "instance" of a model
* Scenarios are defined by what "instances" they contain and how those instances are positioned

This PR leaves the data structures in a limbo where `Model` still exists to refer to furnishings that are laid out around the levels. I left those as-is to minimize how disruptive this PR is. They will also be migrated into the new scenario concept after the existing PRs are merged in and there's less risk of merge conflicts. They will probably be referred to as `Decor` or `Furnishings`.

There is also a flaw in this PR where robots will become invisible when their parent anchor gets hidden. This will be fixed in the future after we migrate to the latest version of Bevy.