### PR TITLE
Texture groups

### DIFF
--- a/rmf_site_editor/src/interaction/select_anchor.rs
+++ b/rmf_site_editor/src/interaction/select_anchor.rs
@@ -386,11 +386,13 @@ impl EdgePlacement {
             Err(r) => (*r).clone(),
         };
         let base = result.create;
-        result.create = Arc::new(move |params: &mut SelectAnchorPlacementParams, edge: Edge<Entity>| {
-            let entity = base(params, edge);
-            f(params, entity);
-            entity
-        });
+        result.create = Arc::new(
+            move |params: &mut SelectAnchorPlacementParams, edge: Edge<Entity>| {
+                let entity = base(params, edge);
+                f(params, entity);
+                entity
+            },
+        );
         Arc::new(result)
     }
 
@@ -838,11 +840,13 @@ impl PathPlacement {
             Err(r) => (*r).clone(),
         };
         let base = result.create;
-        result.create = Arc::new(move |params: &mut SelectAnchorPlacementParams, path: Path<Entity>| {
-            let entity = base(params, path);
-            f(params, entity);
-            entity
-        });
+        result.create = Arc::new(
+            move |params: &mut SelectAnchorPlacementParams, path: Path<Entity>| {
+                let entity = base(params, path);
+                f(params, entity);
+                entity
+            },
+        );
         Arc::new(result)
     }
 
