### PR TITLE
Add a few more properties to legacy navgraphs

### DIFF
--- a/rmf_site_format/src/legacy/nav_graph.rs
+++ b/rmf_site_format/src/legacy/nav_graph.rs
@@ -12,7 +12,7 @@ pub struct NavGraph {
 
 // Readapted from legacy traffic editor implementation
 fn segments_intersect(p1: [f32; 2], p2: [f32; 2], p3: [f32; 2], p4: [f32; 2]) -> bool {
-    // line segments are (x1,y1),(x2,y2) and (x3,y3),(x4,y4)
+    // line segments are [p1-p2] and [p3-p4]
     let [x1, y1] = p1;
     let [x2, y2] = p2;
     let [x3, y3] = p3;
@@ -164,6 +164,7 @@ impl NavGraph {
                     println!("ERROR: Skipping lift {lift_name} due to rotation not being pure yaw");
                     continue;
                 };
+                // TODO(luca) check that the lift position is correct when doing end to end testing
                 match &lift.properties.cabin {
                     LiftCabin::Rect(params) => {
                         lifts.insert(
@@ -176,7 +177,7 @@ impl NavGraph {
                         );
                     }
                 }
-                // TODO(luca) lift property for vertices
+                // TODO(luca) lift property for vertices contained in lifts
             }
 
             graphs.push((
@@ -211,8 +212,10 @@ pub struct NavLaneProperties {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub door_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub orientation_constraint: Option<String>, // TODO(MXG): Add other lane properties
-                                                // demo_mock_floor_name
+    pub orientation_constraint: Option<String>,
+    // TODO(luca): Add other lane properties
+    // demo_mock_floor_name
+    // mutex
 }
 
 impl NavLaneProperties {
@@ -250,6 +253,7 @@ impl NavVertex {
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct NavVertexProperties {
+    // TODO(luca) serialize lift and merge_radius, they are currently skipped
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lift: Option<String>,
     #[serde(skip_serializing_if = "is_false")]

--- a/rmf_site_format/src/legacy/nav_graph.rs
+++ b/rmf_site_format/src/legacy/nav_graph.rs
@@ -257,7 +257,7 @@ impl NavLaneProperties {
             OrientationConstraint::Forwards => Some("forward".to_owned()),
             OrientationConstraint::Backwards => Some("backward".to_owned()),
             OrientationConstraint::RelativeYaw(_) | OrientationConstraint::AbsoluteYaw(_) => {
-                println!(
+                eprintln!(
                     "Skipping orientation constraint [{:?}] because of incompatibility",
                     motion.orientation_constraint
                 );

--- a/rmf_site_format/src/legacy/nav_graph.rs
+++ b/rmf_site_format/src/legacy/nav_graph.rs
@@ -46,13 +46,14 @@ impl NavGraph {
             };
 
             let lanes_with_anchor = {
-                let mut lanes_with_anchor = HashMap::new();
+                let mut lanes_with_anchor: HashMap<u32, Vec<u32>> = HashMap::new();
                 for (lane_id, lane) in &site.navigation.guided.lanes {
                     if !lane.graphs.includes(graph_id) {
                         continue;
                     }
                     for a in lane.anchors.array() {
-                        lanes_with_anchor.insert(a, (*lane_id, lane));
+                        let entry = lanes_with_anchor.entry(a).or_default();
+                        entry.push(*lane_id);
                     }
                 }
                 lanes_with_anchor
@@ -67,12 +68,14 @@ impl NavGraph {
                 let mut vertices = Vec::new();
                 let mut lanes_to_include = HashSet::new();
                 for (id, anchor) in &level.anchors {
-                    let (lane, _) = match lanes_with_anchor.get(id) {
-                        Some(v) => v,
-                        None => continue,
+                    let Some(lanes) = lanes_with_anchor.get(id) else {
+                        continue;
                     };
 
-                    lanes_to_include.insert(*lane);
+                    for lane in lanes.iter() {
+                        lanes_to_include.insert(*lane);
+                    }
+
                     anchor_to_vertex.insert(*id, vertices.len());
                     vertices.push(NavVertex::from_anchor(anchor, location_at_anchor.get(id)));
                 }

--- a/rmf_site_format/src/legacy/nav_graph.rs
+++ b/rmf_site_format/src/legacy/nav_graph.rs
@@ -11,7 +11,7 @@ pub struct NavGraph {
     pub lifts: HashMap<String, NavLift>,
 }
 
-// Readapted from legacy traffic editor implementation
+// Reference: https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line_segment
 fn segments_intersect(p1: [f32; 2], p2: [f32; 2], p3: [f32; 2], p4: [f32; 2]) -> bool {
     // line segments are [p1-p2] and [p3-p4]
     let [x1, y1] = p1;

--- a/rmf_site_format/src/legacy/vertex.rs
+++ b/rmf_site_format/src/legacy/vertex.rs
@@ -80,7 +80,7 @@ impl Vertex {
             return Some(Location {
                 anchor: anchor.into(),
                 tags: LocationTags(tags),
-                name: NameInSite(name.unwrap_or("<Unnamed>".to_string())),
+                name: NameInSite(name.unwrap_or_default()),
                 graphs: AssociatedGraphs::All,
             });
         }

--- a/rmf_site_format/src/lift.rs
+++ b/rmf_site_format/src/lift.rs
@@ -139,7 +139,7 @@ impl LiftProperties<u32> {
         let right_anchor = site.get_anchor(self.reference_anchors.right())?;
         let left_trans = left_anchor.translation_for_category(Category::Level);
         let right_trans = right_anchor.translation_for_category(Category::Level);
-        let yaw = (left_trans[1] - right_trans[1]).atan2(left_trans[0] - right_trans[0]);
+        let yaw = (left_trans[0] - right_trans[0]).atan2(left_trans[1] - right_trans[1]);
         let midpoint = [
             (left_trans[0] + right_trans[0]) / 2.0,
             (left_trans[1] + right_trans[1]) / 2.0,

--- a/rmf_site_format/src/lift.rs
+++ b/rmf_site_format/src/lift.rs
@@ -115,6 +115,60 @@ pub struct LiftProperties<T: RefTrait> {
     pub initial_level: InitialLevel<T>,
 }
 
+impl LiftProperties<u32> {
+    /// Returns the pose of the lift cabin center in global coordinates.
+    pub fn center(&self, site: &Site) -> Option<Pose> {
+        // Center of the aabb
+        let center = match &self.cabin {
+            LiftCabin::Rect(params) => {
+                let front_door_t = params
+                    .front_door
+                    .as_ref()
+                    .map(|d| d.thickness())
+                    .unwrap_or(DEFAULT_CABIN_DOOR_THICKNESS);
+
+                [
+                    -params.depth / 2.0 - params.thickness() - params.gap() - front_door_t / 2.0,
+                    params.shift(),
+                    DEFAULT_LEVEL_HEIGHT / 2.0,
+                ]
+            }
+        };
+        // Get the vector between the reference anchors
+        let left_anchor = site.get_anchor(self.reference_anchors.left())?;
+        let right_anchor = site.get_anchor(self.reference_anchors.right())?;
+        let left_trans = left_anchor.translation_for_category(Category::Level);
+        let right_trans = right_anchor.translation_for_category(Category::Level);
+        let yaw = (left_trans[1] - right_trans[1]).atan2(left_trans[0] - right_trans[0]);
+        let midpoint = [
+            (left_trans[0] + right_trans[0]) / 2.0,
+            (left_trans[1] + right_trans[1]) / 2.0,
+        ];
+        let elevation = match &self.initial_level.0 {
+            Some(l) => site
+                .levels
+                .get(l)
+                .map(|level| level.properties.elevation.0)?,
+            None => {
+                let mut min_elevation = site
+                    .levels
+                    .first_key_value()
+                    .map(|(_, l)| l.properties.elevation.0)?;
+                for l in site.levels.values().skip(1) {
+                    if l.properties.elevation.0 < min_elevation {
+                        min_elevation = l.properties.elevation.0;
+                    }
+                }
+                min_elevation
+            }
+        };
+        Some(Pose {
+            trans: [midpoint[0] + center[0], midpoint[1] + center[1], elevation],
+            rot: Rotation::Yaw(Angle::Rad(yaw)),
+        })
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(transparent)]
 #[cfg_attr(feature = "bevy", derive(Component, Deref, DerefMut))]

--- a/rmf_site_format/src/lift.rs
+++ b/rmf_site_format/src/lift.rs
@@ -137,8 +137,8 @@ impl LiftProperties<u32> {
         // Get the vector between the reference anchors
         let left_anchor = site.get_anchor(self.reference_anchors.left())?;
         let right_anchor = site.get_anchor(self.reference_anchors.right())?;
-        let left_trans = left_anchor.translation_for_category(Category::Level);
-        let right_trans = right_anchor.translation_for_category(Category::Level);
+        let left_trans = left_anchor.translation_for_category(Category::Lift);
+        let right_trans = right_anchor.translation_for_category(Category::Lift);
         let yaw = (left_trans[0] - right_trans[0]).atan2(left_trans[1] - right_trans[1]);
         let midpoint = [
             (left_trans[0] + right_trans[0]) / 2.0,

--- a/rmf_site_format/src/misc.rs
+++ b/rmf_site_format/src/misc.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use crate::{Recall, RefTrait};
+use crate::RefTrait;
 #[cfg(feature = "bevy")]
 use bevy::prelude::*;
 use glam::{Quat, Vec2, Vec3};

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -183,6 +183,12 @@ impl Site {
     pub fn from_bytes<'a>(s: &'a [u8]) -> ron::error::SpannedResult<Self> {
         ron::de::from_bytes(s)
     }
+
+    pub fn get_anchor(&self, id: u32) -> Option<&Anchor> {
+        self.anchors
+            .get(&id)
+            .or_else(|| self.levels.values().find_map(|l| l.anchors.get(&id)))
+    }
 }
 
 pub trait RefTrait: Ord + Eq + Copy + Send + Sync + Hash + 'static {}


### PR DESCRIPTION
## New feature implementation

### Implemented feature

While working on SDF export, I noticed that several properties are missing, this PR brings us "closer" to all the features adding doors, lifts and orientation constraints. It also updates the TODOs to bring them up to date with what is needed since we will need to revisit this section.

### Implementation description

I split this into a standalone PR since the SDF export is already becoming a very large change and this is somewhat orthogonal so it should be easier to review (and probably it would be better to scrutinize this a bit closer, since mistakes in an exported SDF are a lot easier to spot than mistakes in an exported navgraph).
I'll only be able to do full end to end testing when this is integrated with the SDF branch and we can export a full demo world, so this is somewhat experimental code (and parts like the lift center calculation might use another pair of eyes)