### PR TITLE
Remove add_children uses

### DIFF
--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -46,7 +46,8 @@ pub fn add_anchor_visual_cues(
             _ => site_assets.site_anchor_mesh.clone(),
         };
 
-        let body = commands.spawn(PbrBundle {
+        let body = commands
+            .spawn(PbrBundle {
                 mesh: body_mesh,
                 material: site_assets.passive_anchor_material.clone(),
                 ..default()
@@ -54,7 +55,9 @@ pub fn add_anchor_visual_cues(
             .insert(Selectable::new(e))
             .id();
         if subordinate.is_none() {
-            commands.entity(body).insert(DragPlaneBundle::new(e, Vec3::Z));
+            commands
+                .entity(body)
+                .insert(DragPlaneBundle::new(e, Vec3::Z));
         }
 
         let mut entity_commands = commands.entity(e);

--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -46,25 +46,22 @@ pub fn add_anchor_visual_cues(
             _ => site_assets.site_anchor_mesh.clone(),
         };
 
-        let mut entity_commands = commands.entity(e);
-        let body = entity_commands.add_children(|parent| {
-            let mut body = parent.spawn(PbrBundle {
+        let body = commands.spawn(PbrBundle {
                 mesh: body_mesh,
                 material: site_assets.passive_anchor_material.clone(),
                 ..default()
-            });
-            body.insert(Selectable::new(e));
-            if subordinate.is_none() {
-                body.insert(DragPlaneBundle::new(e, Vec3::Z));
-            }
-            let body = body.id();
+            })
+            .insert(Selectable::new(e))
+            .id();
+        if subordinate.is_none() {
+            commands.entity(body).insert(DragPlaneBundle::new(e, Vec3::Z));
+        }
 
-            body
-        });
-
+        let mut entity_commands = commands.entity(e);
         entity_commands
             .insert(AnchorVisualization { body, drag: None })
-            .insert(OutlineVisualization::Anchor { body });
+            .insert(OutlineVisualization::Anchor { body })
+            .add_child(body);
 
         // 3D anchors should always be visible with arrow cue meshes
         if anchor.is_3D() {

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -82,6 +82,7 @@ impl InteractionAssets {
                 material: material_set.passive.clone(),
                 ..default()
             })
+            .set_parent(parent)
             .id();
 
         if let Some(for_entity) = for_entity_opt {
@@ -89,7 +90,6 @@ impl InteractionAssets {
                 .entity(child_entity)
                 .insert(DragAxisBundle::new(for_entity, Vec3::Z).with_materials(material_set));
         }
-        commands.entity(parent).add_child(child_entity);
         child_entity
     }
 
@@ -126,8 +126,8 @@ impl InteractionAssets {
         let drag_parent = commands
             .spawn(SpatialBundle::default())
             .insert(VisualCue::no_outline().irregular().always_xray())
+            .set_parent(anchor)
             .id();
-        commands.entity(anchor).add_child(drag_parent);
 
         let height = 0.0;
         let scale = 0.2;

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -73,7 +73,8 @@ impl InteractionAssets {
         rotation: Quat,
         scale: f32,
     ) -> Entity {
-        let child_entity = commands.spawn(PbrBundle {
+        let child_entity = commands
+            .spawn(PbrBundle {
                 transform: Transform::from_rotation(rotation)
                     .with_translation(offset)
                     .with_scale(Vec3::splat(scale)),
@@ -84,7 +85,8 @@ impl InteractionAssets {
             .id();
 
         if let Some(for_entity) = for_entity_opt {
-            commands.entity(child_entity) 
+            commands
+                .entity(child_entity)
                 .insert(DragAxisBundle::new(for_entity, Vec3::Z).with_materials(material_set));
         }
         commands.entity(parent).add_child(child_entity);

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -65,7 +65,7 @@ pub fn add_physical_light_visual_cues(
             headlight_toggle.0 = false;
         }
 
-        let point = commands 
+        let point = commands
             .spawn(SpatialBundle {
                 visibility: Visibility {
                     is_visible: kind.is_point(),

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -65,98 +65,95 @@ pub fn add_physical_light_visual_cues(
             headlight_toggle.0 = false;
         }
 
-        let bodies = commands
+        let point = commands 
+            .spawn(SpatialBundle {
+                visibility: Visibility {
+                    is_visible: kind.is_point(),
+                },
+                ..default()
+            })
+            .with_children(|point| {
+                point
+                    .spawn(PbrBundle {
+                        mesh: assets.point_light_socket_mesh.clone(),
+                        material: assets.physical_light_cover_material.clone(),
+                        ..default()
+                    })
+                    .insert(Selectable::new(e))
+                    .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
+
+                point
+                    .spawn(PbrBundle {
+                        mesh: assets.point_light_shine_mesh.clone(),
+                        material: light_material.clone(),
+                        ..default()
+                    })
+                    .insert(Selectable::new(e))
+                    .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
+            })
+            .id();
+
+        let spot = commands
+            .spawn(SpatialBundle {
+                visibility: Visibility {
+                    is_visible: kind.is_spot(),
+                },
+                ..default()
+            })
+            .with_children(|spot| {
+                spot.spawn(PbrBundle {
+                    mesh: assets.spot_light_cover_mesh.clone(),
+                    material: assets.physical_light_cover_material.clone(),
+                    ..default()
+                })
+                .insert(Selectable::new(e))
+                .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
+
+                spot.spawn(PbrBundle {
+                    mesh: assets.spot_light_shine_mesh.clone(),
+                    material: light_material.clone(),
+                    ..default()
+                })
+                .insert(Selectable::new(e))
+                .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
+            })
+            .id();
+
+        let directional = commands
+            .spawn(SpatialBundle {
+                visibility: Visibility {
+                    is_visible: kind.is_directional(),
+                },
+                ..default()
+            })
+            .with_children(|dir| {
+                dir.spawn(PbrBundle {
+                    mesh: assets.directional_light_cover_mesh.clone(),
+                    material: assets.direction_light_cover_material.clone(),
+                    ..default()
+                })
+                .insert(Selectable::new(e))
+                .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
+
+                dir.spawn(PbrBundle {
+                    mesh: assets.directional_light_shine_mesh.clone(),
+                    material: light_material.clone(),
+                    ..default()
+                })
+                .insert(Selectable::new(e))
+                .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
+            })
+            .id();
+
+        commands
             .entity(e)
             .insert(light_material.clone())
-            .add_children(|parent| {
-                let point = parent
-                    .spawn(SpatialBundle {
-                        visibility: Visibility {
-                            is_visible: kind.is_point(),
-                        },
-                        ..default()
-                    })
-                    .with_children(|point| {
-                        point
-                            .spawn(PbrBundle {
-                                mesh: assets.point_light_socket_mesh.clone(),
-                                material: assets.physical_light_cover_material.clone(),
-                                ..default()
-                            })
-                            .insert(Selectable::new(e))
-                            .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
-
-                        point
-                            .spawn(PbrBundle {
-                                mesh: assets.point_light_shine_mesh.clone(),
-                                material: light_material.clone(),
-                                ..default()
-                            })
-                            .insert(Selectable::new(e))
-                            .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
-                    })
-                    .id();
-
-                let spot = parent
-                    .spawn(SpatialBundle {
-                        visibility: Visibility {
-                            is_visible: kind.is_spot(),
-                        },
-                        ..default()
-                    })
-                    .with_children(|spot| {
-                        spot.spawn(PbrBundle {
-                            mesh: assets.spot_light_cover_mesh.clone(),
-                            material: assets.physical_light_cover_material.clone(),
-                            ..default()
-                        })
-                        .insert(Selectable::new(e))
-                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
-
-                        spot.spawn(PbrBundle {
-                            mesh: assets.spot_light_shine_mesh.clone(),
-                            material: light_material.clone(),
-                            ..default()
-                        })
-                        .insert(Selectable::new(e))
-                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
-                    })
-                    .id();
-
-                let directional = parent
-                    .spawn(SpatialBundle {
-                        visibility: Visibility {
-                            is_visible: kind.is_directional(),
-                        },
-                        ..default()
-                    })
-                    .with_children(|dir| {
-                        dir.spawn(PbrBundle {
-                            mesh: assets.directional_light_cover_mesh.clone(),
-                            material: assets.direction_light_cover_material.clone(),
-                            ..default()
-                        })
-                        .insert(Selectable::new(e))
-                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
-
-                        dir.spawn(PbrBundle {
-                            mesh: assets.directional_light_shine_mesh.clone(),
-                            material: light_material.clone(),
-                            ..default()
-                        })
-                        .insert(Selectable::new(e))
-                        .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
-                    })
-                    .id();
-
-                return LightBodies {
-                    point,
-                    spot,
-                    directional,
-                };
-            });
-
-        commands.entity(e).insert(bodies);
+            .insert(LightBodies {
+                point,
+                spot,
+                directional,
+            })
+            .push_children(&[point, spot, directional]);
     }
 }
 

--- a/rmf_site_editor/src/occupancy.rs
+++ b/rmf_site_editor/src/occupancy.rs
@@ -276,7 +276,7 @@ fn calculate_grid(
                 );
             }
 
-            commands.entity(level).add_children(|level| {
+            commands.entity(level).with_children(|level| {
                 level
                     .spawn(PbrBundle {
                         mesh: meshes.add(mesh.into()),

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -157,14 +157,14 @@ pub fn handle_loaded_drawing(
                     // We can ignore the layer height here since that update
                     // will be handled by another system.
                 } else {
-                    let mut cmd = commands.entity(entity);
-                    let leaf = cmd.add_children(|p| p.spawn_empty().id());
+                    let leaf = commands.spawn_empty().id();
 
-                    cmd.insert(DrawingSegments { leaf })
+                    commands.entity(entity).insert(DrawingSegments { leaf })
                         .insert(SpatialBundle::from_transform(pose.transform().with_scale(
                             Vec3::new(1.0 / pixels_per_meter.0, 1.0 / pixels_per_meter.0, 1.),
                         )))
-                        .insert(Selectable::new(entity));
+                        .insert(Selectable::new(entity))
+                        .push_children(&[leaf]);
                     leaf
                 };
                 let z = drawing_layer_height(rank);

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -159,7 +159,9 @@ pub fn handle_loaded_drawing(
                 } else {
                     let leaf = commands.spawn_empty().id();
 
-                    commands.entity(entity).insert(DrawingSegments { leaf })
+                    commands
+                        .entity(entity)
+                        .insert(DrawingSegments { leaf })
                         .insert(SpatialBundle::from_transform(pose.transform().with_scale(
                             Vec3::new(1.0 / pixels_per_meter.0, 1.0 / pixels_per_meter.0, 1.),
                         )))

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -241,8 +241,8 @@ pub fn add_floor_visuals(
             ..default()
         });
 
-        let mesh_entity_id = 
-            commands.spawn(PbrBundle {
+        let mesh_entity_id = commands
+            .spawn(PbrBundle {
                 mesh: meshes.add(mesh),
                 material,
                 ..default()
@@ -250,7 +250,8 @@ pub fn add_floor_visuals(
             .insert(Selectable::new(e))
             .id();
 
-        commands.entity(e)
+        commands
+            .entity(e)
             .insert(SpatialBundle {
                 transform: Transform::from_xyz(0.0, 0.0, height),
                 ..default()
@@ -261,7 +262,6 @@ pub fn add_floor_visuals(
             .insert(Category::Floor)
             .insert(PathBehavior::for_floor())
             .add_child(mesh_entity_id);
-
 
         for anchor in &new_floor.0 {
             let mut deps = dependents.get_mut(*anchor).unwrap();

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -125,18 +125,10 @@ pub fn add_lane_visuals(
                 transform: Transform::from_xyz(0.0, 0.0, height),
                 ..default()
             })
+            .set_parent(e)
             .id();
 
         let mut spawn_lane_mesh_and_outline = |lane_tf, lane_mesh, outline_mesh| {
-            let outline = commands
-                .spawn(PbrBundle {
-                    mesh: outline_mesh,
-                    transform: Transform::from_translation(-0.000_5 * Vec3::Z),
-                    visibility: Visibility { is_visible: false },
-                    ..default()
-                })
-                .id();
-
             let mesh = commands
                 .spawn(PbrBundle {
                     mesh: lane_mesh,
@@ -144,10 +136,19 @@ pub fn add_lane_visuals(
                     transform: lane_tf,
                     ..default()
                 })
-                .add_child(outline)
+                .set_parent(layer)
                 .id();
 
-            commands.entity(layer).add_child(mesh);
+            let outline = commands
+                .spawn(PbrBundle {
+                    mesh: outline_mesh,
+                    transform: Transform::from_translation(-0.000_5 * Vec3::Z),
+                    visibility: Visibility { is_visible: false },
+                    ..default()
+                })
+                .set_parent(mesh)
+                .id();
+
             (mesh, outline)
         };
 
@@ -184,8 +185,7 @@ pub fn add_lane_visuals(
                 ..default()
             })
             .insert(Category::Lane)
-            .insert(EdgeLabels::StartEnd)
-            .add_child(layer);
+            .insert(EdgeLabels::StartEnd);
     }
 }
 

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -120,27 +120,29 @@ pub fn add_lane_visuals(
 
         // Create a "layer" entity that manages the height of the lane,
         // determined by the DisplayHeight of the graph.
-        let layer = commands.spawn(SpatialBundle {
-            transform: Transform::from_xyz(0.0, 0.0, height),
-            ..default()
-        }).id();
-
-        let mut spawn_lane_mesh_and_outline = |lane_tf, lane_mesh, outline_mesh| 
-        {
-            let outline = commands
-                    .spawn(PbrBundle {
-                        mesh: outline_mesh,
-                        transform: Transform::from_translation(-0.000_5 * Vec3::Z),
-                        visibility: Visibility { is_visible: false },
-                        ..default()
-                    })
-                    .id();
-
-            let mesh = commands.spawn(PbrBundle {
-                mesh: lane_mesh,
-                material: lane_material.clone(),
-                transform: lane_tf,
+        let layer = commands
+            .spawn(SpatialBundle {
+                transform: Transform::from_xyz(0.0, 0.0, height),
                 ..default()
+            })
+            .id();
+
+        let mut spawn_lane_mesh_and_outline = |lane_tf, lane_mesh, outline_mesh| {
+            let outline = commands
+                .spawn(PbrBundle {
+                    mesh: outline_mesh,
+                    transform: Transform::from_translation(-0.000_5 * Vec3::Z),
+                    visibility: Visibility { is_visible: false },
+                    ..default()
+                })
+                .id();
+
+            let mesh = commands
+                .spawn(PbrBundle {
+                    mesh: lane_mesh,
+                    material: lane_material.clone(),
+                    transform: lane_tf,
+                    ..default()
                 })
                 .add_child(outline)
                 .id();
@@ -152,19 +154,23 @@ pub fn add_lane_visuals(
         let (start, start_outline) = spawn_lane_mesh_and_outline(
             Transform::from_translation(start_anchor),
             assets.lane_end_mesh.clone(),
-            assets.lane_end_outline.clone());
+            assets.lane_end_outline.clone(),
+        );
 
         let (mid, mid_outline) = spawn_lane_mesh_and_outline(
             line_stroke_transform(&start_anchor, &end_anchor, LANE_WIDTH),
             assets.lane_mid_mesh.clone(),
-            assets.lane_mid_outline.clone());
+            assets.lane_mid_outline.clone(),
+        );
 
         let (end, end_outline) = spawn_lane_mesh_and_outline(
             Transform::from_translation(end_anchor),
             assets.lane_end_mesh.clone(),
-            assets.lane_end_outline.clone());
-        
-        commands.entity(e)
+            assets.lane_end_outline.clone(),
+        );
+
+        commands
+            .entity(e)
             .insert(LaneSegments {
                 layer,
                 start,

--- a/rmf_site_editor/src/site/lift.rs
+++ b/rmf_site_editor/src/site/lift.rs
@@ -297,10 +297,14 @@ pub fn update_lift_cabin(
                 *cabin_anchor_groups.get_mut(group).unwrap() = cabin_tf;
             }
             None => {
-                let group = commands.spawn(SpatialBundle::from_transform(cabin_tf))
+                let group = commands
+                    .spawn(SpatialBundle::from_transform(cabin_tf))
                     .insert(CabinAnchorGroupBundle::default())
                     .id();
-                commands.entity(e).insert(ChildCabinAnchorGroup(group)).add_child(group);
+                commands
+                    .entity(e)
+                    .insert(ChildCabinAnchorGroup(group))
+                    .add_child(group);
             }
         };
     }

--- a/rmf_site_editor/src/site/lift.rs
+++ b/rmf_site_editor/src/site/lift.rs
@@ -297,12 +297,10 @@ pub fn update_lift_cabin(
                 *cabin_anchor_groups.get_mut(group).unwrap() = cabin_tf;
             }
             None => {
-                let group = commands.entity(e).add_children(|p| {
-                    p.spawn(SpatialBundle::from_transform(cabin_tf))
-                        .insert(CabinAnchorGroupBundle::default())
-                        .id()
-                });
-                commands.entity(e).insert(ChildCabinAnchorGroup(group));
+                let group = commands.spawn(SpatialBundle::from_transform(cabin_tf))
+                    .insert(CabinAnchorGroupBundle::default())
+                    .id();
+                commands.entity(e).insert(ChildCabinAnchorGroup(group)).add_child(group);
             }
         };
     }

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -76,7 +76,8 @@ fn generate_site_entities(
         }
     };
 
-    let site_id = commands.spawn(SpatialBundle::INVISIBLE_IDENTITY)
+    let site_id = commands
+        .spawn(SpatialBundle::INVISIBLE_IDENTITY)
         .insert(Category::Site)
         .insert(site_data.properties.clone())
         .insert(WorkspaceMarker)
@@ -147,11 +148,7 @@ fn generate_site_entities(
 
             for (fiducial_id, fiducial) in &drawing.fiducials {
                 let fiducial_entity = commands
-                    .spawn(
-                        fiducial
-                            .convert(&id_to_entity)
-                            .for_site(site_id)?,
-                    )
+                    .spawn(fiducial.convert(&id_to_entity).for_site(site_id)?)
                     .insert(SiteID(*fiducial_id))
                     .id();
                 consider_id(*fiducial_id);
@@ -160,15 +157,13 @@ fn generate_site_entities(
 
             for (measurement_id, measurement) in &drawing.measurements {
                 let measurement_entity = commands
-                    .spawn(
-                        measurement
-                            .convert(&id_to_entity)
-                            .for_site(site_id)?,
-                    )
+                    .spawn(measurement.convert(&id_to_entity).for_site(site_id)?)
                     .insert(SiteID(*measurement_id))
                     .id();
                 consider_id(*measurement_id);
-                commands.entity(drawing_entity).add_child(measurement_entity);
+                commands
+                    .entity(drawing_entity)
+                    .add_child(measurement_entity);
             }
 
             consider_id(*drawing_id);
@@ -192,7 +187,8 @@ fn generate_site_entities(
             commands.entity(level_entity).add_child(wall_entity);
         }
 
-        commands.entity(level_entity)
+        commands
+            .entity(level_entity)
             .insert(SpatialBundle::INVISIBLE_IDENTITY)
             .insert(level_data.properties.clone())
             .insert(Category::Level)
@@ -217,13 +213,11 @@ fn generate_site_entities(
             });
 
         // TODO(MXG): Log when a RecencyRanking fails to load correctly.
-        commands.entity(level_entity)
+        commands
+            .entity(level_entity)
             .insert(
-                RecencyRanking::<FloorMarker>::from_u32(
-                    &level_data.rankings.floors,
-                    &id_to_entity,
-                )
-                .unwrap_or(RecencyRanking::new()),
+                RecencyRanking::<FloorMarker>::from_u32(&level_data.rankings.floors, &id_to_entity)
+                    .unwrap_or(RecencyRanking::new()),
             )
             .insert(
                 RecencyRanking::<DrawingMarker>::from_u32(
@@ -265,14 +259,12 @@ fn generate_site_entities(
             commands.entity(lift_entity).add_child(door_entity);
         }
 
-        commands.entity(lift_entity)
-            .insert(Category::Lift)
-            .insert(
-                lift_data
-                    .properties
-                    .convert(&id_to_entity)
-                    .for_site(site_id)?,
-            );
+        commands.entity(lift_entity).insert(Category::Lift).insert(
+            lift_data
+                .properties
+                .convert(&id_to_entity)
+                .for_site(site_id)?,
+        );
 
         id_to_entity.insert(*lift_id, lift_entity);
         consider_id(*lift_id);
@@ -320,7 +312,6 @@ fn generate_site_entities(
         commands.entity(site_id).add_child(location);
     }
 
-
     let nav_graph_rankings = match RecencyRanking::<NavGraphMarker>::from_u32(
         &site_data.navigation.guided.ranking,
         &id_to_entity,
@@ -335,7 +326,8 @@ fn generate_site_entities(
         }
     };
 
-    commands.entity(site_id)
+    commands
+        .entity(site_id)
         .insert(nav_graph_rankings)
         .insert(NextSiteID(highest_id + 1));
 

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -87,104 +87,109 @@ fn generate_site_entities(
         let anchor_entity = commands
             .spawn(AnchorBundle::new(anchor.clone()))
             .insert(SiteID(*anchor_id))
+            .set_parent(site_id)
             .id();
         id_to_entity.insert(*anchor_id, anchor_entity);
         consider_id(*anchor_id);
-        commands.entity(site_id).add_child(anchor_entity);
     }
 
     for (group_id, group) in &site_data.fiducial_groups {
-        let group_entity = commands.spawn(group.clone()).insert(SiteID(*group_id)).id();
+        let group_entity = commands
+            .spawn(group.clone())
+            .insert(SiteID(*group_id))
+            .set_parent(site_id)
+            .id();
         id_to_entity.insert(*group_id, group_entity);
         consider_id(*group_id);
-        commands.entity(site_id).add_child(group_entity);
     }
 
     for (group_id, group) in &site_data.textures {
-        let group_entity = commands.spawn(group.clone()).insert(SiteID(*group_id)).id();
+        let group_entity = commands
+            .spawn(group.clone())
+            .insert(SiteID(*group_id))
+            .set_parent(site_id)
+            .id();
         id_to_entity.insert(*group_id, group_entity);
         consider_id(*group_id);
-        commands.entity(site_id).add_child(group_entity);
     }
 
     for (level_id, level_data) in &site_data.levels {
-        let level_entity = commands.spawn(SiteID(*level_id)).id();
+        let level_entity = commands.spawn(SiteID(*level_id)).set_parent(site_id).id();
 
         for (anchor_id, anchor) in &level_data.anchors {
             let anchor_entity = commands
                 .spawn(AnchorBundle::new(anchor.clone()))
                 .insert(SiteID(*anchor_id))
+                .set_parent(level_entity)
                 .id();
             id_to_entity.insert(*anchor_id, anchor_entity);
             consider_id(*anchor_id);
-            commands.entity(level_entity).add_child(anchor_entity);
         }
 
         for (door_id, door) in &level_data.doors {
             let door_entity = commands
                 .spawn(door.convert(&id_to_entity).for_site(site_id)?)
                 .insert(SiteID(*door_id))
+                .set_parent(level_entity)
                 .id();
             id_to_entity.insert(*door_id, door_entity);
             consider_id(*door_id);
-            commands.entity(level_entity).add_child(door_entity);
         }
 
         for (drawing_id, drawing) in &level_data.drawings {
             let drawing_entity = commands
                 .spawn(DrawingBundle::new(drawing.properties.clone()))
                 .insert(SiteID(*drawing_id))
+                .set_parent(level_entity)
                 .id();
 
             for (anchor_id, anchor) in &drawing.anchors {
                 let anchor_entity = commands
                     .spawn(AnchorBundle::new(anchor.clone()))
                     .insert(SiteID(*anchor_id))
+                    .set_parent(drawing_entity)
                     .id();
                 id_to_entity.insert(*anchor_id, anchor_entity);
                 consider_id(*anchor_id);
-                commands.entity(drawing_entity).add_child(anchor_entity);
             }
 
             for (fiducial_id, fiducial) in &drawing.fiducials {
-                let fiducial_entity = commands
+                commands
                     .spawn(fiducial.convert(&id_to_entity).for_site(site_id)?)
                     .insert(SiteID(*fiducial_id))
+                    .set_parent(drawing_entity)
                     .id();
                 consider_id(*fiducial_id);
-                commands.entity(drawing_entity).add_child(fiducial_entity);
             }
 
             for (measurement_id, measurement) in &drawing.measurements {
-                let measurement_entity = commands
+                commands
                     .spawn(measurement.convert(&id_to_entity).for_site(site_id)?)
                     .insert(SiteID(*measurement_id))
+                    .set_parent(drawing_entity)
                     .id();
                 consider_id(*measurement_id);
-                commands
-                    .entity(drawing_entity)
-                    .add_child(measurement_entity);
             }
 
             consider_id(*drawing_id);
         }
 
         for (floor_id, floor) in &level_data.floors {
-            let floor_entity = commands
+            commands
                 .spawn(floor.convert(&id_to_entity).for_site(site_id)?)
                 .insert(SiteID(*floor_id))
+                .set_parent(level_entity)
                 .id();
             consider_id(*floor_id);
-            commands.entity(level_entity).add_child(floor_entity);
         }
 
         for (wall_id, wall) in &level_data.walls {
-            let wall_entity = commands
+            commands
                 .spawn(wall.convert(&id_to_entity).for_site(site_id)?)
                 .insert(SiteID(*wall_id))
+                .set_parent(level_entity)
                 .id();
             consider_id(*wall_id);
-            commands.entity(level_entity).add_child(wall_entity);
         }
 
         commands
@@ -228,11 +233,10 @@ fn generate_site_entities(
             );
         id_to_entity.insert(*level_id, level_entity);
         consider_id(*level_id);
-        commands.entity(site_id).add_child(level_entity);
     }
 
     for (lift_id, lift_data) in &site_data.lifts {
-        let lift_entity = commands.spawn(SiteID(*lift_id)).id();
+        let lift_entity = commands.spawn(SiteID(*lift_id)).set_parent(site_id).id();
 
         commands.entity(lift_entity).with_children(|lift| {
             lift.spawn(SpatialBundle::default())
@@ -253,10 +257,10 @@ fn generate_site_entities(
             let door_entity = commands
                 .spawn(door.convert(&id_to_entity).for_site(site_id)?)
                 .insert(Dependents::single(lift_entity))
+                .set_parent(lift_entity)
                 .id();
             id_to_entity.insert(*door_id, door_entity);
             consider_id(*door_id);
-            commands.entity(lift_entity).add_child(door_entity);
         }
 
         commands.entity(lift_entity).insert(Category::Lift).insert(
@@ -268,17 +272,16 @@ fn generate_site_entities(
 
         id_to_entity.insert(*lift_id, lift_entity);
         consider_id(*lift_id);
-        commands.entity(site_id).add_child(lift_entity);
     }
 
     for (fiducial_id, fiducial) in &site_data.fiducials {
         let fiducial_entity = commands
             .spawn(fiducial.convert(&id_to_entity).for_site(site_id)?)
             .insert(SiteID(*fiducial_id))
+            .set_parent(site_id)
             .id();
         id_to_entity.insert(*fiducial_id, fiducial_entity);
         consider_id(*fiducial_id);
-        commands.entity(site_id).add_child(fiducial_entity);
     }
 
     for (nav_graph_id, nav_graph_data) in &site_data.navigation.guided.graphs {
@@ -286,30 +289,30 @@ fn generate_site_entities(
             .spawn(SpatialBundle::default())
             .insert(nav_graph_data.clone())
             .insert(SiteID(*nav_graph_id))
+            .set_parent(site_id)
             .id();
         id_to_entity.insert(*nav_graph_id, nav_graph);
         consider_id(*nav_graph_id);
-        commands.entity(site_id).add_child(nav_graph);
     }
 
     for (lane_id, lane_data) in &site_data.navigation.guided.lanes {
         let lane = commands
             .spawn(lane_data.convert(&id_to_entity).for_site(site_id)?)
             .insert(SiteID(*lane_id))
+            .set_parent(site_id)
             .id();
         id_to_entity.insert(*lane_id, lane);
         consider_id(*lane_id);
-        commands.entity(site_id).add_child(lane);
     }
 
     for (location_id, location_data) in &site_data.navigation.guided.locations {
         let location = commands
             .spawn(location_data.convert(&id_to_entity).for_site(site_id)?)
             .insert(SiteID(*location_id))
+            .set_parent(site_id)
             .id();
         id_to_entity.insert(*location_id, location);
         consider_id(*location_id);
-        commands.entity(site_id).add_child(location);
     }
 
     let nav_graph_rankings = match RecencyRanking::<NavGraphMarker>::from_u32(

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -108,53 +108,58 @@ pub fn handle_model_loaded_events(
                     .as_ref()
                     .map(|s| s.clone())
                     .unwrap_or(gltf.scenes.get(0).unwrap().clone());
-                let scene_id = commands
-                    .spawn(SceneBundle {
-                        scene,
-                        transform: Transform::from_scale(**scale),
-                        ..default()
-                    })
-                    .id();
-                commands.entity(e).add_child(scene_id);
-                Some(scene_id)
+                Some(
+                    commands
+                        .spawn(SceneBundle {
+                            scene,
+                            transform: Transform::from_scale(**scale),
+                            ..default()
+                        })
+                        .set_parent(e)
+                        .id(),
+                )
             } else if scenes.contains(&h.typed_weak::<Scene>()) {
                 let h_typed = h.0.clone().typed::<Scene>();
-                let scene_id = commands
-                    .spawn(SceneBundle {
-                        scene: h_typed,
-                        transform: Transform::from_scale(**scale),
-                        ..default()
-                    })
-                    .id();
-                commands.entity(e).add_child(scene_id);
-                Some(scene_id)
+                Some(
+                    commands
+                        .spawn(SceneBundle {
+                            scene: h_typed,
+                            transform: Transform::from_scale(**scale),
+                            ..default()
+                        })
+                        .set_parent(e)
+                        .id(),
+                )
             } else if meshes.contains(&h.typed_weak::<Mesh>()) {
                 let h_typed = h.0.clone().typed::<Mesh>();
-                let mesh_id = commands
-                    .spawn(PbrBundle {
-                        mesh: h_typed,
-                        material: site_assets.default_mesh_grey_material.clone(),
-                        transform: Transform::from_scale(**scale),
-                        ..default()
-                    })
-                    .id();
-                commands.entity(e).add_child(mesh_id);
-                Some(mesh_id)
+                Some(
+                    commands
+                        .spawn(PbrBundle {
+                            mesh: h_typed,
+                            material: site_assets.default_mesh_grey_material.clone(),
+                            transform: Transform::from_scale(**scale),
+                            ..default()
+                        })
+                        .set_parent(e)
+                        .id(),
+                )
             } else if let Some(urdf) = urdfs.get(&h.typed_weak::<UrdfRoot>()) {
-                let urdf_id = commands
-                    .spawn(SpatialBundle::VISIBLE_IDENTITY)
-                    .insert(urdf.clone())
-                    .insert(Category::Workcell)
-                    .id();
-                commands.entity(e).add_child(urdf_id);
-                Some(urdf_id)
+                Some(
+                    commands
+                        .spawn(SpatialBundle::VISIBLE_IDENTITY)
+                        .insert(urdf.clone())
+                        .insert(Category::Workcell)
+                        .set_parent(e)
+                        .id(),
+                )
             } else if let Some(sdf) = sdfs.get(&h.typed_weak::<SdfRoot>()) {
-                let sdf_id = commands
-                    .spawn(SpatialBundle::VISIBLE_IDENTITY)
-                    .insert(sdf.clone())
-                    .id();
-                commands.entity(e).add_child(sdf_id);
-                Some(sdf_id)
+                Some(
+                    commands
+                        .spawn(SpatialBundle::VISIBLE_IDENTITY)
+                        .insert(sdf.clone())
+                        .set_parent(e)
+                        .id(),
+                )
             } else {
                 None
             };

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -102,59 +102,59 @@ pub fn handle_model_loaded_events(
     for (e, h, scale, render_layer) in loading_models.iter() {
         if asset_server.get_load_state(&h.0) == LoadState::Loaded {
             let model_id = if let Some(gltf) = gltfs.get(&h.typed_weak::<Gltf>()) {
-                Some(commands.entity(e).add_children(|parent| {
-                    // Get default scene if present, otherwise index 0
-                    let scene = gltf
-                        .default_scene
-                        .as_ref()
-                        .map(|s| s.clone())
-                        .unwrap_or(gltf.scenes.get(0).unwrap().clone());
-                    parent
-                        .spawn(SceneBundle {
-                            scene,
-                            transform: Transform::from_scale(**scale),
-                            ..default()
-                        })
-                        .id()
-                }))
+                // Get default scene if present, otherwise index 0
+                let scene = gltf
+                    .default_scene
+                    .as_ref()
+                    .map(|s| s.clone())
+                    .unwrap_or(gltf.scenes.get(0).unwrap().clone());
+                let scene_id = commands
+                    .spawn(SceneBundle {
+                        scene,
+                        transform: Transform::from_scale(**scale),
+                        ..default()
+                    })
+                    .id();
+                commands.entity(e).add_child(scene_id);
+                Some(scene_id)
             } else if scenes.contains(&h.typed_weak::<Scene>()) {
-                Some(commands.entity(e).add_children(|parent| {
-                    let h_typed = h.0.clone().typed::<Scene>();
-                    parent
-                        .spawn(SceneBundle {
-                            scene: h_typed,
-                            transform: Transform::from_scale(**scale),
-                            ..default()
-                        })
-                        .id()
-                }))
+                let h_typed = h.0.clone().typed::<Scene>();
+                let scene_id = commands
+                    .spawn(SceneBundle {
+                        scene: h_typed,
+                        transform: Transform::from_scale(**scale),
+                        ..default()
+                    })
+                    .id();
+                commands.entity(e).add_child(scene_id);
+                Some(scene_id)
             } else if meshes.contains(&h.typed_weak::<Mesh>()) {
-                Some(commands.entity(e).add_children(|parent| {
-                    let h_typed = h.0.clone().typed::<Mesh>();
-                    parent
-                        .spawn(PbrBundle {
-                            mesh: h_typed,
-                            material: site_assets.default_mesh_grey_material.clone(),
-                            transform: Transform::from_scale(**scale),
-                            ..default()
-                        })
-                        .id()
-                }))
+                let h_typed = h.0.clone().typed::<Mesh>();
+                let mesh_id = commands
+                    .spawn(PbrBundle {
+                        mesh: h_typed,
+                        material: site_assets.default_mesh_grey_material.clone(),
+                        transform: Transform::from_scale(**scale),
+                        ..default()
+                    })
+                    .id();
+                commands.entity(e).add_child(mesh_id);
+                Some(mesh_id)
             } else if let Some(urdf) = urdfs.get(&h.typed_weak::<UrdfRoot>()) {
-                Some(commands.entity(e).add_children(|parent| {
-                    parent
-                        .spawn(SpatialBundle::VISIBLE_IDENTITY)
-                        .insert(urdf.clone())
-                        .insert(Category::Workcell)
-                        .id()
-                }))
+                let urdf_id = commands
+                    .spawn(SpatialBundle::VISIBLE_IDENTITY)
+                    .insert(urdf.clone())
+                    .insert(Category::Workcell)
+                    .id();
+                commands.entity(e).add_child(urdf_id);
+                Some(urdf_id)
             } else if let Some(sdf) = sdfs.get(&h.typed_weak::<SdfRoot>()) {
-                Some(commands.entity(e).add_children(|parent| {
-                    parent
-                        .spawn(SpatialBundle::VISIBLE_IDENTITY)
-                        .insert(sdf.clone())
-                        .id()
-                }))
+                let sdf_id = commands
+                    .spawn(SpatialBundle::VISIBLE_IDENTITY)
+                    .insert(sdf.clone())
+                    .id();
+                commands.entity(e).add_child(sdf_id);
+                Some(sdf_id)
             } else {
                 None
             };

--- a/rmf_site_editor/src/site/site.rs
+++ b/rmf_site_editor/src/site/site.rs
@@ -116,7 +116,8 @@ pub fn change_site(
 
                     if !found_level {
                         // Create a new blank level for the user
-                        let new_level = commands.spawn(SpatialBundle::default())
+                        let new_level = commands
+                            .spawn(SpatialBundle::default())
                             .insert(LevelProperties {
                                 name: NameInSite("<unnamed level>".to_owned()),
                                 elevation: LevelElevation(0.),
@@ -125,7 +126,10 @@ pub fn change_site(
                             })
                             .id();
 
-                        commands.entity(cmd.site).insert(CachedLevel(new_level)).add_child(new_level);
+                        commands
+                            .entity(cmd.site)
+                            .insert(CachedLevel(new_level))
+                            .add_child(new_level);
                         current_level.0 = Some(new_level);
                     }
                 }

--- a/rmf_site_editor/src/site/site.rs
+++ b/rmf_site_editor/src/site/site.rs
@@ -124,12 +124,10 @@ pub fn change_site(
                                 global_floor_visibility: default(),
                                 global_drawing_visibility: default(),
                             })
+                            .set_parent(cmd.site)
                             .id();
 
-                        commands
-                            .entity(cmd.site)
-                            .insert(CachedLevel(new_level))
-                            .add_child(new_level);
+                        commands.entity(cmd.site).insert(CachedLevel(new_level));
                         current_level.0 = Some(new_level);
                     }
                 }

--- a/rmf_site_editor/src/site/site.rs
+++ b/rmf_site_editor/src/site/site.rs
@@ -116,18 +116,16 @@ pub fn change_site(
 
                     if !found_level {
                         // Create a new blank level for the user
-                        let new_level = commands.entity(cmd.site).add_children(|site| {
-                            site.spawn(SpatialBundle::default())
-                                .insert(LevelProperties {
-                                    name: NameInSite("<unnamed level>".to_owned()),
-                                    elevation: LevelElevation(0.),
-                                    global_floor_visibility: default(),
-                                    global_drawing_visibility: default(),
-                                })
-                                .id()
-                        });
+                        let new_level = commands.spawn(SpatialBundle::default())
+                            .insert(LevelProperties {
+                                name: NameInSite("<unnamed level>".to_owned()),
+                                elevation: LevelElevation(0.),
+                                global_floor_visibility: default(),
+                                global_drawing_visibility: default(),
+                            })
+                            .id();
 
-                        commands.entity(cmd.site).insert(CachedLevel(new_level));
+                        commands.entity(cmd.site).insert(CachedLevel(new_level)).add_child(new_level);
                         current_level.0 = Some(new_level);
                     }
                 }

--- a/rmf_site_editor/src/workcell/workcell.rs
+++ b/rmf_site_editor/src/workcell/workcell.rs
@@ -56,7 +56,7 @@ pub fn add_workcell_visualization(
     for e in new_workcells.iter() {
         let body_mesh = site_assets.site_anchor_mesh.clone();
         let mut entity_commands = commands.entity(e);
-        entity_commands.add_children(|parent| {
+        entity_commands.with_children(|parent| {
             let mut body = parent.spawn(PbrBundle {
                 mesh: body_mesh,
                 material: site_assets.passive_anchor_material.clone(),


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Remove all uses of `add_children` throughout the codebase.

### Implementation description

In preparation for the upgrade to bevy 0.11, the add_children function was [removed](https://github.com/bevyengine/bevy/pull/6942). This PR refactors the code to remove all uses to make migration easier without breaking the code (yet!). Two main cases were encountered:

* Cases in which the return value was actually ignored, a simple `add_children` -> `with_children` change works.
* Cases in which the return value was used, usually to spawn entities and return their id, remove the `add_children`, spawn all the entities and manually add them through either `add_child` or `set_parent`, depending on the case.