### PR TITLE
Add level fiducials to reference drawing features

### DIFF
--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -204,7 +204,7 @@ impl BuildingMap {
             let mut feature_info = HashMap::new();
             let mut primary_drawing_info = None;
             if !level.drawing.filename.is_empty() {
-                let drawing_id = site_id.next().unwrap();
+                let primary_drawing_id = site_id.next().unwrap();
                 let drawing_name = Path::new(&level.drawing.filename)
                     .file_stem()
                     .unwrap_or_default()
@@ -232,7 +232,7 @@ impl BuildingMap {
                     pose.trans[2] as f64,
                     DVec2::new(pose.trans[0] as f64, pose.trans[1] as f64),
                 );
-                primary_drawing_info = Some((drawing_id, drawing_tf));
+                primary_drawing_info = Some((primary_drawing_id, drawing_tf));
 
                 for fiducial in &level.fiducials {
                     let anchor_id = site_id.next().unwrap();
@@ -300,7 +300,7 @@ impl BuildingMap {
                         FeatureInfo {
                             fiducial_id,
                             on_anchor: anchor_id,
-                            in_drawing: drawing_id,
+                            in_drawing: primary_drawing_id,
                             name: (!feature.name.is_empty()).then(|| feature.name.clone()),
                         },
                     );
@@ -327,7 +327,7 @@ impl BuildingMap {
                 }
 
                 drawings.insert(
-                    drawing_id,
+                    primary_drawing_id,
                     SiteDrawing {
                         properties: DrawingProperties {
                             name: NameInSite(drawing_name),
@@ -341,7 +341,7 @@ impl BuildingMap {
                         measurements,
                     },
                 );
-                rankings.drawings.push(drawing_id);
+                rankings.drawings.push(primary_drawing_id);
             }
 
             for (name, layer) in &level.layers {

--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -204,7 +204,8 @@ impl BuildingMap {
             let mut feature_info = HashMap::new();
             let mut primary_drawing_id = None;
             if !level.drawing.filename.is_empty() {
-                primary_drawing_id = Some(site_id.next().unwrap());
+                let drawing_id = site_id.next().unwrap();
+                primary_drawing_id = Some(drawing_id);
                 let drawing_name = Path::new(&level.drawing.filename)
                     .file_stem()
                     .unwrap_or_default()
@@ -299,7 +300,7 @@ impl BuildingMap {
                         FeatureInfo {
                             fiducial_id,
                             on_anchor: anchor_id,
-                            in_drawing: primary_drawing_id.unwrap(),
+                            in_drawing: drawing_id,
                             name: (!feature.name.is_empty()).then(|| feature.name.clone()),
                         },
                     );
@@ -326,7 +327,7 @@ impl BuildingMap {
                 }
 
                 drawings.insert(
-                    primary_drawing_id.unwrap(),
+                    drawing_id,
                     SiteDrawing {
                         properties: DrawingProperties {
                             name: NameInSite(drawing_name),
@@ -340,7 +341,7 @@ impl BuildingMap {
                         measurements,
                     },
                 );
-                rankings.drawings.push(primary_drawing_id.unwrap());
+                rankings.drawings.push(drawing_id);
             }
 
             for (name, layer) in &level.layers {


### PR DESCRIPTION
## Bug fix

### Fixed bug

This PR fixes map alignment when importing legacy projects that include a list of features / constraints but no fiducials, a typical case is a building with only one level (hence no fiducials) but one or more robot maps (hence the sets of constraints and features).

### Fix applied

Previously, no level anchors were spawned so the optimization ran during map alignment would also transform the reference drawing and find an average of all the drawings. With this PR, level anchors are spawned and added to the fiducials in the position where the reference drawing is. The result is that the reference drawing will be "sticky" and stay in its original position with only the imported robot layers being translated.

I had to increase the scope of the reference drawing site id which required wrapping it in an `Option` to handle the "no reference drawing" case. This added a few (safe) boilerplate unwraps.

Before this PR:

[Screencast from 2023-08-17 10-54-01.webm](https://github.com/open-rmf/rmf_site/assets/9111558/1d7ca83b-37bd-4d17-9d07-6bb73df941aa)

After this PR:

[Screencast from 2023-08-17 12-41-16.webm](https://github.com/open-rmf/rmf_site/assets/9111558/c78e6678-ab05-448f-8fb4-1bc19d2706b0)
