### PR TITLE
Add rosdep key and remove dynamic linking by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,13 @@ members = [
 # the workspace needs to explicitly specify this.
 # For more see: https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
+
+# Compile time optimizations as suggested in
+# https://bevyengine.org/learn/quick-start/getting-started/setup/#compile-with-performance-optimizations
+# Enable a small amount of optimization in debug mode
+[profile.dev]
+opt-level = 1
+
+# Enable high optimizations for dependencies (incl. Bevy), but not for our code:
+[profile.dev.package."*"]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ From the root directory:
 $ cargo run
 ```
 
+Use the `--features bevy/dynamic_linking` flag to improve compile time through dynamic linking.
 Use the `--release` flag for better runtime performance.
 
 # Build and Run (WebAssembly)

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -50,13 +50,6 @@ gz-fuel = { git = "https://github.com/open-rmf/gz-fuel-rs", branch = "first_impl
 pathdiff = "*"
 tera = "1.19.1"
 
-# only enable the 'dynamic_linking' feature if we're not building for web or windows
-# TODO(luca) it seems this can be enabled on windows, check
-# https://bevyengine.org/learn/book/getting-started/setup/#enable-fast-compiles-optional
-[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))'.dependencies]
-bevy = { version = "0.11", features = ["dynamic_linking"] }
-surf = { version = "2.3" }
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }
 surf = { version = "2.3" }

--- a/rmf_site_editor/package.xml
+++ b/rmf_site_editor/package.xml
@@ -6,6 +6,9 @@
   <license>Apache License 2.0</license>
 
   <depend>rmf_site_format</depend>
+  <depend>gtk3</depend>
+  <depend>libudev-dev</depend>
+  <depend>libasound2-dev</depend>
 
   <export>
     <build_type>ament_cargo</build_type>


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fix #202, as well as add rosdep keys.

### Fix applied

ROS 2 doesn't play well with dynamic linking so disabling it by default, while adding a note on the README on how to reeanble it at compile time to speed up development.
I also added rosdep keys to package.xml so users that use ROS to run the workcell editor don't need to install any system dependency manually.

These changes make the site editor fully compatible with rosdep, colcon and ros2 run utilities.