### PR TITLE
Add collision parsing to SDF models

### DIFF
--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -16,9 +16,9 @@
 */
 
 use crate::site::{
-    update_anchor_transforms, ConstraintMarker, DoorMarker, FiducialMarker, FloorMarker,
-    LaneMarker, LiftCabin, LiftCabinDoorMarker, LocationTags, MeasurementMarker, ModelMarker,
-    SiteUpdateStage, WallMarker,
+    update_anchor_transforms, CollisionMeshMarker, ConstraintMarker, DoorMarker, FiducialMarker,
+    FloorMarker, LaneMarker, LiftCabin, LiftCabinDoorMarker, LocationTags, MeasurementMarker,
+    ModelMarker, SiteUpdateStage, VisualMeshMarker, WallMarker,
 };
 
 pub mod anchor;
@@ -150,18 +150,23 @@ impl Plugin for InteractionPlugin {
             .add_event::<SpawnPreview>()
             .add_plugin(PickingPlugin)
             .add_plugin(OutlinePlugin)
-            .add_plugin(CategoryVisibilityPlugin::<DoorMarker>::default())
-            .add_plugin(CategoryVisibilityPlugin::<FloorMarker>::default())
-            .add_plugin(CategoryVisibilityPlugin::<LaneMarker>::default())
+            .add_plugin(CategoryVisibilityPlugin::<DoorMarker>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<FloorMarker>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<LaneMarker>::visible(true))
             // TODO(luca) unify the two Lift plugins into a single one?
-            .add_plugin(CategoryVisibilityPlugin::<LiftCabin<Entity>>::default())
-            .add_plugin(CategoryVisibilityPlugin::<LiftCabinDoorMarker>::default())
-            .add_plugin(CategoryVisibilityPlugin::<LocationTags>::default())
-            .add_plugin(CategoryVisibilityPlugin::<FiducialMarker>::default())
-            .add_plugin(CategoryVisibilityPlugin::<ConstraintMarker>::default())
-            .add_plugin(CategoryVisibilityPlugin::<ModelMarker>::default())
-            .add_plugin(CategoryVisibilityPlugin::<MeasurementMarker>::default())
-            .add_plugin(CategoryVisibilityPlugin::<WallMarker>::default())
+            .add_plugin(CategoryVisibilityPlugin::<LiftCabin<Entity>>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<LiftCabinDoorMarker>::visible(
+                true,
+            ))
+            .add_plugin(CategoryVisibilityPlugin::<LocationTags>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<FiducialMarker>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<ConstraintMarker>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<VisualMeshMarker>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<CollisionMeshMarker>::visible(
+                false,
+            ))
+            .add_plugin(CategoryVisibilityPlugin::<MeasurementMarker>::visible(true))
+            .add_plugin(CategoryVisibilityPlugin::<WallMarker>::visible(true))
             .add_plugin(CameraControlsPlugin)
             .add_system_set(
                 SystemSet::on_update(InteractionState::Enable)

--- a/rmf_site_editor/src/interaction/select_anchor.rs
+++ b/rmf_site_editor/src/interaction/select_anchor.rs
@@ -18,8 +18,9 @@
 use crate::{
     interaction::*,
     site::{
-        drawing_editor::CurrentEditDrawing, Anchor, AnchorBundle, Category, Dependents,
-        DrawingMarker, Original, PathBehavior, Pending, TextureNeedsAssignment,
+        drawing_editor::CurrentEditDrawing, Anchor, AnchorBundle, Category, CollisionMeshMarker,
+        Dependents, DrawingMarker, Original, PathBehavior, Pending, TextureNeedsAssignment,
+        VisualMeshMarker,
     },
     CurrentWorkspace,
 };
@@ -27,8 +28,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 use rmf_site_format::{
     Constraint, ConstraintDependents, Door, Edge, Fiducial, Floor, Lane, LiftProperties, Location,
     Measurement, MeshConstraint, MeshElement, Model, ModelMarker, NameInWorkcell, NameOfSite, Path,
-    PixelsPerMeter, Point, Pose, Side, Wall, WorkcellCollisionMarker, WorkcellModel,
-    WorkcellVisualMarker,
+    PixelsPerMeter, Point, Pose, Side, Wall, WorkcellModel,
 };
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -1313,7 +1313,7 @@ impl SelectAnchorPointBuilder {
 
     pub fn for_visual(self, model: WorkcellModel) -> SelectAnchor3D {
         SelectAnchor3D {
-            bundle: PlaceableObject::WorkcellVisual(model),
+            bundle: PlaceableObject::VisualMesh(model),
             parent: None,
             target: self.for_element,
             continuity: self.continuity,
@@ -1322,7 +1322,7 @@ impl SelectAnchorPointBuilder {
 
     pub fn for_collision(self, model: WorkcellModel) -> SelectAnchor3D {
         SelectAnchor3D {
-            bundle: PlaceableObject::WorkcellCollision(model),
+            bundle: PlaceableObject::CollisionMesh(model),
             parent: None,
             target: self.for_element,
             continuity: self.continuity,
@@ -1693,8 +1693,8 @@ impl SelectAnchor {
 enum PlaceableObject {
     Model(Model),
     Anchor,
-    WorkcellVisual(WorkcellModel),
-    WorkcellCollision(WorkcellModel),
+    VisualMesh(WorkcellModel),
+    CollisionMesh(WorkcellModel),
 }
 
 #[derive(Clone)]
@@ -2253,7 +2253,7 @@ pub fn handle_select_anchor_3d_mode(
                     .cursor
                     .set_model_preview(&mut params.commands, Some(m.clone()));
             }
-            PlaceableObject::WorkcellVisual(ref m) | PlaceableObject::WorkcellCollision(ref m) => {
+            PlaceableObject::VisualMesh(ref m) | PlaceableObject::CollisionMesh(ref m) => {
                 // Spawn the model as a child of the cursor
                 params
                     .cursor
@@ -2331,25 +2331,25 @@ pub fn handle_select_anchor_3d_mode(
                         params.commands.entity(id).insert(model);
                         parent
                     }
-                    PlaceableObject::WorkcellVisual(ref a) => {
+                    PlaceableObject::VisualMesh(ref a) => {
                         let mut model = a.clone();
                         let parent = request
                             .parent
                             .unwrap_or(workspace.root.expect("No workspace"));
                         model.pose = compute_parent_inverse_pose(&cursor_tf, &transforms, parent);
                         let mut cmd = params.commands.entity(id);
-                        cmd.insert(WorkcellVisualMarker);
+                        cmd.insert(VisualMeshMarker);
                         model.add_bevy_components(cmd);
                         parent
                     }
-                    PlaceableObject::WorkcellCollision(ref a) => {
+                    PlaceableObject::CollisionMesh(ref a) => {
                         let mut model = a.clone();
                         let parent = request
                             .parent
                             .unwrap_or(workspace.root.expect("No workspace"));
                         model.pose = compute_parent_inverse_pose(&cursor_tf, &transforms, parent);
                         let mut cmd = params.commands.entity(id);
-                        cmd.insert(WorkcellCollisionMarker);
+                        cmd.insert(CollisionMeshMarker);
                         model.add_bevy_components(cmd);
                         parent
                     }

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -210,6 +210,14 @@ pub fn update_model_scenes(
             .insert(Category::Model);
 
         if !has_visibility {
+            // NOTE: We separate this out because for CollisionMeshMarker
+            // entities their visibility will be set by the CategoryVisibility
+            // plugin, which will (usually) set visibility to false. If we
+            // always inserted a true Visibiltiy then we would override the
+            // CategoryVisibility setting. This kind of multiple-source-of-truth
+            // conflict should be resolved by having a more sound way of building
+            // new entities and/or using a dependency tracker as proposed here:
+            // https://github.com/open-rmf/rmf_site/issues/173
             commands.insert(VisibilityBundle {
                 visibility: Visibility::VISIBLE,
                 ..default()

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -206,10 +206,7 @@ pub fn update_model_scenes(
                 format: tentative_format.clone(),
                 entity: None,
             })
-            .insert(SpatialBundle {
-                transform: pose.transform(),
-                ..default()
-            })
+            .insert(TransformBundle::from_transform(pose.transform()))
             .insert(Category::Model);
 
         if !has_visibility {

--- a/rmf_site_editor/src/site/sdf.rs
+++ b/rmf_site_editor/src/site/sdf.rs
@@ -29,6 +29,14 @@ use rmf_site_format::{
     ModelMarker, NameInSite, Pose, Rotation, Scale, WorkcellCollisionMarker, WorkcellVisualMarker,
 };
 
+/// An empty component to mark this entity as a visual mesh
+#[derive(Component, Debug, Clone, Default)]
+pub struct VisualMeshMarker;
+
+/// An empty component to mark this entity as a collision mesh
+#[derive(Component, Debug, Clone, Default)]
+pub struct CollisionMeshMarker;
+
 // TODO(luca) reduce chances for panic and do proper error handling here
 fn compute_model_source(path: &str, uri: &str) -> AssetSource {
     let binding = path.strip_prefix("search://").unwrap();
@@ -73,6 +81,74 @@ fn parse_pose(pose: &Option<SdfPose>) -> Pose {
     }
 }
 
+fn spawn_geometry(
+    commands: &mut Commands,
+    geometry: &SdfGeometry,
+    visual_name: &str,
+    pose: &Option<SdfPose>,
+    sdf_path: &str,
+    is_static: bool,
+) -> Option<Entity> {
+    let pose = parse_pose(pose);
+    match geometry {
+        SdfGeometry::Mesh(mesh) => Some(
+            commands
+                .spawn(Model {
+                    name: NameInSite(visual_name.to_owned()),
+                    source: compute_model_source(sdf_path, &mesh.uri),
+                    pose,
+                    is_static: IsStatic(is_static),
+                    constraints: ConstraintDependents::default(),
+                    scale: parse_scale(&mesh.scale),
+                    marker: ModelMarker,
+                })
+                .id(),
+        ),
+        SdfGeometry::Box(b) => {
+            let s = &b.size.0;
+            Some(
+                commands
+                    .spawn(MeshPrimitive::Box {
+                        size: [s.x as f32, s.y as f32, s.z as f32],
+                    })
+                    .insert(pose)
+                    .insert(SpatialBundle::VISIBLE_IDENTITY)
+                    .id(),
+            )
+        }
+        SdfGeometry::Capsule(c) => Some(
+            commands
+                .spawn(MeshPrimitive::Capsule {
+                    radius: c.radius as f32,
+                    length: c.length as f32,
+                })
+                .insert(pose)
+                .insert(SpatialBundle::VISIBLE_IDENTITY)
+                .id(),
+        ),
+        SdfGeometry::Cylinder(c) => Some(
+            commands
+                .spawn(MeshPrimitive::Cylinder {
+                    radius: c.radius as f32,
+                    length: c.length as f32,
+                })
+                .insert(pose)
+                .insert(SpatialBundle::VISIBLE_IDENTITY)
+                .id(),
+        ),
+        SdfGeometry::Sphere(s) => Some(
+            commands
+                .spawn(MeshPrimitive::Sphere {
+                    radius: s.radius as f32,
+                })
+                .insert(pose)
+                .insert(SpatialBundle::VISIBLE_IDENTITY)
+                .id(),
+        ),
+        _ => None,
+    }
+}
+
 // TODO(luca) reduce duplication between sdf -> MeshPrimitive and urdf -> MeshPrimitive
 pub fn handle_new_sdf_roots(mut commands: Commands, new_sdfs: Query<(Entity, &SdfRoot)>) {
     for (e, sdf) in new_sdfs.iter() {
@@ -83,72 +159,39 @@ pub fn handle_new_sdf_roots(mut commands: Commands, new_sdfs: Query<(Entity, &Sd
                 .id();
             commands.entity(e).add_child(link_id);
             for visual in &link.visual {
-                let pose = parse_pose(&visual.pose);
-                let id = match &visual.geometry {
-                    SdfGeometry::Mesh(mesh) => Some(
-                        commands
-                            .spawn(Model {
-                                name: NameInSite(visual.name.clone()),
-                                source: compute_model_source(&sdf.path, &mesh.uri),
-                                pose,
-                                is_static: IsStatic(sdf.model.r#static.unwrap_or(false)),
-                                constraints: ConstraintDependents::default(),
-                                scale: parse_scale(&mesh.scale),
-                                marker: ModelMarker,
-                            })
-                            .id(),
-                    ),
-                    SdfGeometry::Box(b) => {
-                        let s = &b.size.0;
-                        Some(
-                            commands
-                                .spawn(MeshPrimitive::Box {
-                                    size: [s.x as f32, s.y as f32, s.z as f32],
-                                })
-                                .insert(pose)
-                                .insert(SpatialBundle::VISIBLE_IDENTITY)
-                                .id(),
-                        )
-                    }
-                    SdfGeometry::Capsule(c) => Some(
-                        commands
-                            .spawn(MeshPrimitive::Capsule {
-                                radius: c.radius as f32,
-                                length: c.length as f32,
-                            })
-                            .insert(pose)
-                            .insert(SpatialBundle::VISIBLE_IDENTITY)
-                            .id(),
-                    ),
-                    SdfGeometry::Cylinder(c) => Some(
-                        commands
-                            .spawn(MeshPrimitive::Cylinder {
-                                radius: c.radius as f32,
-                                length: c.length as f32,
-                            })
-                            .insert(pose)
-                            .insert(SpatialBundle::VISIBLE_IDENTITY)
-                            .id(),
-                    ),
-                    SdfGeometry::Sphere(s) => Some(
-                        commands
-                            .spawn(MeshPrimitive::Sphere {
-                                radius: s.radius as f32,
-                            })
-                            .insert(pose)
-                            .insert(SpatialBundle::VISIBLE_IDENTITY)
-                            .id(),
-                    ),
-                    _ => None,
-                };
+                let id = spawn_geometry(
+                    &mut commands,
+                    &visual.geometry,
+                    &visual.name,
+                    &visual.pose,
+                    &sdf.path,
+                    sdf.model.r#static.unwrap_or(false),
+                );
                 match id {
                     Some(id) => {
+                        commands.entity(id).insert(VisualMeshMarker);
                         commands.entity(link_id).add_child(id);
                     }
                     None => warn!("Found unhandled geometry type {:?}", &visual.geometry),
                 }
             }
-            // TODO(luca) parse and display collisions
+            for collision in &link.collision {
+                let id = spawn_geometry(
+                    &mut commands,
+                    &collision.geometry,
+                    &collision.name,
+                    &collision.pose,
+                    &sdf.path,
+                    sdf.model.r#static.unwrap_or(false),
+                );
+                match id {
+                    Some(id) => {
+                        commands.entity(id).insert(CollisionMeshMarker);
+                        commands.entity(link_id).add_child(id);
+                    }
+                    None => warn!("Found unhandled geometry type {:?}", &collision.geometry),
+                }
+            }
         }
         commands.entity(e).remove::<SdfRoot>();
     }

--- a/rmf_site_editor/src/site/sdf.rs
+++ b/rmf_site_editor/src/site/sdf.rs
@@ -26,7 +26,7 @@ use sdformat_rs::{SdfGeometry, SdfPose, Vector3d};
 
 use rmf_site_format::{
     Angle, AssetSource, ConstraintDependents, Geometry, IsStatic, MeshPrimitive, Model,
-    ModelMarker, NameInSite, Pose, Rotation, Scale, WorkcellCollisionMarker, WorkcellVisualMarker,
+    ModelMarker, NameInSite, Pose, Rotation, Scale,
 };
 
 /// An empty component to mark this entity as a visual mesh
@@ -205,8 +205,8 @@ pub fn handle_new_mesh_primitives(
         &Selectable,
         Or<(
             With<ModelMarker>,
-            With<WorkcellVisualMarker>,
-            With<WorkcellCollisionMarker>,
+            With<VisualMeshMarker>,
+            With<CollisionMeshMarker>,
         )>,
     >,
     mut meshes: ResMut<Assets<Mesh>>,

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -288,13 +288,25 @@ pub fn top_menu_bar(
                         .send((!params.resources.measurements.0).into());
                 }
                 if ui
-                    .checkbox(&mut params.resources.models.0.clone(), "Models")
+                    .checkbox(
+                        &mut params.resources.collisions.0.clone(),
+                        "Collision meshes",
+                    )
                     .clicked()
                 {
                     params
                         .events
-                        .models
-                        .send((!params.resources.models.0).into());
+                        .collisions
+                        .send((!params.resources.collisions.0).into());
+                }
+                if ui
+                    .checkbox(&mut params.resources.visuals.0.clone(), "Visual meshes")
+                    .clicked()
+                {
+                    params
+                        .events
+                        .visuals
+                        .send((!params.resources.visuals.0).into());
                 }
                 if ui
                     .checkbox(&mut params.resources.walls.0.clone(), "Walls")

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -24,10 +24,11 @@ use crate::{
     occupancy::CalculateGrid,
     recency::ChangeRank,
     site::{
-        AlignSiteDrawings, AssociatedGraphs, BeginEditDrawing, Change, ConsiderAssociatedGraph,
-        ConsiderLocationTag, CurrentLevel, Delete, DrawingMarker, ExportLights, FinishEditDrawing,
-        GlobalDrawingVisibility, GlobalFloorVisibility, LayerVisibility, MergeGroups,
-        PhysicalLightToggle, SaveNavGraphs, SiteState, Texture, ToggleLiftDoorAvailability,
+        AlignSiteDrawings, AssociatedGraphs, BeginEditDrawing, Change, CollisionMeshMarker,
+        ConsiderAssociatedGraph, ConsiderLocationTag, CurrentLevel, Delete, DrawingMarker,
+        ExportLights, FinishEditDrawing, GlobalDrawingVisibility, GlobalFloorVisibility,
+        LayerVisibility, MergeGroups, PhysicalLightToggle, SaveNavGraphs, SiteState, Texture,
+        ToggleLiftDoorAvailability, VisualMeshMarker,
     },
     AppState, CreateNewWorkspace, CurrentWorkspace, LoadWorkspace, SaveWorkspace,
 };
@@ -236,9 +237,10 @@ pub struct VisibilityEvents<'w, 's> {
     pub locations: EventWriter<'w, 's, SetCategoryVisibility<LocationTags>>,
     pub fiducials: EventWriter<'w, 's, SetCategoryVisibility<FiducialMarker>>,
     pub constraints: EventWriter<'w, 's, SetCategoryVisibility<ConstraintMarker>>,
-    pub models: EventWriter<'w, 's, SetCategoryVisibility<ModelMarker>>,
     pub measurements: EventWriter<'w, 's, SetCategoryVisibility<MeasurementMarker>>,
     pub walls: EventWriter<'w, 's, SetCategoryVisibility<WallMarker>>,
+    pub visuals: EventWriter<'w, 's, SetCategoryVisibility<VisualMeshMarker>>,
+    pub collisions: EventWriter<'w, 's, SetCategoryVisibility<CollisionMeshMarker>>,
 }
 
 #[derive(SystemParam)]
@@ -251,9 +253,10 @@ pub struct VisibilityResources<'w, 's> {
     pub locations: Res<'w, CategoryVisibility<LocationTags>>,
     pub fiducials: Res<'w, CategoryVisibility<FiducialMarker>>,
     pub constraints: Res<'w, CategoryVisibility<ConstraintMarker>>,
-    pub models: Res<'w, CategoryVisibility<ModelMarker>>,
     pub measurements: Res<'w, CategoryVisibility<MeasurementMarker>>,
     pub walls: Res<'w, CategoryVisibility<WallMarker>>,
+    pub visuals: Res<'w, CategoryVisibility<VisualMeshMarker>>,
+    pub collisions: Res<'w, CategoryVisibility<CollisionMeshMarker>>,
     _ignore: Query<'w, 's, ()>,
 }
 

--- a/rmf_site_editor/src/workcell/keyboard.rs
+++ b/rmf_site_editor/src/workcell/keyboard.rs
@@ -18,19 +18,9 @@
 use bevy::prelude::*;
 use bevy_egui::EguiContext;
 
-use rmf_site_format::{WorkcellCollisionMarker, WorkcellVisualMarker};
-
 pub fn handle_workcell_keyboard_input(
     keyboard_input: Res<Input<KeyCode>>,
     mut egui_context: ResMut<EguiContext>,
-    mut visuals: Query<
-        &mut Visibility,
-        (With<WorkcellVisualMarker>, Without<WorkcellCollisionMarker>),
-    >,
-    mut collisions: Query<
-        &mut Visibility,
-        (With<WorkcellCollisionMarker>, Without<WorkcellVisualMarker>),
-    >,
 ) {
     let egui_context = egui_context.ctx_mut();
     let ui_has_focus = egui_context.wants_pointer_input()
@@ -41,6 +31,7 @@ pub fn handle_workcell_keyboard_input(
         return;
     }
 
+    /*
     if keyboard_input.any_pressed([KeyCode::LShift, KeyCode::RShift]) {
         if keyboard_input.just_pressed(KeyCode::V) {
             info!("Toggling visuals");
@@ -56,4 +47,5 @@ pub fn handle_workcell_keyboard_input(
             }
         }
     }
+    */
 }

--- a/rmf_site_editor/src/workcell/load.rs
+++ b/rmf_site_editor/src/workcell/load.rs
@@ -19,7 +19,10 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::{
-    site::{AnchorBundle, DefaultFile, Dependents, PreventDeletion, SiteState},
+    site::{
+        AnchorBundle, CollisionMeshMarker, DefaultFile, Dependents, PreventDeletion, SiteState,
+        VisualMeshMarker,
+    },
     workcell::ChangeCurrentWorkcell,
     WorkspaceMarker,
 };
@@ -28,7 +31,6 @@ use std::collections::HashSet;
 
 use rmf_site_format::{
     Category, ConstraintDependents, MeshConstraint, NameInWorkcell, SiteID, Workcell,
-    WorkcellCollisionMarker, WorkcellVisualMarker,
 };
 
 pub struct LoadWorkcell {
@@ -62,7 +64,7 @@ fn generate_workcell_entities(commands: &mut Commands, workcell: &Workcell) -> E
     id_to_entity.insert(&workcell.id, root);
 
     for (id, parented_visual) in &workcell.visuals {
-        let cmd = commands.spawn((SiteID(*id), WorkcellVisualMarker));
+        let cmd = commands.spawn((SiteID(*id), VisualMeshMarker));
         let e = cmd.id();
         parented_visual.bundle.add_bevy_components(cmd);
         // TODO(luca) this hashmap update is duplicated, refactor into function
@@ -74,7 +76,7 @@ fn generate_workcell_entities(commands: &mut Commands, workcell: &Workcell) -> E
     }
 
     for (id, parented_collision) in &workcell.collisions {
-        let cmd = commands.spawn((SiteID(*id), WorkcellCollisionMarker));
+        let cmd = commands.spawn((SiteID(*id), CollisionMeshMarker));
         let e = cmd.id();
         parented_collision.bundle.add_bevy_components(cmd);
         // TODO(luca) this hashmap update is duplicated, refactor into function

--- a/rmf_site_editor/src/workcell/save.rs
+++ b/rmf_site_editor/src/workcell/save.rs
@@ -19,7 +19,7 @@ use bevy::ecs::system::SystemState;
 use bevy::prelude::*;
 use std::path::PathBuf;
 
-use crate::site::Pending;
+use crate::site::{CollisionMeshMarker, Pending, VisualMeshMarker};
 use crate::ExportFormat;
 
 use thiserror::Error as ThisError;
@@ -57,8 +57,8 @@ fn assign_site_ids(world: &mut World, workcell: Entity) {
                 Or<(
                     With<Anchor>,
                     With<LinkMarker>,
-                    With<WorkcellVisualMarker>,
-                    With<WorkcellCollisionMarker>,
+                    With<VisualMeshMarker>,
+                    With<CollisionMeshMarker>,
                 )>,
                 Without<Pending>,
             ),
@@ -110,12 +110,12 @@ pub fn generate_workcell(
                 &Scale,
             ),
             (
-                Or<(With<WorkcellVisualMarker>, With<WorkcellCollisionMarker>)>,
+                Or<(With<VisualMeshMarker>, With<CollisionMeshMarker>)>,
                 Without<Pending>,
             ),
         >,
-        Query<&WorkcellVisualMarker>,
-        Query<&WorkcellCollisionMarker>,
+        Query<&VisualMeshMarker>,
+        Query<&CollisionMeshMarker>,
         Query<&SiteID>,
         Query<&WorkcellProperties>,
         Query<&Parent>,

--- a/rmf_site_editor/src/workcell/urdf.rs
+++ b/rmf_site_editor/src/workcell/urdf.rs
@@ -18,9 +18,10 @@
 use bevy::prelude::*;
 use std::collections::{HashMap, HashSet};
 
+use crate::site::{CollisionMeshMarker, VisualMeshMarker};
+
 use rmf_site_format::{
-    Anchor, Angle, Category, Link, MeshPrimitive, Pose, Rotation, UrdfRoot,
-    WorkcellCollisionMarker, WorkcellModel, WorkcellVisualMarker,
+    Anchor, Angle, Category, Link, MeshPrimitive, Pose, Rotation, UrdfRoot, WorkcellModel,
 };
 
 use urdf_rs::JointType;
@@ -48,15 +49,14 @@ pub fn handle_new_urdf_roots(mut commands: Commands, new_urdfs: Query<(Entity, &
             root_links.insert(link_entity);
             for visual in &link.visual {
                 let model = WorkcellModel::from(visual);
-                let cmd = commands.spawn((SpatialBundle::VISIBLE_IDENTITY, WorkcellVisualMarker));
+                let cmd = commands.spawn((SpatialBundle::VISIBLE_IDENTITY, VisualMeshMarker));
                 let id = cmd.id();
                 model.add_bevy_components(cmd);
                 commands.entity(link_entity).add_child(id);
             }
             for collision in &link.collision {
                 let model = WorkcellModel::from(collision);
-                let cmd =
-                    commands.spawn((SpatialBundle::VISIBLE_IDENTITY, WorkcellCollisionMarker));
+                let cmd = commands.spawn((SpatialBundle::VISIBLE_IDENTITY, CollisionMeshMarker));
                 let id = cmd.id();
                 model.add_bevy_components(cmd);
                 commands.entity(link_entity).add_child(id);

--- a/rmf_site_format/src/workcell.rs
+++ b/rmf_site_format/src/workcell.rs
@@ -218,14 +218,6 @@ impl Default for Geometry {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "bevy", derive(Component))]
-pub struct WorkcellVisualMarker;
-
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "bevy", derive(Component))]
-pub struct WorkcellCollisionMarker;
-
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct WorkcellModel {
     pub name: String,
@@ -245,7 +237,6 @@ impl WorkcellModel {
                 ));
             }
             Geometry::Mesh { filename, scale } => {
-                println!("Setting pose of {:?} to {:?}", filename, self.pose);
                 let scale = Scale(scale.unwrap_or_default());
                 // TODO(luca) Make a bundle for workcell models to avoid manual insertion here
                 commands.insert((


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR adds support for collision meshes in sdf parsing and unifies the concept of site / workcell visual and collision to offer the same UX.

### Implementation description

Collisions were previously ignored when parsing SDF files. Now they will be parsed and spawned, although they will not be visualized by default.
Visualization can be toggled via the "View" menu on the top bar. I had to do a minor refactor of the `CategoryVisibility` plugin to allow disabled visualization on app initialization.
To simplify the UX and remove duplicated components I removed the `WorkcellVisualMarker` and `WorkcellCollisionMarker` to use a single marker component for both site and workcell projects.

### Test it!

Loading the demo world should look and feel the same. By clicking on the `View` menu you should be able to enable visualization of collision meshes (they usually look like greatly simplified version of the same mesh). All the rest of the features, at least for the site editor mode, should be unchanged.

[Screencast from 2023-08-22 16-40-52.webm](https://github.com/open-rmf/rmf_site/assets/9111558/f7d2008b-fb2a-443e-9292-43101352935e)