### PR TITLE
Make georeference menus only show in site editor state

### DIFF
--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -13,7 +13,7 @@ use crate::{
     generate_map_tiles,
     interaction::{camera_controls, MoveTo, Selected},
     widgets::menu_bar::{
-        Menu, MenuDisabled, MenuEvent, MenuItem, MenuVisualizationConstraint, ToolMenu, ViewMenu,
+        Menu, MenuDisabled, MenuEvent, MenuItem, MenuVisualizationStates, ToolMenu, ViewMenu,
     },
     workspace::CurrentWorkspace,
     AppState, OSMTile,
@@ -544,35 +544,28 @@ pub struct OSMMenu {
 impl FromWorld for OSMMenu {
     fn from_world(world: &mut World) -> Self {
         // Only show the menu in site editor modes
-        let visualization_constraint = |state: &AppState| match state {
-            AppState::SiteEditor | AppState::SiteDrawingEditor | AppState::SiteVisualizer => true,
-            AppState::MainMenu | AppState::WorkcellEditor => false,
-        };
+        let target_states = MenuVisualizationStates(HashSet::from([
+            AppState::SiteEditor,
+            AppState::SiteDrawingEditor,
+            AppState::SiteVisualizer,
+        ]));
         // Tools menu
         let set_reference = world
             .spawn(MenuItem::Text("Set Reference".to_string()))
-            .insert(MenuVisualizationConstraint(Box::new(
-                visualization_constraint,
-            )))
+            .insert(target_states.clone())
             .id();
         let view_reference = world
             .spawn(MenuItem::Text("View Reference".to_string()))
-            .insert(MenuVisualizationConstraint(Box::new(
-                visualization_constraint,
-            )))
+            .insert(target_states.clone())
             .id();
         let settings_reference = world
             .spawn(MenuItem::Text("Settings".to_string()))
-            .insert(MenuVisualizationConstraint(Box::new(
-                visualization_constraint,
-            )))
+            .insert(target_states.clone())
             .id();
 
         let sub_menu = world
             .spawn(Menu::from_title("Geographic Offset".to_string()))
-            .insert(MenuVisualizationConstraint(Box::new(
-                visualization_constraint,
-            )))
+            .insert(target_states.clone())
             .id();
         world.entity_mut(sub_menu).push_children(&[
             set_reference,
@@ -587,9 +580,7 @@ impl FromWorld for OSMMenu {
         let view_header = world.resource::<ViewMenu>().get();
         let satellite_map_check_button = world
             .spawn(MenuItem::CheckBox("Satellite Map".to_string(), false))
-            .insert(MenuVisualizationConstraint(Box::new(
-                visualization_constraint,
-            )))
+            .insert(target_states.clone())
             .id();
         world
             .entity_mut(view_header)

--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -544,7 +544,7 @@ pub struct OSMMenu {
 impl FromWorld for OSMMenu {
     fn from_world(world: &mut World) -> Self {
         // Only show the menu in site editor modes
-        let visualization_constraint = |state: &State<AppState>| match state.get() {
+        let visualization_constraint = |state: &AppState| match state {
             AppState::SiteEditor | AppState::SiteDrawingEditor | AppState::SiteVisualizer => true,
             AppState::MainMenu | AppState::WorkcellEditor => false,
         };

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -57,7 +57,7 @@ pub enum MenuItem {
 }
 
 #[derive(Component, Deref, DerefMut)]
-pub struct MenuVisualizationConstraint(pub Box<dyn Fn(&State<AppState>) -> bool + Send + Sync>);
+pub struct MenuVisualizationConstraint(pub Box<dyn Fn(&AppState) -> bool + Send + Sync>);
 
 /// This resource provides the root entity for the file menu
 #[derive(Resource)]
@@ -173,7 +173,7 @@ fn render_sub_menu(
     skip_top_label: bool,
 ) {
     if let Some(constraint) = menu_constraints.get(*entity).ok().flatten() {
-        if !(constraint.0)(state) {
+        if !(constraint.0)(state.get()) {
             return;
         }
     }

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -184,13 +184,13 @@ fn render_sub_menu(
         // Draw ui
         match e {
             MenuItem::Text(title) => {
-                if ui.add_enabled(disabled, Button::new(title)).clicked() {
+                if ui.add_enabled(!disabled, Button::new(title)).clicked() {
                     extension_events.send(MenuEvent::MenuClickEvent(*entity));
                 }
             }
             MenuItem::CheckBox(title, mut value) => {
                 if ui
-                    .add_enabled(disabled, egui::Checkbox::new(&mut value, title))
+                    .add_enabled(!disabled, egui::Checkbox::new(&mut value, title))
                     .clicked()
                 {
                     extension_events.send(MenuEvent::MenuClickEvent(*entity));

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     AppState, CreateNewWorkspace, CurrentWorkspace, LoadWorkspace, SaveWorkspace,
     ValidateWorkspace,
 };
-use bevy::{ecs::system::SystemParam, prelude::*};
+use bevy::{ecs::query::Has, ecs::system::SystemParam, prelude::*};
 use bevy_egui::{
     egui::{self, Button, CollapsingHeader},
     EguiContexts,
@@ -271,8 +271,10 @@ pub struct VisibilityParameters<'w> {
 
 #[derive(SystemParam)]
 pub struct MenuParams<'w, 's> {
+    state: Res<'w, State<AppState>>,
     menus: Query<'w, 's, (&'static Menu, Entity)>,
-    menu_items: Query<'w, 's, (&'static mut MenuItem, Option<&'static MenuDisabled>)>,
+    menu_items: Query<'w, 's, (&'static mut MenuItem, Has<MenuDisabled>)>,
+    menu_constraints: Query<'w, 's, Option<&'static MenuVisualizationConstraint>>,
     extension_events: EventWriter<'w, MenuEvent>,
     view_menu: Res<'w, ViewMenu>,
 }

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -274,7 +274,7 @@ pub struct MenuParams<'w, 's> {
     state: Res<'w, State<AppState>>,
     menus: Query<'w, 's, (&'static Menu, Entity)>,
     menu_items: Query<'w, 's, (&'static mut MenuItem, Has<MenuDisabled>)>,
-    menu_constraints: Query<'w, 's, Option<&'static MenuVisualizationConstraint>>,
+    menu_states: Query<'w, 's, Option<&'static MenuVisualizationStates>>,
     extension_events: EventWriter<'w, MenuEvent>,
     view_menu: Res<'w, ViewMenu>,
 }


### PR DESCRIPTION
## Bug fix

### Fixed bug

Simple fix for a part of #188 (targeting specifically the georeference menus). If it looks good I'll port it to the rest of UI (i.e. `View` menu).

### Fix applied

This PR changes the georeference systems to only run when the app is in the `SiteEditor` state, as well as adds systems that are triggered when entering / exiting the state that spawn / despawn the submenus and insert / delete the tracking resource.
Happy to achieve a similar effect another way but we should have ways to only show menus in specific states.