### PR TITLE
Use State::overwrite_set and log errors

### DIFF
--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -88,7 +88,7 @@ fn egui_ui(
                 // warehouse generator.
                 // if ui.button("Warehouse generator").clicked() {
                 //     info!("Entering warehouse generator");
-                //     _app_state.set(AppState::WarehouseGenerator).unwrap();
+                //     _app_state.overwrite_set(AppState::WarehouseGenerator).unwrap();
                 // }
             });
 

--- a/rmf_site_editor/src/site/drawing_editor/mod.rs
+++ b/rmf_site_editor/src/site/drawing_editor/mod.rs
@@ -141,7 +141,7 @@ fn switch_edit_drawing_mode(
                 error!("Cannot change transform of drawing editor view");
             }
 
-            if let Some(err) = app_state.set(AppState::SiteDrawingEditor).err() {
+            if let Some(err) = app_state.overwrite_set(AppState::SiteDrawingEditor).err() {
                 error!("Unable to switch to drawing editor mode: {err:?}");
             }
 
@@ -173,11 +173,11 @@ fn switch_edit_drawing_mode(
             }
 
             if is_site.contains(w) {
-                if let Some(err) = app_state.set(AppState::SiteEditor).err() {
+                if let Some(err) = app_state.overwrite_set(AppState::SiteEditor).err() {
                     error!("Failed to switch back to site editing mode: {err:?}");
                 }
             } else if is_workcell.contains(w) {
-                if let Some(err) = app_state.set(AppState::WorkcellEditor).err() {
+                if let Some(err) = app_state.overwrite_set(AppState::WorkcellEditor).err() {
                     error!("Failed to switch back to workcell editing mode: {err:?}");
                 }
             } else {
@@ -186,7 +186,7 @@ fn switch_edit_drawing_mode(
                     "Unable to identify the type for the current workspace \
                     {w:?}, so we will default to site editing mode",
                 );
-                if let Some(err) = app_state.set(AppState::SiteEditor).err() {
+                if let Some(err) = app_state.overwrite_set(AppState::SiteEditor).err() {
                     error!("Failed to switch back to site editing mode: {err:?}");
                 }
             }

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -367,7 +367,9 @@ pub fn load_site(
             change_current_site.send(ChangeCurrentSite { site, level: None });
 
             if *site_display_state.current() == SiteState::Off {
-                site_display_state.set(SiteState::Display).ok();
+                if let Err(err) = site_display_state.overwrite_set(SiteState::Display) {
+                    error!("Failed to turn the site display on: {err}");
+                }
             }
         }
     }

--- a/rmf_site_editor/src/site/site_visualizer/mod.rs
+++ b/rmf_site_editor/src/site/site_visualizer/mod.rs
@@ -77,12 +77,16 @@ fn update_level_elevation(
 
 fn disable_interaction(mut interaction_state: ResMut<State<InteractionState>>) {
     info!("Entering site visualizer");
-    interaction_state.set(InteractionState::Disable).ok();
+    if let Err(err) = interaction_state.overwrite_set(InteractionState::Disable) {
+        error!("Failed to disable interactions: {err}");
+    }
 }
 
 fn enable_interaction(mut interaction_state: ResMut<State<InteractionState>>) {
     info!("Exiting site visualizer");
-    interaction_state.set(InteractionState::Enable).ok();
+    if let Err(err) = interaction_state.overwrite_set(InteractionState::Enable) {
+        error!("Failed to enable interactions: {err}");
+    }
 }
 
 impl Plugin for SiteVisualizerPlugin {

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -373,7 +373,11 @@ fn site_ui_layout(
                                 ViewOccupancy::new(&mut events).show(ui);
                             });
                         if ui.add(Button::new("Building preview")).clicked() {
-                            events.app_state.set(AppState::SiteVisualizer).ok();
+                            if let Err(err) =
+                                events.app_state.overwrite_set(AppState::SiteVisualizer)
+                            {
+                                error!("Failed to switch to full site visualization: {err}");
+                            }
                         }
                     });
                 });
