### PR TITLE
Fix the way the site editor resizes on the web

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Make sure you install rust from the main rust website. Cargo should take care of
 These are only needed if you're going to build a WebAssembly binary:
 ```bash
 $ sudo apt install binaryen
-$ cargo install --version 0.2.84 wasm-bindgen-cli
-$ cargo install basic-http-server
+$ cargo install wasm-bindgen-cli@0.2.84 basic-http-server
 $ rustup target add wasm32-unknown-unknown
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Make sure you install rust from the main rust website. Cargo should take care of
 These are only needed if you're going to build a WebAssembly binary:
 ```bash
 $ sudo apt install binaryen
-$ cargo install wasm-bindgen-cli basic-http-server
+$ cargo install --version 0.2.84 wasm-bindgen-cli
+$ cargo install basic-http-server
 $ rustup target add wasm32-unknown-unknown
 ```
 

--- a/web/index.html
+++ b/web/index.html
@@ -17,24 +17,13 @@
 </head>
 <body>
 <canvas id="rmf_site_editor_canvas">
+  <script type="module">
+    import init from "./librmf_site_editor.js";
+    document.addEventListener('contextmenu', function(evt) { evt.preventDefault(); });
+    init("./librmf_site_editor_bg_optimized.wasm").then(function (wasm) {
+      wasm.run_js();
+    });
+  </script>
 </canvas>
-<script type="module">
-  import init from "./librmf_site_editor.js";
-
-  document.addEventListener('contextmenu', function(evt) { evt.preventDefault(); });
-  resize_canvas();
-  window.addEventListener('resize', resize_canvas);
-
-  function resize_canvas() {
-    let canvas = document.getElementById("rmf_site_editor_canvas");
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-    console.log('canvas size: ' + canvas.width + ' ' + canvas.height);
-  }
-
-  init("./librmf_site_editor_bg_optimized.wasm").then(function (wasm) {
-    wasm.run_js();
-  });
-</script>
 </body>
 </html>


### PR DESCRIPTION
I'm not sure why the `resize_canvas` function was written, but it hasn't been working correctly in a long time, and I just discovered that if we simply remove it, the canvas will rescale itself correctly on its own.

I'm also recommending people install specifically version 0.2.84 of wasm-bindgen-cli or else there will be errors generating the JavaScript bindings.