@@ -1222,10 +1226,14 @@ impl SelectAnchorEdgeBuilder {
     pub fn for_wall(self) -> SelectAnchor {
         SelectAnchor {
             target: self.for_element,
-            placement: EdgePlacement::new::<Wall<Entity>>(self.placement)
-                .with_extra(|params, entity| {
-                    params.commands.entity(entity).insert(TextureNeedsAssignment);
-                }),
+            placement: EdgePlacement::new::<Wall<Entity>>(self.placement).with_extra(
+                |params, entity| {
+                    params
+                        .commands
+                        .entity(entity)
+                        .insert(TextureNeedsAssignment);
+                },
+            ),
             continuity: self.continuity,
             scope: Scope::General,
         }
@@ -1341,10 +1349,14 @@ impl SelectAnchorPathBuilder {
     pub fn for_floor(self) -> SelectAnchor {
         SelectAnchor {
             target: self.for_element,
-            placement: PathPlacement::new::<Floor<Entity>>(self.placement)
-                .with_extra(|params, entity| {
-                    params.commands.entity(entity).insert(TextureNeedsAssignment);
-                }),
+            placement: PathPlacement::new::<Floor<Entity>>(self.placement).with_extra(
+                |params, entity| {
+                    params
+                        .commands
+                        .entity(entity)
+                        .insert(TextureNeedsAssignment);
+                },
+            ),
             continuity: self.continuity,
             scope: Scope::General,
         }

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(error_generic_member_access, provide_any)]
+
 use bevy::{
     log::LogPlugin, pbr::DirectionalLightShadowMap, prelude::*, render::renderer::RenderAdapterInfo,
 };

--- a/rmf_site_editor/src/log.rs
+++ b/rmf_site_editor/src/log.rs
@@ -141,7 +141,7 @@ impl Default for LogHistory {
         {
             let fmt_layer = tracing_subscriber::fmt::Layer::default();
             let subscriber = subscriber.with(fmt_layer);
-            tracing::subscriber::set_global_default(subscriber);
+            tracing::subscriber::set_global_default(subscriber).ok();
         }
         #[cfg(target_arch = "wasm32")]
         {

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -308,29 +308,17 @@ pub fn update_floors_for_moved_anchors(
 }
 
 pub fn update_floors(
-    floors: Query<
-        (&FloorSegments, &Path<Entity>, &Affiliation<Entity>),
-        With<FloorMarker>,
-    >,
+    floors: Query<(&FloorSegments, &Path<Entity>, &Affiliation<Entity>), With<FloorMarker>>,
     changed_floors: Query<
         Entity,
         (
             With<FloorMarker>,
-            Or<(
-                Changed<Affiliation<Entity>>,
-                Changed<Path<Entity>>,
-            )>,
-        )
+            Or<(Changed<Affiliation<Entity>>, Changed<Path<Entity>>)>,
+        ),
     >,
     changed_texture_sources: Query<
         &Members,
-        (
-            With<Group>,
-            Or<(
-                Changed<Handle<Image>>,
-                Changed<Texture>,
-            )>,
-        )
+        (With<Group>, Or<(Changed<Handle<Image>>, Changed<Texture>)>),
     >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -339,13 +327,11 @@ pub fn update_floors(
     anchors: AnchorParams,
     textures: Query<(Option<&Handle<Image>>, &Texture)>,
 ) {
-    for e in changed_floors.iter()
-        .chain(
-            changed_texture_sources
+    for e in changed_floors.iter().chain(
+        changed_texture_sources
             .iter()
-            .flat_map(|members| members.iter().cloned())
-        )
-    {
+            .flat_map(|members| members.iter().cloned()),
+    ) {
         let Ok((segment, path, texture_source)) = floors.get(e) else { continue };
         let (base_color_texture, texture) = from_texture_source(texture_source, &textures);
         if let Ok(mut mesh) = mesh_handles.get_mut(segment.mesh) {

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -211,7 +211,7 @@ pub fn add_floor_visuals(
         (
             Entity,
             &Path<Entity>,
-            &Texture,
+            &Affiliation<Entity>,
             Option<&RecencyRank<FloorMarker>>,
             Option<&LayerVisibility>,
             Option<&Parent>,
@@ -219,14 +219,16 @@ pub fn add_floor_visuals(
         Added<FloorMarker>,
     >,
     anchors: AnchorParams,
+    textures: Query<(Option<&Handle<Image>>, &Texture)>,
     mut dependents: Query<&mut Dependents, With<Anchor>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     default_floor_vis: Query<(&GlobalFloorVisibility, &RecencyRanking<DrawingMarker>)>,
-    asset_server: Res<AssetServer>,
 ) {
-    for (e, new_floor, texture, rank, vis, parent) in &floors {
-        let mesh = make_floor_mesh(e, new_floor, texture, &anchors);
+    for (e, new_floor, texture_source, rank, vis, parent) in &floors {
+        let (base_color_texture, texture) = from_texture_source(texture_source, &textures);
+
+        let mesh = make_floor_mesh(e, new_floor, &texture, &anchors);
         let mut cmd = commands.entity(e);
         let height = floor_height(rank);
         let default_vis = parent
@@ -234,7 +236,7 @@ pub fn add_floor_visuals(
             .flatten();
         let (base_color, alpha_mode) = floor_transparency(vis, default_vis);
         let material = materials.add(StandardMaterial {
-            base_color_texture: Some(asset_server.load(&String::from(&texture.source))),
+            base_color_texture,
             base_color,
             alpha_mode,
             ..default()
@@ -268,24 +270,10 @@ pub fn add_floor_visuals(
     }
 }
 
-pub fn update_changed_floor(
-    changed_path: Query<
-        (Entity, &FloorSegments, &Path<Entity>, &Texture),
-        (Changed<Path<Entity>>, With<FloorMarker>),
-    >,
+pub fn update_changed_floor_ranks(
     changed_rank: Query<(Entity, &RecencyRank<FloorMarker>), Changed<RecencyRank<FloorMarker>>>,
-    anchors: AnchorParams,
-    mut mesh_assets: ResMut<Assets<Mesh>>,
     mut transforms: Query<&mut Transform>,
-    mut mesh_handles: Query<&mut Handle<Mesh>>,
 ) {
-    for (e, segments, path, texture) in &changed_path {
-        if let Ok(mut mesh) = mesh_handles.get_mut(segments.mesh) {
-            *mesh = mesh_assets.add(make_floor_mesh(e, path, texture, &anchors));
-        }
-        // TODO(MXG): Update texture once we support textures
-    }
-
     for (e, rank) in &changed_rank {
         if let Ok(mut tf) = transforms.get_mut(e) {
             tf.translation.z = floor_height(Some(rank));
@@ -293,9 +281,10 @@ pub fn update_changed_floor(
     }
 }
 
-pub fn update_floor_for_moved_anchors(
-    floors: Query<(Entity, &FloorSegments, &Path<Entity>, &Texture), With<FloorMarker>>,
+pub fn update_floors_for_moved_anchors(
+    floors: Query<(Entity, &FloorSegments, &Path<Entity>, &Affiliation<Entity>), With<FloorMarker>>,
     anchors: AnchorParams,
+    textures: Query<(Option<&Handle<Image>>, &Texture)>,
     changed_anchors: Query<
         &Dependents,
         (
@@ -308,34 +297,62 @@ pub fn update_floor_for_moved_anchors(
 ) {
     for dependents in &changed_anchors {
         for dependent in dependents.iter() {
-            if let Some((e, segments, path, texture)) = floors.get(*dependent).ok() {
+            if let Some((e, segments, path, texture_source)) = floors.get(*dependent).ok() {
+                let (_, texture) = from_texture_source(texture_source, &textures);
                 if let Ok(mut mesh) = mesh_handles.get_mut(segments.mesh) {
-                    *mesh = mesh_assets.add(make_floor_mesh(e, path, texture, &anchors));
+                    *mesh = mesh_assets.add(make_floor_mesh(e, path, &texture, &anchors));
                 }
             }
         }
     }
 }
 
-pub fn update_floor_for_changed_texture(
+pub fn update_floors(
+    floors: Query<
+        (&FloorSegments, &Path<Entity>, &Affiliation<Entity>),
+        With<FloorMarker>,
+    >,
     changed_floors: Query<
-        (Entity, &FloorSegments, &Path<Entity>, &Texture),
-        (Changed<Texture>, With<FloorMarker>),
+        Entity,
+        (
+            With<FloorMarker>,
+            Or<(
+                Changed<Affiliation<Entity>>,
+                Changed<Path<Entity>>,
+            )>,
+        )
+    >,
+    changed_texture_sources: Query<
+        &Members,
+        (
+            With<Group>,
+            Or<(
+                Changed<Handle<Image>>,
+                Changed<Texture>,
+            )>,
+        )
     >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut mesh_handles: Query<&mut Handle<Mesh>>,
     material_handles: Query<&Handle<StandardMaterial>>,
     anchors: AnchorParams,
-    asset_server: Res<AssetServer>,
+    textures: Query<(Option<&Handle<Image>>, &Texture)>,
 ) {
-    for (e, segment, path, texture) in &changed_floors {
+    for e in changed_floors.iter()
+        .chain(
+            changed_texture_sources
+            .iter()
+            .flat_map(|members| members.iter().cloned())
+        )
+    {
+        let Ok((segment, path, texture_source)) = floors.get(e) else { continue };
+        let (base_color_texture, texture) = from_texture_source(texture_source, &textures);
         if let Ok(mut mesh) = mesh_handles.get_mut(segment.mesh) {
             if let Ok(material) = material_handles.get(segment.mesh) {
-                *mesh = meshes.add(make_floor_mesh(e, path, texture, &anchors));
+                *mesh = meshes.add(make_floor_mesh(e, path, &texture, &anchors));
                 if let Some(mut material) = materials.get_mut(material) {
-                    material.base_color_texture =
-                        Some(asset_server.load(&String::from(&texture.source)));
+                    material.base_color_texture = base_color_texture;
                 }
             }
         }

--- a/rmf_site_editor/src/site/group.rs
+++ b/rmf_site_editor/src/site/group.rs
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use rmf_site_format::{Affiliation, Group};
+use bevy::{
+    ecs::system::{Command, EntityCommands},
+    prelude::*,
+};
+
+#[derive(Component, Deref)]
+pub struct Members(Vec<Entity>);
+
+#[derive(Component, Clone, Copy)]
+struct LastAffiliation(Option<Entity>);
+
+pub fn update_members_of_groups(
+    mut commands: Commands,
+    mut changed_affiliation: Query<(Entity, &Affiliation<Entity>), Changed<Affiliation<Entity>>>,
+) {
+    for (e, affiliation) in &mut changed_affiliation {
+        commands.entity(e).set_membership(affiliation.0);
+    }
+}
+
+struct ChangeMembership {
+    member: Entity,
+    group: Option<Entity>,
+}
+
+impl Command for ChangeMembership {
+    fn write(self, world: &mut World) {
+        let last = world.get_entity(self.member)
+            .map(|e| e.get::<LastAffiliation>()).flatten().cloned();
+        if let Some(last) = last {
+            if last.0 == self.group {
+                // There is no effect from this change
+                return;
+            }
+
+            if let Some(last) = last.0 {
+                if let Some(mut e) = world.get_entity_mut(last) {
+                    if let Some(mut members) = e.get_mut::<Members>() {
+                        members.0.retain(|m| *m != self.member);
+                    }
+                }
+            }
+        }
+
+        if let Some(new_group) = self.group {
+            if let Some(mut e) = world.get_entity_mut(new_group) {
+                if let Some(mut members) = e.get_mut::<Members>() {
+                    members.0.push(self.member);
+                } else {
+                    e.insert(Members(vec![self.member]));
+                }
+            }
+        }
+
+        if let Some(mut e) = world.get_entity_mut(self.member) {
+            e.insert(LastAffiliation(self.group));
+        }
+    }
+}
+
+pub trait SetMembershipExt {
+    fn set_membership(&mut self, group: Option<Entity>) -> &mut Self;
+}
+
+impl<'w, 's, 'a> SetMembershipExt for EntityCommands<'w, 's, 'a> {
+    fn set_membership(&mut self, group: Option<Entity>) -> &mut Self {
+        let member = self.id();
+        self.commands().add(ChangeMembership { member, group });
+        self
+    }
+}

--- a/rmf_site_editor/src/site/group.rs
+++ b/rmf_site_editor/src/site/group.rs
@@ -15,11 +15,11 @@
  *
 */
 
-use rmf_site_format::{Affiliation, Group};
 use bevy::{
     ecs::system::{Command, EntityCommands},
     prelude::*,
 };
+use rmf_site_format::{Affiliation, Group};
 
 #[derive(Component, Deref)]
 pub struct Members(Vec<Entity>);
@@ -43,8 +43,11 @@ struct ChangeMembership {
 
 impl Command for ChangeMembership {
     fn write(self, world: &mut World) {
-        let last = world.get_entity(self.member)
-            .map(|e| e.get::<LastAffiliation>()).flatten().cloned();
+        let last = world
+            .get_entity(self.member)
+            .map(|e| e.get::<LastAffiliation>())
+            .flatten()
+            .cloned();
         if let Some(last) = last {
             if last.0 == self.group {
                 // There is no effect from this change

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -94,6 +94,12 @@ fn generate_site_entities(commands: &mut Commands, site_data: &rmf_site_format::
                 consider_id(*group_id);
             }
 
+            for (group_id, group) in &site_data.textures {
+                let group_entity = site.spawn(group.clone()).insert(SiteID(*group_id)).id();
+                id_to_entity.insert(*group_id, group_entity);
+                consider_id(*group_id);
+            }
+
             for (level_id, level_data) in &site_data.levels {
                 let mut level_cmd = site.spawn(SiteID(*level_id));
 
@@ -326,7 +332,8 @@ pub fn load_site(
                 commands.entity(err.site).despawn_recursive();
                 error!(
                     "Failed to load the site entities because the file had an \
-                    internal inconsistency: {err:#?}",
+                    internal inconsistency:\n{err:#?}\n---\nSite Data:\n{:#?}",
+                    &cmd.site,
                 );
                 continue;
             }

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -222,6 +222,14 @@ impl Plugin for SitePlugin {
                     .with_system(update_drawing_pixels_per_meter)
                     .with_system(update_drawing_children_to_pixel_coordinates)
                     .with_system(fetch_image_for_texture)
+                    .with_system(detect_last_selected_texture::<FloorMarker>)
+                    .with_system(apply_last_selected_texture::<FloorMarker>
+                        .after(detect_last_selected_texture::<FloorMarker>)
+                    )
+                    .with_system(detect_last_selected_texture::<WallMarker>)
+                    .with_system(apply_last_selected_texture::<WallMarker>
+                        .after(detect_last_selected_texture::<WallMarker>)
+                    )
                     .with_system(update_material_for_display_color),
             )
             .add_system_set(

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -48,6 +48,9 @@ pub use fiducial::*;
 pub mod floor;
 pub use floor::*;
 
+pub mod group;
+pub use group::*;
+
 pub mod lane;
 pub use lane::*;
 
@@ -98,6 +101,9 @@ pub use site::*;
 
 pub mod site_visualizer;
 pub use site_visualizer::*;
+
+pub mod texture;
+pub use texture::*;
 
 pub mod util;
 pub use util::*;
@@ -215,6 +221,7 @@ impl Plugin for SitePlugin {
                     .with_system(update_model_tentative_formats)
                     .with_system(update_drawing_pixels_per_meter)
                     .with_system(update_drawing_children_to_pixel_coordinates)
+                    .with_system(fetch_image_for_texture)
                     .with_system(update_material_for_display_color),
             )
             .add_system_set(
@@ -253,9 +260,9 @@ impl Plugin for SitePlugin {
                     .with_system(update_changed_door)
                     .with_system(update_door_for_moved_anchors)
                     .with_system(add_floor_visuals)
-                    .with_system(update_changed_floor)
-                    .with_system(update_floor_for_moved_anchors)
-                    .with_system(update_floor_for_changed_texture)
+                    .with_system(update_floors)
+                    .with_system(update_floors_for_moved_anchors)
+                    .with_system(update_floors)
                     .with_system(update_floor_visibility)
                     .with_system(update_drawing_visibility)
                     .with_system(add_lane_visuals)
@@ -292,6 +299,7 @@ impl Plugin for SitePlugin {
                     .with_system(update_constraint_for_changed_labels)
                     .with_system(update_changed_constraint)
                     .with_system(update_model_scenes)
+                    .with_system(update_members_of_groups)
                     .with_system(handle_new_sdf_roots)
                     .with_system(update_model_scales)
                     .with_system(make_models_selectable)
@@ -301,9 +309,8 @@ impl Plugin for SitePlugin {
                     .with_system(update_drawing_rank)
                     .with_system(add_physical_camera_visuals)
                     .with_system(add_wall_visual)
-                    .with_system(update_wall_edge)
-                    .with_system(update_wall_for_moved_anchors)
-                    .with_system(update_wall_for_changed_texture)
+                    .with_system(update_walls_for_moved_anchors)
+                    .with_system(update_walls)
                     .with_system(update_transforms_for_changed_poses)
                     .with_system(align_site_drawings)
                     .with_system(export_lights),

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -223,12 +223,14 @@ impl Plugin for SitePlugin {
                     .with_system(update_drawing_children_to_pixel_coordinates)
                     .with_system(fetch_image_for_texture)
                     .with_system(detect_last_selected_texture::<FloorMarker>)
-                    .with_system(apply_last_selected_texture::<FloorMarker>
-                        .after(detect_last_selected_texture::<FloorMarker>)
+                    .with_system(
+                        apply_last_selected_texture::<FloorMarker>
+                            .after(detect_last_selected_texture::<FloorMarker>),
                     )
                     .with_system(detect_last_selected_texture::<WallMarker>)
-                    .with_system(apply_last_selected_texture::<WallMarker>
-                        .after(detect_last_selected_texture::<WallMarker>)
+                    .with_system(
+                        apply_last_selected_texture::<WallMarker>
+                            .after(detect_last_selected_texture::<WallMarker>),
                     )
                     .with_system(update_material_for_display_color),
             )

--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -111,7 +111,12 @@ fn assign_site_ids(world: &mut World, site: Entity) -> Result<(), SiteGeneration
         Query<
             Entity,
             (
-                Or<(With<Anchor>, With<FiducialMarker>, With<MeasurementMarker>)>,
+                Or<(
+                    With<Anchor>,
+                    With<FiducialMarker>,
+                    With<MeasurementMarker>,
+                    With<Group>,
+                )>,
                 Without<Pending>,
             ),
         >,
@@ -285,7 +290,7 @@ fn generate_levels(
             (
                 &Path<Entity>,
                 Option<&Original<Path<Entity>>>,
-                &Texture,
+                &Affiliation<Entity>,
                 &PreferredSemiTransparency,
                 &SiteID,
                 &Parent,
@@ -330,7 +335,7 @@ fn generate_levels(
             (
                 &Edge<Entity>,
                 Option<&Original<Edge<Entity>>>,
-                &Texture,
+                &Affiliation<Entity>,
                 &SiteID,
                 &Parent,
             ),
@@ -525,11 +530,17 @@ fn generate_levels(
         if let Ok((_, _, _, _, level_id, _, _, _)) = q_levels.get(parent.get()) {
             if let Some(level) = levels.get_mut(&level_id.0) {
                 let anchors = get_anchor_id_path(&path)?;
+                let texture = if let Affiliation(Some(e)) = texture {
+                    Affiliation(Some(get_group_id(*e)?))
+                } else {
+                    Affiliation(None)
+                };
+
                 level.floors.insert(
                     id.0,
                     Floor {
                         anchors,
-                        texture: texture.clone(),
+                        texture,
                         preferred_semi_transparency: preferred_alpha.clone(),
                         marker: FloorMarker,
                     },
@@ -592,11 +603,17 @@ fn generate_levels(
         if let Ok((_, _, _, _, level_id, _, _, _)) = q_levels.get(parent.get()) {
             if let Some(level) = levels.get_mut(&level_id.0) {
                 let anchors = get_anchor_id_edge(edge)?;
+                let texture = if let Affiliation(Some(e)) = texture {
+                    Affiliation(Some(get_group_id(*e)?))
+                } else {
+                    Affiliation(None)
+                };
+
                 level.walls.insert(
                     id.0,
                     Wall {
                         anchors,
-                        texture: texture.clone(),
+                        texture,
                         marker: WallMarker,
                     },
                 );
@@ -866,6 +883,34 @@ fn generate_fiducial_groups(
     Ok(fiducial_groups)
 }
 
+fn generate_texture_groups(
+    world: &mut World,
+    parent: Entity,
+) -> Result<BTreeMap<u32, TextureGroup>, SiteGenerationError> {
+    let mut state: SystemState<(
+        Query<(&NameInSite, &Texture, &SiteID), With<Group>>,
+        Query<&Children>,
+    )> = SystemState::new(world);
+
+    let (q_groups, q_children) = state.get(world);
+
+    let Ok(children) = q_children.get(parent) else {
+        return Ok(BTreeMap::new());
+    };
+
+    let mut texture_groups = BTreeMap::new();
+    for child in children {
+        let Ok((name, texture, site_id)) = q_groups.get(*child) else { continue };
+        texture_groups.insert(site_id.0, TextureGroup {
+            name: name.clone(),
+            texture: texture.clone(),
+            group: Default::default(),
+        });
+    }
+
+    Ok(texture_groups)
+}
+
 fn generate_nav_graphs(
     world: &mut World,
     site: Entity,
@@ -1054,6 +1099,7 @@ pub fn generate_site(
     let lifts = generate_lifts(world, site)?;
     let fiducials = generate_fiducials(world, site)?;
     let fiducial_groups = generate_fiducial_groups(world, site)?;
+    let textures = generate_texture_groups(world, site)?;
     let nav_graphs = generate_nav_graphs(world, site)?;
     let lanes = generate_lanes(world, site)?;
     let locations = generate_locations(world, site)?;
@@ -1075,6 +1121,7 @@ pub fn generate_site(
         lifts,
         fiducials,
         fiducial_groups,
+        textures,
         navigation: Navigation {
             guided: Guided {
                 graphs: nav_graphs,

--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -901,11 +901,14 @@ fn generate_texture_groups(
     let mut texture_groups = BTreeMap::new();
     for child in children {
         let Ok((name, texture, site_id)) = q_groups.get(*child) else { continue };
-        texture_groups.insert(site_id.0, TextureGroup {
-            name: name.clone(),
-            texture: texture.clone(),
-            group: Default::default(),
-        });
+        texture_groups.insert(
+            site_id.0,
+            TextureGroup {
+                name: name.clone(),
+                texture: texture.clone(),
+                group: Default::default(),
+            },
+        );
     }
 
     Ok(texture_groups)

--- a/rmf_site_editor/src/site/texture.rs
+++ b/rmf_site_editor/src/site/texture.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use rmf_site_format::{Texture, Affiliation};
+use bevy::prelude::*;
+
+pub fn fetch_image_for_texture(
+    mut commands: Commands,
+    mut changed_textures: Query<(Entity, Option<&mut Handle<Image>>, &Texture), Changed<Texture>>,
+    asset_server: Res<AssetServer>,
+) {
+    for (e, mut image, texture) in &mut changed_textures {
+        if let Some(mut image) = image {
+            *image = asset_server.load(String::from(&texture.source));
+        } else {
+            let image: Handle<Image> = asset_server.load(String::from(&texture.source));
+            commands.entity(e).insert(image);
+        }
+    }
+}
+
+// Helper function for entities that need to access their affiliated texture
+// information.
+pub fn from_texture_source(
+    texture_source: &Affiliation<Entity>,
+    textures: &Query<(Option<&Handle<Image>>, &Texture)>,
+) -> (Option<Handle<Image>>, Texture) {
+    texture_source.0
+    .map(|t| textures.get(t).ok())
+    .flatten()
+    .map(|(i, t)| (i.cloned(), t.clone()))
+    .unwrap_or_else(|| (None, Texture::default()))
+}

--- a/rmf_site_editor/src/site/texture.rs
+++ b/rmf_site_editor/src/site/texture.rs
@@ -15,8 +15,8 @@
  *
 */
 
-use rmf_site_format::{Texture, Affiliation, FloorMarker, WallMarker, Group};
 use bevy::prelude::*;
+use rmf_site_format::{Affiliation, FloorMarker, Group, Texture, WallMarker};
 
 #[derive(Component)]
 pub struct TextureNeedsAssignment;
@@ -40,9 +40,7 @@ pub fn detect_last_selected_texture<T: Component>(
     mut commands: Commands,
     parents: Query<&Parent>,
     mut last_selected: Query<&mut LastSelectedTexture<T>>,
-    changed_affiliations: Query<
-        &Affiliation<Entity>, (Changed<Affiliation<Entity>>, With<T>)
-    >,
+    changed_affiliations: Query<&Affiliation<Entity>, (Changed<Affiliation<Entity>>, With<T>)>,
     removed_groups: RemovedComponents<Group>,
 ) {
     if let Some(Affiliation(Some(affiliation))) = changed_affiliations.iter().last() {
@@ -70,7 +68,10 @@ pub fn apply_last_selected_texture<T: Component>(
     mut commands: Commands,
     parents: Query<&Parent>,
     last_selected: Query<&LastSelectedTexture<T>>,
-    mut unassigned: Query<(Entity, &mut Affiliation<Entity>), (With<TextureNeedsAssignment>, With<T>)>,
+    mut unassigned: Query<
+        (Entity, &mut Affiliation<Entity>),
+        (With<TextureNeedsAssignment>, With<T>),
+    >,
 ) {
     for (e, mut affiliation) in &mut unassigned {
         let mut search = e;
@@ -93,7 +94,7 @@ pub fn apply_last_selected_texture<T: Component>(
 }
 
 #[derive(Component)]
-pub struct LastSelectedTexture<T>{
+pub struct LastSelectedTexture<T> {
     selection: Option<Entity>,
     marker: std::marker::PhantomData<T>,
 }
@@ -104,9 +105,10 @@ pub fn from_texture_source(
     texture_source: &Affiliation<Entity>,
     textures: &Query<(Option<&Handle<Image>>, &Texture)>,
 ) -> (Option<Handle<Image>>, Texture) {
-    texture_source.0
-    .map(|t| textures.get(t).ok())
-    .flatten()
-    .map(|(i, t)| (i.cloned(), t.clone()))
-    .unwrap_or_else(|| (None, Texture::default()))
+    texture_source
+        .0
+        .map(|t| textures.get(t).ok())
+        .flatten()
+        .map(|(i, t)| (i.cloned(), t.clone()))
+        .unwrap_or_else(|| (None, Texture::default()))
 }

--- a/rmf_site_editor/src/site/wall.rs
+++ b/rmf_site_editor/src/site/wall.rs
@@ -96,7 +96,15 @@ pub fn add_wall_visual(
 }
 
 pub fn update_walls_for_moved_anchors(
-    mut walls: Query<(Entity, &Edge<Entity>, &Affiliation<Entity>, &mut Handle<Mesh>), With<WallMarker>>,
+    mut walls: Query<
+        (
+            Entity,
+            &Edge<Entity>,
+            &Affiliation<Entity>,
+            &mut Handle<Mesh>,
+        ),
+        With<WallMarker>,
+    >,
     anchors: AnchorParams,
     textures: Query<(Option<&Handle<Image>>, &Texture)>,
     changed_anchors: Query<
@@ -132,34 +140,23 @@ pub fn update_walls(
         Entity,
         (
             With<WallMarker>,
-            Or<(
-                Changed<Affiliation<Entity>>,
-                Changed<Edge<Entity>>,
-            )>,
+            Or<(Changed<Affiliation<Entity>>, Changed<Edge<Entity>>)>,
         ),
     >,
     changed_texture_sources: Query<
         &Members,
-        (
-            With<Group>,
-            Or<(
-                Changed<Handle<Image>>,
-                Changed<Texture>,
-            )>,
-        )
+        (With<Group>, Or<(Changed<Handle<Image>>, Changed<Texture>)>),
     >,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     anchors: AnchorParams,
     textures: Query<(Option<&Handle<Image>>, &Texture)>,
 ) {
-    for e in changed_walls.iter()
-        .chain(
-            changed_texture_sources
+    for e in changed_walls.iter().chain(
+        changed_texture_sources
             .iter()
-            .flat_map(|members| members.iter().cloned())
-        )
-    {
+            .flat_map(|members| members.iter().cloned()),
+    ) {
         let Ok((edge, texture_source, mut mesh, material)) = walls.get_mut(e) else { continue };
         let (base_color_texture, texture) = from_texture_source(texture_source, &textures);
         *mesh = meshes.add(make_wall(e, edge, &texture, &anchors));

--- a/rmf_site_editor/src/widgets/console.rs
+++ b/rmf_site_editor/src/widgets/console.rs
@@ -15,12 +15,8 @@
  *
 */
 
-use crate::{log::*, site::*, widgets::AppEvents};
-use bevy::{ecs::system::SystemParam, prelude::*};
-use bevy_egui::{
-    egui::{self, CollapsingHeader, Color32, FontId, RichText, Ui},
-    EguiContext,
-};
+use crate::{log::*, widgets::AppEvents};
+use bevy_egui::egui::{self, CollapsingHeader, Color32, RichText, Ui};
 
 pub struct ConsoleWidget<'a, 'w2, 's2> {
     events: &'a mut AppEvents<'w2, 's2>,

--- a/rmf_site_editor/src/widgets/console.rs
+++ b/rmf_site_editor/src/widgets/console.rs
@@ -158,12 +158,10 @@ fn print_log(ui: &mut egui::Ui, element: &LogHistoryElement) {
         }
 
         if truncated {
-            ui
-                .label(" [...]")
-                .on_hover_text(
-                    "Some of the message is hidden. Click on it to copy the \
-                    full text to your clipboard."
-                );
+            ui.label(" [...]").on_hover_text(
+                "Some of the message is hidden. Click on it to copy the \
+                    full text to your clipboard.",
+            );
         }
     });
 }

--- a/rmf_site_editor/src/widgets/console.rs
+++ b/rmf_site_editor/src/widgets/console.rs
@@ -135,13 +135,35 @@ fn print_log(ui: &mut egui::Ui, element: &LogHistoryElement) {
             LogCategory::Error => Color32::RED,
             LogCategory::Bevy => Color32::LIGHT_BLUE,
         };
+
+        let mut truncated = false;
+        let msg = if element.log.message.len() > 80 {
+            truncated = true;
+            &element.log.message[..80]
+        } else {
+            &element.log.message
+        };
+
+        let msg = if let Some(nl) = msg.find("\n") {
+            truncated = true;
+            &msg[..nl]
+        } else {
+            msg
+        };
+
         ui.label(RichText::new(element.log.category.to_string()).color(category_text_color));
         // Selecting the label allows users to copy log entry to clipboard
-        if ui
-            .selectable_label(false, element.log.message.to_string())
-            .clicked()
-        {
+        if ui.selectable_label(false, msg).clicked() {
             ui.output().copied_text = element.log.category.to_string() + &element.log.message;
+        }
+
+        if truncated {
+            ui
+                .label(" [...]")
+                .on_hover_text(
+                    "Some of the message is hidden. Click on it to copy the \
+                    full text to your clipboard."
+                );
         }
     });
 }

--- a/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
@@ -25,7 +25,7 @@ use bevy_egui::egui::{ComboBox, ImageButton, Ui};
 #[derive(Resource, Default)]
 pub struct SearchForFiducial(pub String);
 
-enum SearchResult {
+pub(crate) enum SearchResult {
     Empty,
     Current,
     NoMatch,
@@ -34,7 +34,7 @@ enum SearchResult {
 }
 
 impl SearchResult {
-    fn consider(&mut self, entity: Entity) {
+    pub(crate) fn consider(&mut self, entity: Entity) {
         match self {
             Self::NoMatch => {
                 *self = SearchResult::Match(entity);
@@ -46,7 +46,7 @@ impl SearchResult {
         }
     }
 
-    fn conflict(&mut self, text: &'static str) {
+    pub(crate) fn conflict(&mut self, text: &'static str) {
         match self {
             // If we already found a match then don't change the behavior
             Self::Match(_) | Self::Current | Self::Conflict(_) | Self::Empty => {}
@@ -109,7 +109,7 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectFiducialWidget<'a, 'w1, 'w2, 's1, 's2> {
             let mut result = SearchResult::NoMatch;
             let mut any_partial_matches = false;
 
-            if *search == "" {
+            if search.is_empty() {
                 // An empty string should not be used
                 result = SearchResult::Empty;
             }
@@ -231,14 +231,11 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectFiducialWidget<'a, 'w1, 'w2, 's1, 's2> {
         let mut new_affiliation = affiliation.clone();
         ui.horizontal(|ui| {
             if ui
-                .add(ImageButton::new(self.params.icons.trash.egui(), [18., 18.]))
-                .on_hover_text("Remove this fiducial from its group")
+                .add(ImageButton::new(self.params.icons.exit.egui(), [18., 18.]))
+                .on_hover_text("Remove this fiducial from its current group")
                 .clicked()
             {
-                self.events
-                    .change_more
-                    .affiliation
-                    .send(Change::new(Affiliation(None), self.entity));
+                new_affiliation = Affiliation(None);
             }
             ComboBox::from_id_source("fiducial_affiliation")
                 .selected_text(selected_text)

--- a/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
@@ -16,19 +16,16 @@
 */
 
 use crate::{
-    site::{DefaultFile, Change, Category},
     inspector::{InspectAssetSource, InspectValue, SearchResult},
+    site::{Category, Change, DefaultFile},
     widgets::egui::RichText,
-    WorkspaceMarker, Icons, AppEvents,
+    AppEvents, Icons, WorkspaceMarker,
 };
-use bevy::{
-    prelude::*,
-    ecs::system::SystemParam,
-};
-use bevy_egui::egui::{Grid, Ui, ImageButton, ComboBox};
+use bevy::{ecs::system::SystemParam, prelude::*};
+use bevy_egui::egui::{ComboBox, Grid, ImageButton, Ui};
 use rmf_site_format::{
-    RecallAssetSource, Texture, NameInSite, Group, Affiliation, FloorMarker,
-    WallMarker, TextureGroup,
+    Affiliation, FloorMarker, Group, NameInSite, RecallAssetSource, Texture, TextureGroup,
+    WallMarker,
 };
 
 #[derive(Resource, Default)]
@@ -62,7 +59,12 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
         params: &'a InspectTextureAffiliationParams<'w1, 's1>,
         events: &'a mut AppEvents<'w2, 's2>,
     ) -> Self {
-        Self { entity, default_file, params, events }
+        Self {
+            entity,
+            default_file,
+            params,
+            events,
+        }
     }
 
     pub fn show(self, ui: &mut Ui) {
@@ -111,10 +113,11 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
         ui.label("Texture");
         ui.horizontal(|ui| {
             if any_partial_matches {
-                if ui.add(ImageButton::new(
-                    self.params.icons.search.egui(),
-                    [18., 18.],
-                ))
+                if ui
+                    .add(ImageButton::new(
+                        self.params.icons.search.egui(),
+                        [18., 18.],
+                    ))
                     .on_hover_text("Search results for this text can be found below")
                     .clicked()
                 {
@@ -127,10 +130,11 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
 
             match result {
                 SearchResult::Empty => {
-                    if ui.add(ImageButton::new(
-                        self.params.icons.hidden.egui(),
-                        [18., 18.],
-                    ))
+                    if ui
+                        .add(ImageButton::new(
+                            self.params.icons.hidden.egui(),
+                            [18., 18.],
+                        ))
                         .on_hover_text("An empty string is not a good texture name")
                         .clicked()
                     {
@@ -138,10 +142,11 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
                     }
                 }
                 SearchResult::Current => {
-                    if ui.add(ImageButton::new(
-                        self.params.icons.selected.egui(),
-                        [18., 18.],
-                    ))
+                    if ui
+                        .add(ImageButton::new(
+                            self.params.icons.selected.egui(),
+                            [18., 18.],
+                        ))
                         .on_hover_text("This is the name of the currently selected texture")
                         .clicked()
                     {
@@ -149,22 +154,20 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
                     }
                 }
                 SearchResult::NoMatch => {
-                    if ui.add(ImageButton::new(
-                        self.params.icons.add.egui(),
-                        [18., 18.],
-                    ))
-                        .on_hover_text(
-                            if affiliation.0.is_some() {
-                                "Create a new copy of the current texture"
-                            } else {
-                                "Create a new texture"
-                            }
-                        )
+                    if ui
+                        .add(ImageButton::new(self.params.icons.add.egui(), [18., 18.]))
+                        .on_hover_text(if affiliation.0.is_some() {
+                            "Create a new copy of the current texture"
+                        } else {
+                            "Create a new texture"
+                        })
                         .clicked()
                     {
-                        let new_texture = if let Some((_, t)) = affiliation.0.map(
-                            |a| self.params.texture_groups.get(a).ok()
-                        ).flatten() {
+                        let new_texture = if let Some((_, t)) = affiliation
+                            .0
+                            .map(|a| self.params.texture_groups.get(a).ok())
+                            .flatten()
+                        {
                             t.clone()
                         } else {
                             Texture::default()
@@ -180,17 +183,18 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
                             })
                             .set_parent(site)
                             .id();
-                        self.events
-                            .change_more
-                            .affiliation
-                            .send(Change::new(Affiliation(Some(new_texture_group)), self.entity));
+                        self.events.change_more.affiliation.send(Change::new(
+                            Affiliation(Some(new_texture_group)),
+                            self.entity,
+                        ));
                     }
                 }
                 SearchResult::Match(group) => {
-                    if ui.add(ImageButton::new(
-                        self.params.icons.confirm.egui(),
-                        [18., 18.],
-                    ))
+                    if ui
+                        .add(ImageButton::new(
+                            self.params.icons.confirm.egui(),
+                            [18., 18.],
+                        ))
                         .on_hover_text("Select this texture")
                         .clicked()
                     {
@@ -201,10 +205,11 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
                     }
                 }
                 SearchResult::Conflict(text) => {
-                    if ui.add(ImageButton::new(
-                        self.params.icons.reject.egui(),
-                        [18., 18.],
-                    ))
+                    if ui
+                        .add(ImageButton::new(
+                            self.params.icons.reject.egui(),
+                            [18., 18.],
+                        ))
                         .on_hover_text(text)
                         .clicked()
                     {
@@ -218,16 +223,20 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
         });
 
         let (current_texture_name, current_texture) = if let Some(a) = affiliation.0 {
-            self.params.texture_groups.get(a).ok().map(
-                |(n, t)| (n.0.as_str(), Some((a, t)))
-            )
+            self.params
+                .texture_groups
+                .get(a)
+                .ok()
+                .map(|(n, t)| (n.0.as_str(), Some((a, t))))
         } else {
             None
-        }.unwrap_or(("<none>", None));
+        }
+        .unwrap_or(("<none>", None));
 
         let mut new_affiliation = affiliation.clone();
         ui.horizontal(|ui| {
-            if ui.add(ImageButton::new(self.params.icons.exit.egui(), [18., 18.]))
+            if ui
+                .add(ImageButton::new(self.params.icons.exit.egui(), [18., 18.]))
                 .on_hover_text(format!("Remove this texture from the {}", category.label()))
                 .clicked()
             {
@@ -262,9 +271,7 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
         if let Some((group, texture)) = current_texture {
             ui.add_space(5.0);
             ui.label(RichText::new(format!("Properties of [{current_texture_name}]")).size(18.0));
-            if let Some(new_texture) = InspectTexture::new(
-                texture, self.default_file
-            ).show(ui) {
+            if let Some(new_texture) = InspectTexture::new(texture, self.default_file).show(ui) {
                 self.events
                     .change_more
                     .texture
@@ -281,23 +288,23 @@ pub struct InspectTexture<'a> {
 }
 
 impl<'a> InspectTexture<'a> {
-    pub fn new(
-        texture: &'a Texture,
-        default_file: Option<&'a DefaultFile>,
-    ) -> Self {
-        Self { texture, default_file }
+    pub fn new(texture: &'a Texture, default_file: Option<&'a DefaultFile>) -> Self {
+        Self {
+            texture,
+            default_file,
+        }
     }
 
     pub fn show(self, ui: &mut Ui) -> Option<Texture> {
         let mut new_texture = self.texture.clone();
 
         // TODO(luca) recall
-        if let Some(new_source) =
-            InspectAssetSource::new(
-                &new_texture.source,
-                &RecallAssetSource::default(),
-                self.default_file,
-            ).show(ui)
+        if let Some(new_source) = InspectAssetSource::new(
+            &new_texture.source,
+            &RecallAssetSource::default(),
+            self.default_file,
+        )
+        .show(ui)
         {
             new_texture.source = new_source;
         }

--- a/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
@@ -16,33 +16,41 @@
 */
 
 use crate::{
-    site::DefaultFile,
-    AppEvents,
-    inspector::{InspectAssetSource, InspectValue},
+    site::{DefaultFile, Change, Category},
+    inspector::{InspectAssetSource, InspectValue, SearchResult},
     widgets::egui::RichText,
-    WorkspaceMarker,
+    WorkspaceMarker, Icons, AppEvents,
 };
-use bevy::prelude::*;
-use bevy_egui::egui::{Grid, Ui};
+use bevy::{
+    prelude::*,
+    ecs::system::SystemParam,
+};
+use bevy_egui::egui::{Grid, Ui, ImageButton, ComboBox};
 use rmf_site_format::{
     RecallAssetSource, Texture, NameInSite, Group, Affiliation, FloorMarker,
-    WallMarker,
+    WallMarker, TextureGroup,
 };
 
+#[derive(Resource, Default)]
+pub struct SearchForTexture(pub String);
+
+#[derive(SystemParam)]
 pub struct InspectTextureAffiliationParams<'w, 's> {
     with_texture: Query<
         'w,
         's,
-        &'static Affiliation<Entity>,
+        (&'static Category, &'static Affiliation<Entity>),
         Or<(With<FloorMarker>, With<WallMarker>)>,
     >,
     texture_groups: Query<'w, 's, (&'static NameInSite, &'static Texture), With<Group>>,
     parents: Query<'w, 's, &'static Parent>,
     sites: Query<'w, 's, &'static Children, With<WorkspaceMarker>>,
+    icons: Res<'w, Icons>,
 }
 
 pub struct InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
     entity: Entity,
+    default_file: Option<&'a DefaultFile>,
     params: &'a InspectTextureAffiliationParams<'w1, 's1>,
     events: &'a mut AppEvents<'w2, 's2>,
 }
@@ -50,14 +58,15 @@ pub struct InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
 impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
     pub fn new(
         entity: Entity,
+        default_file: Option<&'a DefaultFile>,
         params: &'a InspectTextureAffiliationParams<'w1, 's1>,
         events: &'a mut AppEvents<'w2, 's2>,
     ) -> Self {
-        Self { entity, params, events }
+        Self { entity, default_file, params, events }
     }
 
     pub fn show(self, ui: &mut Ui) {
-        let Ok(affiliation) = self.params.with_texture.get(self.entity) else { return };
+        let Ok((category, affiliation)) = self.params.with_texture.get(self.entity) else { return };
         let mut site = self.entity;
         let children = loop {
             if let Ok(children) = self.params.sites.get(site) {
@@ -70,11 +79,199 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
                 return;
             }
         };
+        let site = site;
+
+        let search = &mut self.events.change_more.search_for_texture.0;
+
+        let mut any_partial_matches = false;
+        let mut result = SearchResult::NoMatch;
+        for child in children {
+            let Ok((name, _)) = self.params.texture_groups.get(*child) else { continue };
+            if name.0.contains(&*search) {
+                any_partial_matches = true;
+            }
+
+            if name.0 == *search {
+                result.consider(*child);
+            }
+        }
+        let any_partial_matches = any_partial_matches;
+
+        if search.is_empty() {
+            result = SearchResult::Empty;
+        }
+
+        if let (SearchResult::Match(e), Some(current)) = (&result, &affiliation.0) {
+            if *e == *current {
+                result = SearchResult::Current;
+            }
+        }
 
         ui.separator();
         ui.label("Texture");
+        ui.horizontal(|ui| {
+            if any_partial_matches {
+                if ui.add(ImageButton::new(
+                    self.params.icons.search.egui(),
+                    [18., 18.],
+                ))
+                    .on_hover_text("Search results for this text can be found below")
+                    .clicked()
+                {
+                    info!("Use the drop-down box to choose a texture");
+                }
+            } else {
+                ui.add(ImageButton::new(self.params.icons.empty.egui(), [18., 18.]))
+                    .on_hover_text("No search results can be found for this text");
+            }
 
+            match result {
+                SearchResult::Empty => {
+                    if ui.add(ImageButton::new(
+                        self.params.icons.hidden.egui(),
+                        [18., 18.],
+                    ))
+                        .on_hover_text("An empty string is not a good texture name")
+                        .clicked()
+                    {
+                        warn!("You should not use an empty string as a texture name");
+                    }
+                }
+                SearchResult::Current => {
+                    if ui.add(ImageButton::new(
+                        self.params.icons.selected.egui(),
+                        [18., 18.],
+                    ))
+                        .on_hover_text("This is the name of the currently selected texture")
+                        .clicked()
+                    {
+                        info!("This texture is already selected");
+                    }
+                }
+                SearchResult::NoMatch => {
+                    if ui.add(ImageButton::new(
+                        self.params.icons.add.egui(),
+                        [18., 18.],
+                    ))
+                        .on_hover_text(
+                            if affiliation.0.is_some() {
+                                "Create a new copy of the current texture"
+                            } else {
+                                "Create a new texture"
+                            }
+                        )
+                        .clicked()
+                    {
+                        let new_texture = if let Some((_, t)) = affiliation.0.map(
+                            |a| self.params.texture_groups.get(a).ok()
+                        ).flatten() {
+                            t.clone()
+                        } else {
+                            Texture::default()
+                        };
 
+                        let new_texture_group = self
+                            .events
+                            .commands
+                            .spawn(TextureGroup {
+                                name: NameInSite(search.clone()),
+                                texture: new_texture,
+                                group: default(),
+                            })
+                            .set_parent(site)
+                            .id();
+                        self.events
+                            .change_more
+                            .affiliation
+                            .send(Change::new(Affiliation(Some(new_texture_group)), self.entity));
+                    }
+                }
+                SearchResult::Match(group) => {
+                    if ui.add(ImageButton::new(
+                        self.params.icons.confirm.egui(),
+                        [18., 18.],
+                    ))
+                        .on_hover_text("Select this texture")
+                        .clicked()
+                    {
+                        self.events
+                            .change_more
+                            .affiliation
+                            .send(Change::new(Affiliation(Some(group)), self.entity));
+                    }
+                }
+                SearchResult::Conflict(text) => {
+                    if ui.add(ImageButton::new(
+                        self.params.icons.reject.egui(),
+                        [18., 18.],
+                    ))
+                        .on_hover_text(text)
+                        .clicked()
+                    {
+                        warn!("Cannot set {search} as the texture: {text}");
+                    }
+                }
+            }
+
+            ui.text_edit_singleline(search)
+                .on_hover_text("Search for or create a new texture");
+        });
+
+        let (current_texture_name, current_texture) = if let Some(a) = affiliation.0 {
+            self.params.texture_groups.get(a).ok().map(
+                |(n, t)| (n.0.as_str(), Some((a, t)))
+            )
+        } else {
+            None
+        }.unwrap_or(("<none>", None));
+
+        let mut new_affiliation = affiliation.clone();
+        ui.horizontal(|ui| {
+            if ui.add(ImageButton::new(self.params.icons.exit.egui(), [18., 18.]))
+                .on_hover_text(format!("Remove this texture from the {}", category.label()))
+                .clicked()
+            {
+                new_affiliation = Affiliation(None);
+            }
+
+            ComboBox::from_id_source("texture_affiliation")
+                .selected_text(current_texture_name)
+                .show_ui(ui, |ui| {
+                    for child in children {
+                        if affiliation.0.is_some_and(|a| a == *child) {
+                            continue;
+                        }
+
+                        if let Ok((n, _)) = self.params.texture_groups.get(*child) {
+                            if n.0.contains(&*search) {
+                                let select_affiliation = Affiliation(Some(*child));
+                                ui.selectable_value(&mut new_affiliation, select_affiliation, &n.0);
+                            }
+                        }
+                    }
+                });
+        });
+
+        if new_affiliation != *affiliation {
+            self.events
+                .change_more
+                .affiliation
+                .send(Change::new(new_affiliation, self.entity));
+        }
+
+        if let Some((group, texture)) = current_texture {
+            ui.add_space(5.0);
+            ui.label(RichText::new(format!("Properties of [{current_texture_name}]")).size(18.0));
+            if let Some(new_texture) = InspectTexture::new(
+                texture, self.default_file
+            ).show(ui) {
+                self.events
+                    .change_more
+                    .texture
+                    .send(Change::new(new_texture, group))
+            }
+        }
+        ui.add_space(10.0);
     }
 }
 
@@ -94,7 +291,6 @@ impl<'a> InspectTexture<'a> {
     pub fn show(self, ui: &mut Ui) -> Option<Texture> {
         let mut new_texture = self.texture.clone();
 
-        ui.label(RichText::new("Texture Properties").size(18.0));
         // TODO(luca) recall
         if let Some(new_source) =
             InspectAssetSource::new(
@@ -110,7 +306,7 @@ impl<'a> InspectTexture<'a> {
             if let Some(width) = new_texture.width {
                 if let Some(new_width) = InspectValue::<f32>::new(String::from("Width"), width)
                     .clamp_range(0.001..=std::f32::MAX)
-                    .speed(0.1)
+                    .speed(0.01)
                     .tooltip("Texture width in meters".to_string())
                     .show(ui)
                 {
@@ -121,7 +317,7 @@ impl<'a> InspectTexture<'a> {
             if let Some(height) = new_texture.height {
                 if let Some(new_height) = InspectValue::<f32>::new(String::from("Height"), height)
                     .clamp_range(0.001..=std::f32::MAX)
-                    .speed(0.1)
+                    .speed(0.01)
                     .tooltip("Texture height in meters".to_string())
                     .show(ui)
                 {
@@ -142,11 +338,7 @@ impl<'a> InspectTexture<'a> {
             }
         });
 
-        if new_texture.width != self.texture.width
-            || new_texture.height != self.texture.height
-            || new_texture.alpha != self.texture.alpha
-            || new_texture.source != self.texture.source
-        {
+        if new_texture != *self.texture {
             Some(new_texture)
         } else {
             None

--- a/rmf_site_editor/src/widgets/inspector/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/mod.rs
@@ -406,7 +406,8 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectorWidget<'a, 'w1, 'w2, 's1, 's2> {
                 default_file,
                 &self.params.texture,
                 self.events,
-            ).show(ui);
+            )
+            .show(ui);
 
             if let Ok(texture) = self.params.textures.get(selection) {
                 ui.label(RichText::new("Texture Properties").size(18.0));

--- a/rmf_site_editor/src/widgets/inspector/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/mod.rs
@@ -122,6 +122,7 @@ pub struct InspectorParams<'w, 's> {
     pub scales: Query<'w, 's, &'static Scale>,
     pub textures: Query<'w, 's, &'static Texture>,
     pub layer: InspectorLayerParams<'w, 's>,
+    pub texture: InspectTextureAffiliationParams<'w, 's>,
     pub default_file: Query<'w, 's, &'static DefaultFile>,
 }
 
@@ -400,7 +401,15 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectorWidget<'a, 'w1, 'w2, 's1, 's2> {
                 }
             }
 
+            InspectTextureAffiliation::new(
+                selection,
+                default_file,
+                &self.params.texture,
+                self.events,
+            ).show(ui);
+
             if let Ok(texture) = self.params.textures.get(selection) {
+                ui.label(RichText::new("Texture Properties").size(18.0));
                 if let Some(new_texture) = InspectTexture::new(texture, default_file).show(ui) {
                     self.events
                         .change_more

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -49,6 +49,10 @@ pub fn top_menu_bar(
                     {
                         file_events.save.send(SaveWorkspace::new().to_dialog());
                     }
+                    ui.menu_button("Text expansion", |ui| {
+                        ui.label("Oh look");
+                        ui.label("It worked");
+                    });
                 }
                 if ui
                     .add(Button::new("Open").shortcut_text("Ctrl+O"))

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -66,9 +66,7 @@ pub mod icons;
 pub use icons::*;
 
 pub mod inspector;
-use inspector::{
-    InspectorParams, InspectorWidget, SearchForFiducial, SearchForTexture,
-};
+use inspector::{InspectorParams, InspectorWidget, SearchForFiducial, SearchForTexture};
 
 pub mod move_layer;
 pub use move_layer::*;

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -66,7 +66,9 @@ pub mod icons;
 pub use icons::*;
 
 pub mod inspector;
-use inspector::{InspectorParams, InspectorWidget, SearchForFiducial};
+use inspector::{
+    InspectorParams, InspectorWidget, SearchForFiducial, SearchForTexture,
+};
 
 pub mod move_layer;
 pub use move_layer::*;
@@ -102,6 +104,7 @@ impl Plugin for StandardUiLayout {
             .init_resource::<PendingDrawing>()
             .init_resource::<PendingModel>()
             .init_resource::<SearchForFiducial>()
+            .init_resource::<SearchForTexture>()
             .add_system_set(SystemSet::on_enter(AppState::MainMenu).with_system(init_ui_style))
             .add_system_set(
                 SystemSet::on_update(AppState::SiteEditor)
@@ -154,6 +157,7 @@ pub struct ChangeEvents<'w, 's> {
 pub struct MoreChangeEvents<'w, 's> {
     pub affiliation: EventWriter<'w, 's, Change<Affiliation<Entity>>>,
     pub search_for_fiducial: ResMut<'w, SearchForFiducial>,
+    pub search_for_texture: ResMut<'w, SearchForTexture>,
     pub distance: EventWriter<'w, 's, Change<Distance>>,
     pub texture: EventWriter<'w, 's, Change<Texture>>,
 }

--- a/rmf_site_format/src/constraint.rs
+++ b/rmf_site_format/src/constraint.rs
@@ -35,10 +35,7 @@ pub struct Constraint<T: RefTrait> {
 pub struct ConstraintMarker;
 
 impl<T: RefTrait> Constraint<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Constraint<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Constraint<U>, T> {
         Ok(Constraint {
             edge: self.edge.convert(id_map)?,
             marker: Default::default(),

--- a/rmf_site_format/src/constraint.rs
+++ b/rmf_site_format/src/constraint.rs
@@ -17,8 +17,9 @@
 
 use crate::{Edge, RefTrait};
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Bundle, Component, Entity};
+use bevy::prelude::{Bundle, Component};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]
@@ -33,16 +34,15 @@ pub struct Constraint<T: RefTrait> {
 #[cfg_attr(feature = "bevy", derive(Component))]
 pub struct ConstraintMarker;
 
-#[cfg(feature = "bevy")]
-impl Constraint<u32> {
-    pub fn to_ecs(
+impl<T: RefTrait> Constraint<T> {
+    pub fn convert<U: RefTrait>(
         &self,
-        id_to_entity: &std::collections::HashMap<u32, Entity>,
-    ) -> Constraint<Entity> {
-        Constraint {
-            edge: self.edge.to_ecs(id_to_entity),
+        id_map: &HashMap<T, U>,
+    ) -> Result<Constraint<U>, T> {
+        Ok(Constraint {
+            edge: self.edge.convert(id_map)?,
             marker: Default::default(),
-        }
+        })
     }
 }
 

--- a/rmf_site_format/src/door.rs
+++ b/rmf_site_format/src/door.rs
@@ -19,6 +19,7 @@ use crate::*;
 #[cfg(feature = "bevy")]
 use bevy::prelude::{Bundle, Component, Entity};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub const DEFAULT_DOOR_THICKNESS: f32 = 0.05;
 
@@ -384,15 +385,14 @@ impl Door<Entity> {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl Door<u32> {
-    pub fn to_ecs(&self, id_to_entity: &std::collections::HashMap<u32, Entity>) -> Door<Entity> {
-        Door {
-            anchors: self.anchors.to_ecs(id_to_entity),
+impl<T: RefTrait> Door<T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Door<U>, T> {
+        Ok(Door {
+            anchors: self.anchors.convert(id_map)?,
             name: self.name.clone(),
             kind: self.kind.clone(),
             marker: Default::default(),
-        }
+        })
     }
 }
 

--- a/rmf_site_format/src/edge.rs
+++ b/rmf_site_format/src/edge.rs
@@ -17,8 +17,9 @@
 
 use crate::{RefTrait, Side};
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Component, Entity};
+use bevy::prelude::Component;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(transparent)]
@@ -106,12 +107,14 @@ impl<T: RefTrait> From<[T; 2]> for Edge<T> {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl Edge<u32> {
-    pub fn to_ecs(&self, id_to_entity: &std::collections::HashMap<u32, Entity>) -> Edge<Entity> {
-        Edge([
-            *id_to_entity.get(&self.left()).unwrap(),
-            *id_to_entity.get(&self.right()).unwrap(),
-        ])
+impl<T: RefTrait> Edge<T> {
+    pub fn convert<U: RefTrait>(
+        &self,
+        id_map: &HashMap<T, U>,
+    ) -> Result<Edge<U>, T> {
+        Ok(Edge([
+            id_map.get(&self.left()).ok_or(self.left())?.clone(),
+            id_map.get(&self.right()).ok_or(self.right())?.clone(),
+        ]))
     }
 }

--- a/rmf_site_format/src/edge.rs
+++ b/rmf_site_format/src/edge.rs
@@ -108,10 +108,7 @@ impl<T: RefTrait> From<[T; 2]> for Edge<T> {
 }
 
 impl<T: RefTrait> Edge<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Edge<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Edge<U>, T> {
         Ok(Edge([
             id_map.get(&self.left()).ok_or(self.left())?.clone(),
             id_map.get(&self.right()).ok_or(self.right())?.clone(),

--- a/rmf_site_format/src/fiducial.rs
+++ b/rmf_site_format/src/fiducial.rs
@@ -61,10 +61,7 @@ impl FiducialGroup {
 pub struct FiducialMarker;
 
 impl<T: RefTrait> Fiducial<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Fiducial<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Fiducial<U>, T> {
         Ok(Fiducial {
             anchor: self.anchor.convert(id_map)?,
             affiliation: self.affiliation.convert(id_map)?,

--- a/rmf_site_format/src/fiducial.rs
+++ b/rmf_site_format/src/fiducial.rs
@@ -19,6 +19,7 @@ use crate::{Affiliation, Group, NameInSite, Point, RefTrait};
 #[cfg(feature = "bevy")]
 use bevy::prelude::{Bundle, Component, Entity};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Mark a point within a drawing or level to serve as a ground truth relative
 /// to other drawings and levels.
@@ -59,17 +60,16 @@ impl FiducialGroup {
 #[cfg_attr(feature = "bevy", derive(Component))]
 pub struct FiducialMarker;
 
-#[cfg(feature = "bevy")]
-impl Fiducial<u32> {
-    pub fn to_ecs(
+impl<T: RefTrait> Fiducial<T> {
+    pub fn convert<U: RefTrait>(
         &self,
-        id_to_entity: &std::collections::HashMap<u32, Entity>,
-    ) -> Fiducial<Entity> {
-        Fiducial {
-            anchor: self.anchor.to_ecs(id_to_entity),
-            affiliation: self.affiliation.to_ecs(id_to_entity),
+        id_map: &HashMap<T, U>,
+    ) -> Result<Fiducial<U>, T> {
+        Ok(Fiducial {
+            anchor: self.anchor.convert(id_map)?,
+            affiliation: self.affiliation.convert(id_map)?,
             marker: Default::default(),
-        }
+        })
     }
 }
 

--- a/rmf_site_format/src/floor.rs
+++ b/rmf_site_format/src/floor.rs
@@ -41,10 +41,7 @@ pub struct Floor<T: RefTrait> {
 pub struct FloorMarker;
 
 impl<T: RefTrait> Floor<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Floor<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Floor<U>, T> {
         Ok(Floor {
             anchors: self.anchors.convert(id_map)?,
             texture: self.texture.convert(id_map)?,

--- a/rmf_site_format/src/floor.rs
+++ b/rmf_site_format/src/floor.rs
@@ -17,15 +17,16 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Bundle, Component, Entity};
+use bevy::prelude::{Bundle, Component};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]
 pub struct Floor<T: RefTrait> {
     pub anchors: Path<T>,
     #[serde(default, skip_serializing_if = "is_default")]
-    pub texture: Texture,
+    pub texture: Affiliation<T>,
     #[serde(
         default = "PreferredSemiTransparency::for_floor",
         skip_serializing_if = "PreferredSemiTransparency::is_default_for_floor"
@@ -39,27 +40,17 @@ pub struct Floor<T: RefTrait> {
 #[cfg_attr(feature = "bevy", derive(Component))]
 pub struct FloorMarker;
 
-#[cfg(feature = "bevy")]
-impl Floor<Entity> {
-    pub fn to_u32(&self, anchors: Path<u32>) -> Floor<u32> {
-        Floor {
-            anchors,
-            texture: self.texture.clone(),
+impl<T: RefTrait> Floor<T> {
+    pub fn convert<U: RefTrait>(
+        &self,
+        id_map: &HashMap<T, U>,
+    ) -> Result<Floor<U>, T> {
+        Ok(Floor {
+            anchors: self.anchors.convert(id_map)?,
+            texture: self.texture.convert(id_map)?,
             preferred_semi_transparency: PreferredSemiTransparency::for_floor(),
             marker: Default::default(),
-        }
-    }
-}
-
-#[cfg(feature = "bevy")]
-impl Floor<u32> {
-    pub fn to_ecs(&self, id_to_entity: &std::collections::HashMap<u32, Entity>) -> Floor<Entity> {
-        Floor {
-            anchors: self.anchors.to_ecs(id_to_entity),
-            texture: self.texture.clone(),
-            preferred_semi_transparency: PreferredSemiTransparency::for_floor(),
-            marker: Default::default(),
-        }
+        })
     }
 }
 
@@ -67,12 +58,7 @@ impl<T: RefTrait> From<Path<T>> for Floor<T> {
     fn from(path: Path<T>) -> Self {
         Floor {
             anchors: path,
-            texture: Texture {
-                source: AssetSource::Remote(
-                    "OpenRobotics/RMF_Materials/textures/blue_linoleum.png".to_owned(),
-                ),
-                ..Default::default()
-            },
+            texture: Affiliation(None),
             preferred_semi_transparency: PreferredSemiTransparency::for_floor(),
             marker: Default::default(),
         }

--- a/rmf_site_format/src/lane.rs
+++ b/rmf_site_format/src/lane.rs
@@ -17,8 +17,9 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Bundle, Component, Entity};
+use bevy::prelude::{Bundle, Component};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]
@@ -192,16 +193,15 @@ impl Recall for RecallReverseLane {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl Lane<u32> {
-    pub fn to_ecs(&self, id_to_entity: &std::collections::HashMap<u32, Entity>) -> Lane<Entity> {
-        Lane {
-            anchors: self.anchors.to_ecs(id_to_entity),
+impl<T: RefTrait> Lane<T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Lane<U>, T> {
+        Ok(Lane {
+            anchors: self.anchors.convert(id_map)?,
             forward: self.forward.clone(),
             reverse: self.reverse.clone(),
-            graphs: self.graphs.to_ecs(id_to_entity),
+            graphs: self.graphs.convert(id_map)?,
             marker: Default::default(),
-        }
+        })
     }
 }
 

--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -1,4 +1,7 @@
-use super::{level::Level, lift::Lift, PortingError, Result};
+use super::{
+    level::Level, lift::Lift, floor::FloorParameters, PortingError, Result,
+    wall::WallProperties,
+};
 use crate::{
     alignment::align_legacy_building, Affiliation, Anchor, Angle, AssetSource, AssociatedGraphs,
     DisplayColor, Dock as SiteDock, Drawing as SiteDrawing, DrawingProperties,
@@ -6,7 +9,7 @@ use crate::{
     Level as SiteLevel, LevelElevation, LevelProperties as SiteLevelProperties, Motion, NameInSite,
     NameOfSite, NavGraph, Navigation, OrientationConstraint, PixelsPerMeter, Pose,
     PreferredSemiTransparency, RankingsInLevel, ReverseLane, Rotation, Site, SiteProperties,
-    DEFAULT_NAV_GRAPH_COLORS,
+    DEFAULT_NAV_GRAPH_COLORS, Texture as SiteTexture, TextureGroup,
 };
 use glam::{DAffine2, DMat3, DQuat, DVec2, DVec3, EulerRot};
 use serde::{Deserialize, Serialize};
@@ -146,7 +149,9 @@ impl BuildingMap {
         let mut level_name_to_id = BTreeMap::new();
         let mut lanes = BTreeMap::<u32, SiteLane<u32>>::new();
         let mut locations = BTreeMap::new();
-
+        let mut textures: BTreeMap<u32, SiteTexture> = BTreeMap::new();
+        let mut floor_texture_map: HashMap<FloorParameters, u32> = HashMap::new();
+        let mut wall_texture_map: HashMap<WallProperties, u32> = HashMap::new();
         let mut lift_cabin_anchors: BTreeMap<String, Vec<(u32, Anchor)>> = BTreeMap::new();
 
         let mut building_id_to_nav_graph_id = HashMap::new();
@@ -433,7 +438,12 @@ impl BuildingMap {
 
             let mut floors = BTreeMap::new();
             for floor in &level.floors {
-                let site_floor = floor.to_site(&vertex_to_anchor_id)?;
+                let site_floor = floor.to_site(
+                    &vertex_to_anchor_id,
+                    &mut textures,
+                    &mut floor_texture_map,
+                    &mut site_id,
+                )?;
                 let id = site_id.next().unwrap();
                 floors.insert(id, site_floor);
                 rankings.floors.push(id);
@@ -456,7 +466,12 @@ impl BuildingMap {
 
             let mut walls = BTreeMap::new();
             for wall in &level.walls {
-                let site_wall = wall.to_site(&vertex_to_anchor_id)?;
+                let site_wall = wall.to_site(
+                    &vertex_to_anchor_id,
+                    &mut textures,
+                    &mut wall_texture_map,
+                    &mut site_id,
+                )?;
                 walls.insert(site_id.next().unwrap(), site_wall);
             }
 
@@ -595,6 +610,28 @@ impl BuildingMap {
             })
             .collect();
 
+        let textures = textures
+            .into_iter()
+            .map(
+                |(id, texture)| {
+                    let name: String = (&texture.source).into();
+                    let name = Path::new(&name)
+                        .file_stem()
+                        .map(|s| s.to_str().map(|s| s.to_owned()))
+                        .flatten()
+                        .unwrap_or(name);
+                    (
+                        id,
+                        TextureGroup {
+                            name: NameInSite(name),
+                            texture,
+                            group: Default::default(),
+                        }
+                    )
+                }
+            )
+            .collect();
+
         Ok(Site {
             format_version: Default::default(),
             anchors: site_anchors,
@@ -605,6 +642,7 @@ impl BuildingMap {
             lifts,
             fiducial_groups,
             fiducials: cartesian_fiducials,
+            textures,
             navigation: Navigation {
                 guided: Guided {
                     graphs: nav_graphs,

--- a/rmf_site_format/src/legacy/building_map.rs
+++ b/rmf_site_format/src/legacy/building_map.rs
@@ -1,6 +1,5 @@
 use super::{
-    level::Level, lift::Lift, floor::FloorParameters, PortingError, Result,
-    wall::WallProperties,
+    floor::FloorParameters, level::Level, lift::Lift, wall::WallProperties, PortingError, Result,
 };
 use crate::{
     alignment::align_legacy_building, Affiliation, Anchor, Angle, AssetSource, AssociatedGraphs,
@@ -9,7 +8,7 @@ use crate::{
     Level as SiteLevel, LevelElevation, LevelProperties as SiteLevelProperties, Motion, NameInSite,
     NameOfSite, NavGraph, Navigation, OrientationConstraint, PixelsPerMeter, Pose,
     PreferredSemiTransparency, RankingsInLevel, ReverseLane, Rotation, Site, SiteProperties,
-    DEFAULT_NAV_GRAPH_COLORS, Texture as SiteTexture, TextureGroup,
+    Texture as SiteTexture, TextureGroup, DEFAULT_NAV_GRAPH_COLORS,
 };
 use glam::{DAffine2, DMat3, DQuat, DVec2, DVec3, EulerRot};
 use serde::{Deserialize, Serialize};
@@ -612,24 +611,22 @@ impl BuildingMap {
 
         let textures = textures
             .into_iter()
-            .map(
-                |(id, texture)| {
-                    let name: String = (&texture.source).into();
-                    let name = Path::new(&name)
-                        .file_stem()
-                        .map(|s| s.to_str().map(|s| s.to_owned()))
-                        .flatten()
-                        .unwrap_or(name);
-                    (
-                        id,
-                        TextureGroup {
-                            name: NameInSite(name),
-                            texture,
-                            group: Default::default(),
-                        }
-                    )
-                }
-            )
+            .map(|(id, texture)| {
+                let name: String = (&texture.source).into();
+                let name = Path::new(&name)
+                    .file_stem()
+                    .map(|s| s.to_str().map(|s| s.to_owned()))
+                    .flatten()
+                    .unwrap_or(name);
+                (
+                    id,
+                    TextureGroup {
+                        name: NameInSite(name),
+                        texture,
+                        group: Default::default(),
+                    },
+                )
+            })
             .collect();
 
         Ok(Site {

--- a/rmf_site_format/src/legacy/floor.rs
+++ b/rmf_site_format/src/legacy/floor.rs
@@ -1,12 +1,15 @@
 use super::{rbmf::*, PortingError, Result};
 use crate::{
     Angle, AssetSource, Floor as SiteFloor, FloorMarker, Path,
-    PreferredSemiTransparency, Texture,
+    PreferredSemiTransparency, Texture, Affiliation,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, BTreeMap},
+    ops::RangeFrom,
+};
 
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone, Default, Hash, PartialEq, Eq)]
 pub struct FloorParameters {
     pub texture_name: RbmfString,
     pub texture_rotation: RbmfFloat,
@@ -20,7 +23,13 @@ pub struct Floor {
 }
 
 impl Floor {
-    pub fn to_site(&self, vertex_to_anchor_id: &HashMap<usize, u32>) -> Result<SiteFloor<u32>> {
+    pub fn to_site(
+        &self,
+        vertex_to_anchor_id: &HashMap<usize, u32>,
+        textures: &mut BTreeMap<u32, Texture>,
+        texture_map: &mut HashMap<FloorParameters, u32>,
+        site_id: &mut RangeFrom<u32>,
+    ) -> Result<SiteFloor<u32>> {
         let mut anchors = Vec::new();
         for v in &self.vertices {
             let anchor = *vertex_to_anchor_id
@@ -30,9 +39,8 @@ impl Floor {
             anchors.push(anchor);
         }
 
-        Ok(SiteFloor {
-            anchors: Path(anchors),
-            texture: if self.parameters.texture_name.1.is_empty() {
+        let texture_site_id = *texture_map.entry(self.parameters.clone()).or_insert_with(|| {
+            let texture = if self.parameters.texture_name.1.is_empty() {
                 Texture {
                     source: AssetSource::Remote(
                         "OpenRobotics/RMF_Materials/textures/blue_linoleum.png".to_owned(),
@@ -51,7 +59,16 @@ impl Floor {
                     height: Some(self.parameters.texture_scale.1 as f32),
                     ..Default::default()
                 }
-            },
+            };
+
+            let texture_site_id = site_id.next().unwrap();
+            textures.insert(texture_site_id, texture);
+            texture_site_id
+        });
+
+        Ok(SiteFloor {
+            anchors: Path(anchors),
+            texture: Affiliation(Some(texture_site_id)),
             preferred_semi_transparency: PreferredSemiTransparency::for_floor(),
             marker: FloorMarker,
         })

--- a/rmf_site_format/src/legacy/floor.rs
+++ b/rmf_site_format/src/legacy/floor.rs
@@ -1,11 +1,11 @@
 use super::{rbmf::*, PortingError, Result};
 use crate::{
-    Angle, AssetSource, Floor as SiteFloor, FloorMarker, Path,
-    PreferredSemiTransparency, Texture, Affiliation,
+    Affiliation, Angle, AssetSource, Floor as SiteFloor, FloorMarker, Path,
+    PreferredSemiTransparency, Texture,
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, BTreeMap},
+    collections::{BTreeMap, HashMap},
     ops::RangeFrom,
 };
 
@@ -39,32 +39,34 @@ impl Floor {
             anchors.push(anchor);
         }
 
-        let texture_site_id = *texture_map.entry(self.parameters.clone()).or_insert_with(|| {
-            let texture = if self.parameters.texture_name.1.is_empty() {
-                Texture {
-                    source: AssetSource::Remote(
-                        "OpenRobotics/RMF_Materials/textures/blue_linoleum.png".to_owned(),
-                    ),
-                    ..Default::default()
-                }
-            } else {
-                Texture {
-                    source: AssetSource::Remote(
-                        "OpenRobotics/RMF_Materials/textures/".to_owned()
-                            + &self.parameters.texture_name.1
-                            + ".png",
-                    ),
-                    rotation: Some(Angle::Deg(self.parameters.texture_rotation.1 as f32)),
-                    width: Some(self.parameters.texture_scale.1 as f32),
-                    height: Some(self.parameters.texture_scale.1 as f32),
-                    ..Default::default()
-                }
-            };
+        let texture_site_id = *texture_map
+            .entry(self.parameters.clone())
+            .or_insert_with(|| {
+                let texture = if self.parameters.texture_name.1.is_empty() {
+                    Texture {
+                        source: AssetSource::Remote(
+                            "OpenRobotics/RMF_Materials/textures/blue_linoleum.png".to_owned(),
+                        ),
+                        ..Default::default()
+                    }
+                } else {
+                    Texture {
+                        source: AssetSource::Remote(
+                            "OpenRobotics/RMF_Materials/textures/".to_owned()
+                                + &self.parameters.texture_name.1
+                                + ".png",
+                        ),
+                        rotation: Some(Angle::Deg(self.parameters.texture_rotation.1 as f32)),
+                        width: Some(self.parameters.texture_scale.1 as f32),
+                        height: Some(self.parameters.texture_scale.1 as f32),
+                        ..Default::default()
+                    }
+                };
 
-            let texture_site_id = site_id.next().unwrap();
-            textures.insert(texture_site_id, texture);
-            texture_site_id
-        });
+                let texture_site_id = site_id.next().unwrap();
+                textures.insert(texture_site_id, texture);
+                texture_site_id
+            });
 
         Ok(SiteFloor {
             anchors: Path(anchors),

--- a/rmf_site_format/src/legacy/rbmf.rs
+++ b/rmf_site_format/src/legacy/rbmf.rs
@@ -1,10 +1,13 @@
 // RBMF stands for "RMF Building Map Format"
 
-use std::ops::{Deref, DerefMut};
+use std::{
+    ops::{Deref, DerefMut},
+    hash::Hash,
+};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Hash)]
 pub struct RbmfString(usize, pub String);
 
 impl From<String> for RbmfString {
@@ -30,6 +33,8 @@ impl PartialEq for RbmfString {
         self.1 == other.1
     }
 }
+
+impl Eq for RbmfString { }
 
 impl From<RbmfString> for String {
     fn from(s: RbmfString) -> Self {
@@ -116,6 +121,14 @@ impl PartialEq for RbmfFloat {
         self.1 == other.1
     }
 }
+
+impl Hash for RbmfFloat {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_i64((self.1 * 10000.0) as i64);
+    }
+}
+
+impl Eq for RbmfFloat { }
 
 impl PartialOrd for RbmfFloat {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {

--- a/rmf_site_format/src/legacy/rbmf.rs
+++ b/rmf_site_format/src/legacy/rbmf.rs
@@ -1,8 +1,8 @@
 // RBMF stands for "RMF Building Map Format"
 
 use std::{
-    ops::{Deref, DerefMut},
     hash::Hash,
+    ops::{Deref, DerefMut},
 };
 
 use serde::{Deserialize, Serialize};
@@ -34,7 +34,7 @@ impl PartialEq for RbmfString {
     }
 }
 
-impl Eq for RbmfString { }
+impl Eq for RbmfString {}
 
 impl From<RbmfString> for String {
     fn from(s: RbmfString) -> Self {
@@ -128,7 +128,7 @@ impl Hash for RbmfFloat {
     }
 }
 
-impl Eq for RbmfFloat { }
+impl Eq for RbmfFloat {}
 
 impl PartialOrd for RbmfFloat {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {

--- a/rmf_site_format/src/legacy/wall.rs
+++ b/rmf_site_format/src/legacy/wall.rs
@@ -1,7 +1,12 @@
 use super::{rbmf::*, PortingError, Result};
-use crate::{AssetSource, Texture, Wall as SiteWall, DEFAULT_LEVEL_HEIGHT};
+use crate::{
+    AssetSource, Texture, Wall as SiteWall, Affiliation, DEFAULT_LEVEL_HEIGHT,
+};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, BTreeMap},
+    ops::RangeFrom,
+};
 
 fn default_height() -> RbmfFloat {
     RbmfFloat::from(DEFAULT_LEVEL_HEIGHT as f64)
@@ -15,7 +20,7 @@ fn default_scale() -> RbmfFloat {
     RbmfFloat::from(1.0)
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Hash, PartialEq, Eq)]
 pub struct WallProperties {
     pub alpha: RbmfFloat,
     pub texture_name: RbmfString,
@@ -43,19 +48,25 @@ impl Default for WallProperties {
 pub struct Wall(pub usize, pub usize, pub WallProperties);
 
 impl Wall {
-    pub fn to_site(&self, vertex_to_anchor_id: &HashMap<usize, u32>) -> Result<SiteWall<u32>> {
+    pub fn to_site(
+        &self,
+        vertex_to_anchor_id: &HashMap<usize, u32>,
+        textures: &mut BTreeMap<u32, Texture>,
+        texture_map: &mut HashMap<WallProperties, u32>,
+        site_id: &mut RangeFrom<u32>,
+    ) -> Result<SiteWall<u32>> {
         let left_anchor = vertex_to_anchor_id
             .get(&self.0)
             .ok_or(PortingError::InvalidVertex(self.0))?;
         let right_anchor = vertex_to_anchor_id
             .get(&self.1)
             .ok_or(PortingError::InvalidVertex(self.1))?;
-        Ok(SiteWall {
-            anchors: [*left_anchor, *right_anchor].into(),
-            texture: if self.2.texture_name.is_empty() {
+
+        let texture_site_id = *texture_map.entry(self.2.clone()).or_insert_with(|| {
+            let texture = if self.2.texture_name.1.is_empty() {
                 Texture {
                     source: AssetSource::Remote(
-                        "OpenRobotics/RMF_Materials/textures/default.png".to_owned(),
+                        "OpenRobotics/RMF_Materials/textures/blue_linoleum.png".to_owned(),
                     ),
                     ..Default::default()
                 }
@@ -66,12 +77,21 @@ impl Wall {
                             + &self.2.texture_name.1
                             + ".png",
                     ),
+                    rotation: None,
+                    width: Some((self.2.texture_width.1/self.2.texture_scale.1) as f32),
+                    height: Some((self.2.texture_height.1/self.2.texture_scale.1) as f32),
                     alpha: Some(self.2.alpha.1 as f32),
-                    width: Some((self.2.texture_width.1 / self.2.texture_scale.1) as f32),
-                    height: Some((self.2.texture_height.1 / self.2.texture_scale.1) as f32),
-                    ..Default::default()
                 }
-            },
+            };
+
+            let texture_site_id = site_id.next().unwrap();
+            textures.insert(texture_site_id, texture);
+            texture_site_id
+        });
+
+        Ok(SiteWall {
+            anchors: [*left_anchor, *right_anchor].into(),
+            texture: Affiliation(Some(texture_site_id)),
             marker: Default::default(),
         })
     }

--- a/rmf_site_format/src/legacy/wall.rs
+++ b/rmf_site_format/src/legacy/wall.rs
@@ -1,10 +1,8 @@
 use super::{rbmf::*, PortingError, Result};
-use crate::{
-    AssetSource, Texture, Wall as SiteWall, Affiliation, DEFAULT_LEVEL_HEIGHT,
-};
+use crate::{Affiliation, AssetSource, Texture, Wall as SiteWall, DEFAULT_LEVEL_HEIGHT};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, BTreeMap},
+    collections::{BTreeMap, HashMap},
     ops::RangeFrom,
 };
 
@@ -78,8 +76,8 @@ impl Wall {
                             + ".png",
                     ),
                     rotation: None,
-                    width: Some((self.2.texture_width.1/self.2.texture_scale.1) as f32),
-                    height: Some((self.2.texture_height.1/self.2.texture_scale.1) as f32),
+                    width: Some((self.2.texture_width.1 / self.2.texture_scale.1) as f32),
+                    height: Some((self.2.texture_height.1 / self.2.texture_scale.1) as f32),
                     alpha: Some(self.2.alpha.1 as f32),
                 }
             };

--- a/rmf_site_format/src/lift.rs
+++ b/rmf_site_format/src/lift.rs
@@ -60,10 +60,7 @@ pub struct LiftCabinDoor<T: RefTrait> {
 }
 
 impl<T: RefTrait> LiftCabinDoor<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<LiftCabinDoor<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<LiftCabinDoor<U>, T> {
         Ok(LiftCabinDoor {
             kind: self.kind.clone(),
             reference_anchors: self.reference_anchors.convert(id_map)?,
@@ -85,11 +82,9 @@ impl<T: RefTrait> Default for LevelVisits<T> {
 }
 
 impl<T: RefTrait> LevelVisits<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<LevelVisits<U>, T> {
-        let set: Result<BTreeSet<U>, T> = self.0
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<LevelVisits<U>, T> {
+        let set: Result<BTreeSet<U>, T> = self
+            .0
             .iter()
             .map(|level| id_map.get(level).copied().ok_or(*level))
             .collect();
@@ -178,10 +173,7 @@ impl<T: RefTrait> LiftCabin<T> {
         None
     }
 
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<LiftCabin<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<LiftCabin<U>, T> {
         let result = match self {
             LiftCabin::Rect(cabin) => LiftCabin::Rect(cabin.convert(id_map)?),
         };
@@ -486,10 +478,7 @@ pub struct LiftCabinDoorPlacement<T: RefTrait> {
 }
 
 impl<T: RefTrait> LiftProperties<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<LiftProperties<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<LiftProperties<U>, T> {
         Ok(LiftProperties {
             name: self.name.clone(),
             reference_anchors: self.reference_anchors.convert(id_map)?,

--- a/rmf_site_format/src/location.rs
+++ b/rmf_site_format/src/location.rs
@@ -85,10 +85,7 @@ impl Default for LocationTags {
 }
 
 impl<T: RefTrait> Location<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Location<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Location<U>, T> {
         Ok(Location {
             anchor: self.anchor.convert(id_map)?,
             tags: self.tags.clone(),

--- a/rmf_site_format/src/location.rs
+++ b/rmf_site_format/src/location.rs
@@ -17,8 +17,9 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Bundle, Component, Deref, DerefMut, Entity};
+use bevy::prelude::{Bundle, Component, Deref, DerefMut};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum LocationTag {
@@ -83,18 +84,17 @@ impl Default for LocationTags {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl Location<u32> {
-    pub fn to_ecs(
+impl<T: RefTrait> Location<T> {
+    pub fn convert<U: RefTrait>(
         &self,
-        id_to_entity: &std::collections::HashMap<u32, Entity>,
-    ) -> Location<Entity> {
-        Location {
-            anchor: Point(*id_to_entity.get(&self.anchor).unwrap()),
+        id_map: &HashMap<T, U>,
+    ) -> Result<Location<U>, T> {
+        Ok(Location {
+            anchor: self.anchor.convert(id_map)?,
             tags: self.tags.clone(),
             name: self.name.clone(),
-            graphs: self.graphs.to_ecs(id_to_entity),
-        }
+            graphs: self.graphs.convert(id_map)?,
+        })
     }
 }
 

--- a/rmf_site_format/src/measurement.rs
+++ b/rmf_site_format/src/measurement.rs
@@ -61,10 +61,7 @@ impl Measurement<Entity> {
 }
 
 impl<T: RefTrait> Measurement<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Measurement<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Measurement<U>, T> {
         Ok(Measurement {
             anchors: self.anchors.convert(id_map)?,
             distance: self.distance,

--- a/rmf_site_format/src/measurement.rs
+++ b/rmf_site_format/src/measurement.rs
@@ -19,6 +19,7 @@ use crate::*;
 #[cfg(feature = "bevy")]
 use bevy::prelude::{Bundle, Component, Deref, DerefMut, Entity};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]
@@ -59,18 +60,17 @@ impl Measurement<Entity> {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl Measurement<u32> {
-    pub fn to_ecs(
+impl<T: RefTrait> Measurement<T> {
+    pub fn convert<U: RefTrait>(
         &self,
-        id_to_entity: &std::collections::HashMap<u32, Entity>,
-    ) -> Measurement<Entity> {
-        Measurement {
-            anchors: self.anchors.to_ecs(id_to_entity),
+        id_map: &HashMap<T, U>,
+    ) -> Result<Measurement<U>, T> {
+        Ok(Measurement {
+            anchors: self.anchors.convert(id_map)?,
             distance: self.distance,
             label: self.label.clone(),
             marker: Default::default(),
-        }
+        })
     }
 }
 

--- a/rmf_site_format/src/misc.rs
+++ b/rmf_site_format/src/misc.rs
@@ -20,6 +20,7 @@ use crate::{Recall, RefTrait};
 use bevy::prelude::*;
 use glam::{Quat, Vec2, Vec3};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub const DEFAULT_LEVEL_HEIGHT: f32 = 3.0;
 
@@ -475,12 +476,15 @@ impl<T: RefTrait> Default for Affiliation<T> {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl Affiliation<u32> {
-    pub fn to_ecs(
+impl<T: RefTrait> Affiliation<T> {
+    pub fn convert<U: RefTrait>(
         &self,
-        id_to_entity: &std::collections::HashMap<u32, Entity>,
-    ) -> Affiliation<Entity> {
-        Affiliation(self.0.map(|a| *id_to_entity.get(&a).unwrap()))
+        id_map: &HashMap<T, U>,
+    ) -> Result<Affiliation<U>, T> {
+        if let Some(x) = self.0 {
+            Ok(Affiliation(Some(id_map.get(&x).ok_or(x)?.clone())))
+        } else {
+            Ok(Affiliation(None))
+        }
     }
 }

--- a/rmf_site_format/src/misc.rs
+++ b/rmf_site_format/src/misc.rs
@@ -477,10 +477,7 @@ impl<T: RefTrait> Default for Affiliation<T> {
 }
 
 impl<T: RefTrait> Affiliation<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Affiliation<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Affiliation<U>, T> {
         if let Some(x) = self.0 {
             Ok(Affiliation(Some(id_map.get(&x).ok_or(x)?.clone())))
         } else {

--- a/rmf_site_format/src/nav_graph.rs
+++ b/rmf_site_format/src/nav_graph.rs
@@ -113,16 +113,11 @@ impl<T: RefTrait> Default for AssociatedGraphs<T> {
 }
 
 impl<T: RefTrait> AssociatedGraphs<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<AssociatedGraphs<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<AssociatedGraphs<U>, T> {
         let result = match self {
             Self::All => AssociatedGraphs::All,
             Self::Only(set) => AssociatedGraphs::Only(Self::convert_set(set, id_map)?),
-            Self::AllExcept(set) => {
-                AssociatedGraphs::AllExcept(Self::convert_set(set, id_map)?)
-            }
+            Self::AllExcept(set) => AssociatedGraphs::AllExcept(Self::convert_set(set, id_map)?),
         };
         Ok(result)
     }
@@ -131,8 +126,7 @@ impl<T: RefTrait> AssociatedGraphs<T> {
         set: &BTreeSet<T>,
         id_map: &HashMap<T, U>,
     ) -> Result<BTreeSet<U>, T> {
-        set
-            .iter()
+        set.iter()
             .map(|g| id_map.get(g).cloned().ok_or(*g))
             .collect()
     }

--- a/rmf_site_format/src/path.rs
+++ b/rmf_site_format/src/path.rs
@@ -17,22 +17,24 @@
 
 use crate::RefTrait;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Component, Deref, DerefMut, Entity};
+use bevy::prelude::{Component, Deref, DerefMut};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(transparent)]
 #[cfg_attr(feature = "bevy", derive(Component, Deref, DerefMut))]
 pub struct Path<T: RefTrait>(pub Vec<T>);
 
-#[cfg(feature = "bevy")]
-impl Path<u32> {
-    pub fn to_ecs(&self, id_to_entity: &std::collections::HashMap<u32, Entity>) -> Path<Entity> {
-        Path(
-            self.0
-                .iter()
-                .map(|a| *id_to_entity.get(a).unwrap())
-                .collect(),
-        )
+impl<T: RefTrait> Path<T> {
+    pub fn convert<U: RefTrait>(
+        &self,
+        id_map: &HashMap<T, U>,
+    ) -> Result<Path<U>, T> {
+        let path: Result<Vec<U>, T> = self.0
+            .iter()
+            .map(|a| id_map.get(a).cloned().ok_or(*a))
+            .collect();
+        Ok(Path(path?))
     }
 }

--- a/rmf_site_format/src/path.rs
+++ b/rmf_site_format/src/path.rs
@@ -27,11 +27,9 @@ use std::collections::HashMap;
 pub struct Path<T: RefTrait>(pub Vec<T>);
 
 impl<T: RefTrait> Path<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Path<U>, T> {
-        let path: Result<Vec<U>, T> = self.0
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Path<U>, T> {
+        let path: Result<Vec<U>, T> = self
+            .0
             .iter()
             .map(|a| id_map.get(a).cloned().ok_or(*a))
             .collect();

--- a/rmf_site_format/src/point.rs
+++ b/rmf_site_format/src/point.rs
@@ -17,8 +17,9 @@
 
 use crate::RefTrait;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Component, Deref, DerefMut, Entity};
+use bevy::prelude::{Component, Deref, DerefMut};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 #[serde(transparent)]
@@ -31,9 +32,11 @@ impl<T: RefTrait> From<T> for Point<T> {
     }
 }
 
-#[cfg(feature = "bevy")]
-impl Point<u32> {
-    pub fn to_ecs(&self, id_to_entity: &std::collections::HashMap<u32, Entity>) -> Point<Entity> {
-        Point(*id_to_entity.get(&self.0).unwrap())
+impl<T: RefTrait> Point<T> {
+    pub fn convert<U: RefTrait>(
+        &self,
+        id_map: &HashMap<T, U>,
+    ) -> Result<Point<U>, T> {
+        Ok(Point(id_map.get(&self.0).ok_or(self.0)?.clone()))
     }
 }

--- a/rmf_site_format/src/point.rs
+++ b/rmf_site_format/src/point.rs
@@ -33,10 +33,7 @@ impl<T: RefTrait> From<T> for Point<T> {
 }
 
 impl<T: RefTrait> Point<T> {
-    pub fn convert<U: RefTrait>(
-        &self,
-        id_map: &HashMap<T, U>,
-    ) -> Result<Point<U>, T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Point<U>, T> {
         Ok(Point(id_map.get(&self.0).ok_or(self.0)?.clone()))
     }
 }

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -51,6 +51,9 @@ pub struct Site {
     /// Properties of each level
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub levels: BTreeMap<u32, Level>,
+    /// The groups of textures being used in the site
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub textures: BTreeMap<u32, TextureGroup>,
     /// The fiducial groups that exist in the site
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub fiducial_groups: BTreeMap<u32, FiducialGroup>,

--- a/rmf_site_format/src/texture.rs
+++ b/rmf_site_format/src/texture.rs
@@ -17,7 +17,7 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::Component;
+use bevy::prelude::{Component, Bundle};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
@@ -32,4 +32,14 @@ pub struct Texture {
     pub width: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<f32>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[cfg_attr(feature = "bevy", derive(Bundle))]
+pub struct TextureGroup {
+    pub name: NameInSite,
+    #[serde(flatten)]
+    pub texture: Texture,
+    #[serde(skip)]
+    pub group: Group,
 }

--- a/rmf_site_format/src/texture.rs
+++ b/rmf_site_format/src/texture.rs
@@ -17,7 +17,7 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Component, Bundle};
+use bevy::prelude::{Bundle, Component};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]

--- a/rmf_site_format/src/wall.rs
+++ b/rmf_site_format/src/wall.rs
@@ -17,15 +17,16 @@
 
 use crate::*;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{Bundle, Component, Entity};
+use bevy::prelude::{Bundle, Component};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Bundle))]
 pub struct Wall<T: RefTrait> {
     pub anchors: Edge<T>,
     #[serde(skip_serializing_if = "is_default")]
-    pub texture: Texture,
+    pub texture: Affiliation<T>,
     #[serde(skip)]
     pub marker: WallMarker,
 }
@@ -34,25 +35,13 @@ pub struct Wall<T: RefTrait> {
 #[cfg_attr(feature = "bevy", derive(Component))]
 pub struct WallMarker;
 
-#[cfg(feature = "bevy")]
-impl Wall<Entity> {
-    pub fn to_u32(&self, anchors: Edge<u32>) -> Wall<u32> {
-        Wall {
-            anchors,
-            texture: self.texture.clone(),
+impl<T: RefTrait> Wall<T> {
+    pub fn convert<U: RefTrait>(&self, id_map: &HashMap<T, U>) -> Result<Wall<U>, T> {
+        Ok(Wall {
+            anchors: self.anchors.convert(id_map)?,
+            texture: self.texture.convert(id_map)?,
             marker: Default::default(),
-        }
-    }
-}
-
-#[cfg(feature = "bevy")]
-impl Wall<u32> {
-    pub fn to_ecs(&self, id_to_entity: &std::collections::HashMap<u32, Entity>) -> Wall<Entity> {
-        Wall {
-            anchors: self.anchors.to_ecs(id_to_entity),
-            texture: self.texture.clone(),
-            marker: Default::default(),
-        }
+        })
     }
 }
 
@@ -60,12 +49,7 @@ impl<T: RefTrait> From<Edge<T>> for Wall<T> {
     fn from(anchors: Edge<T>) -> Self {
         Self {
             anchors,
-            texture: Texture {
-                source: AssetSource::Remote(
-                    "OpenRobotics/RMF_Materials/textures/default.png".to_owned(),
-                ),
-                ..Default::default()
-            },
+            texture: Affiliation(None),
             marker: Default::default(),
         }
     }


### PR DESCRIPTION
This PR introduces a concept of texture groups. Elements like floors and walls will no longer have their own texture properties but instead will be affiliated with a `TextureGroup` that describes the texture properties. Changing the properties of one texture group will affect all elements affiliated with the group.

Individual elements can be moved between texture groups at any time or become "unaffiliated" in which case they will be rendered with a simple white texture (in a future PR we can consider having a special "unaffiliated" texture to make these cases more obvious).

Texture groups can be renamed, merged, or deleted at any time by expanding the `Group` menu in the right panel.