@@ -550,7 +554,9 @@ fn site_visualizer_ui_layout(
                             [18., 18.],
                             "Return to site editor"
                         )).clicked() {
-                            events.app_state.set(AppState::SiteEditor).ok();
+                            if let Err(err) = events.app_state.overwrite_set(AppState::SiteEditor) {
+                                error!("Failed to return to site editor: {err}");
+                            }
                         }
                     });
                 });

--- a/rmf_site_editor/src/workcell/load.rs
+++ b/rmf_site_editor/src/workcell/load.rs
@@ -156,7 +156,9 @@ pub fn load_workcell(
 
             // TODO(luca) get rid of SiteState
             if *site_display_state.current() == SiteState::Display {
-                site_display_state.set(SiteState::Off).ok();
+                if let Err(err) = site_display_state.overwrite_set(SiteState::Off) {
+                    error!("Failed to turn the site display off: {err}");
+                }
             }
         }
     }

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -240,13 +240,19 @@ fn handle_workspace_data(
                     match building.to_site() {
                         Ok(site) => {
                             // Switch state
-                            app_state.set(AppState::SiteEditor).ok();
+                            if let Err(err) = app_state.overwrite_set(AppState::SiteEditor) {
+                                error!("Failed to open the site edit mode: {err}");
+                            }
                             load_site.send(LoadSite {
                                 site,
                                 focus: true,
                                 default_file: file,
                             });
-                            interaction_state.set(InteractionState::Enable).ok();
+                            if let Err(err) =
+                                interaction_state.overwrite_set(InteractionState::Enable)
+                            {
+                                error!("Failed to turn on interaction: {err}");
+                            }
                         }
                         Err(err) => {
                             error!("Failed converting to site {:?}", err);
@@ -263,13 +269,17 @@ fn handle_workspace_data(
             match Site::from_bytes(&data) {
                 Ok(site) => {
                     // Switch state
-                    app_state.set(AppState::SiteEditor).ok();
+                    if let Err(err) = app_state.overwrite_set(AppState::SiteEditor) {
+                        error!("Failed to open the site edit mode: {err}");
+                    }
                     load_site.send(LoadSite {
                         site,
                         focus: true,
                         default_file: file,
                     });
-                    interaction_state.set(InteractionState::Enable).ok();
+                    if let Err(err) = interaction_state.overwrite_set(InteractionState::Enable) {
+                        error!("Failed to turn on interaction: {err}");
+                    }
                 }
                 Err(err) => {
                     error!("Failed loading site {:?}", err);
@@ -281,13 +291,17 @@ fn handle_workspace_data(
             match Workcell::from_bytes(&data) {
                 Ok(workcell) => {
                     // Switch state
-                    app_state.set(AppState::WorkcellEditor).ok();
+                    if let Err(err) = app_state.overwrite_set(AppState::WorkcellEditor) {
+                        error!("Failed to open the workcell edit mode: {err}");
+                    }
                     load_workcell.send(LoadWorkcell {
                         workcell,
                         focus: true,
                         default_file: file,
                     });
-                    interaction_state.set(InteractionState::Enable).ok();
+                    if let Err(err) = interaction_state.overwrite_set(InteractionState::Enable) {
+                        error!("Failed to turn on interaction: {err}");
+                    }
                 }
                 Err(err) => {
                     error!("Failed loading workcell {:?}", err);


### PR DESCRIPTION
When trying to launch a site directly from the command line, a race condition was causing a state to not change correctly. An easy fix for this is to always use `overwrite_set` instead of simply `set` for changing states. We don't make use of the queuing or stacking features of states so `overwrite_set` is what we should've been using in the first place.

This PR also adds logging for all the state change errors in case a different problem appears in the future.