### PR TITLE
Fix dragging behavior when FPS is low

### DIFF
--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -282,10 +282,13 @@ pub fn update_gizmo_click_start(
         }
     }
 
-    let clicked = mouse_button_input.just_pressed(MouseButton::Left)
+    // Ignore if button was pressed and released in the same frame, to avoid being stuck in
+    // dragging behavior in cases when the frame rate is low.
+    let clicking = (mouse_button_input.just_pressed(MouseButton::Left)
+        && !mouse_button_input.just_released(MouseButton::Left))
         || touch_input.iter_just_pressed().next().is_some();
 
-    if clicked {
+    if clicking {
         if let GizmoState::Hovering(e) = *gizmo_state {
             click.send(GizmoClicked(e));
             if let Ok(Some(intersection)) = intersections.get_single().map(|i| i.position()) {


### PR DESCRIPTION
## Bug fix

### Fixed bug

Starting and finishing dragging is done by two separate systems where:

* System to start drag behavior listens for "button left - just pressed" and initializes dragging.
* System to end drag behavior listens for "button left - just released _and_ we are dragging" and stops dragging.

This can cause an issue in cases when the FPS of the application is very low and the button is pressed and released on the same frame. We can get stuck in dragging behavior with the second system failing to cleanup the dragging.

### Fix applied

This PR changes the drag start system to only start dragging if the button was pressed but not released in the current frame.