### PR TITLE
Workaround flatten issue and add roundtrip unit test to fix broken project save / load

### DIFF
--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["rlib"]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.23"
 serde_json = "*"
-ron = "0.7"
+ron = "0.8"
 thiserror = "*"
 glam = "0.22"
 # add features=["bevy"] to a dependent Cargo.toml to get the bevy-related features

--- a/rmf_site_format/src/drawing.rs
+++ b/rmf_site_format/src/drawing.rs
@@ -33,7 +33,12 @@ impl Default for PixelsPerMeter {
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct Drawing {
-    #[serde(flatten)]
+    // Even though round trip flattening is supposed to work after
+    // https://github.com/ron-rs/ron/pull/455, it seems it currently fails
+    // in ron, even forcing a dependency on that commit.
+    // TODO(luca) investigate further, come up with a minimum example,
+    // open an upstream issue and link it here for reference.
+    // #[serde(flatten)]
     pub properties: DrawingProperties,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub anchors: BTreeMap<u32, Anchor>,

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -98,17 +98,17 @@ impl Site {
         ron::ser::to_string_pretty(self, style)
     }
 
-    pub fn from_reader<R: io::Read>(reader: R) -> ron::Result<Self> {
+    pub fn from_reader<R: io::Read>(reader: R) -> ron::error::SpannedResult<Self> {
         // TODO(MXG): Validate the parsed data, e.g. make sure anchor pairs
         // belong to the same level.
         ron::de::from_reader(reader)
     }
 
-    pub fn from_str<'a>(s: &'a str) -> ron::Result<Self> {
+    pub fn from_str<'a>(s: &'a str) -> ron::error::SpannedResult<Self> {
         ron::de::from_str(s)
     }
 
-    pub fn from_bytes<'a>(s: &'a [u8]) -> ron::Result<Self> {
+    pub fn from_bytes<'a>(s: &'a [u8]) -> ron::error::SpannedResult<Self> {
         ron::de::from_bytes(s)
     }
 }
@@ -119,3 +119,17 @@ impl RefTrait for u32 {}
 
 #[cfg(feature = "bevy")]
 impl RefTrait for Entity {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::legacy::building_map::BuildingMap;
+
+    #[test]
+    fn serde_roundtrip() {
+        let data = std::fs::read("../assets/demo_maps/office.building.yaml").unwrap();
+        let map = BuildingMap::from_bytes(&data).unwrap();
+        let site_string = map.to_site().unwrap().to_string().unwrap();
+        Site::from_str(&site_string).unwrap();
+    }
+}


### PR DESCRIPTION
## Bug fix

### Fixed bug

The drawing editor PR introduced use of `flatten` that seems to not work very well with `ron`. Sadly I couldn't manage to get a minimal reproducible example to open an upstream issue but at least I added a unit test that will catch this sort of issues in CI, commented the guilty line and added a TODO in place to investigate the issue further.
I also updated `ron` to 0.8 which is supposed to help but doesn't really.