### PR TITLE
Apply workcell datum convention to dummy workcell link

### DIFF
--- a/rmf_site_format/src/workcell.rs
+++ b/rmf_site_format/src/workcell.rs
@@ -696,7 +696,10 @@ impl Workcell {
                     rot: Rotation::Quat([0.0, 0.0, 0.0, 0.0]),
                     trans: [0.0, 0.0, 0.0],
                 }),
-                name: Some(NameInWorkcell(String::from("world"))),
+                // As per Industrial Workcell Coordinate Conventions, the name of the workcell
+                // datum link shall be "<workcell_name>_workcell_link".
+                name: Some(NameInWorkcell(
+                    String::from(self.properties.name.0.clone() + "_workcell_link"))),
                 mesh_constraint: None,
                 marker: FrameMarker,
             };

--- a/rmf_site_format/src/workcell.rs
+++ b/rmf_site_format/src/workcell.rs
@@ -698,8 +698,9 @@ impl Workcell {
                 }),
                 // As per Industrial Workcell Coordinate Conventions, the name of the workcell
                 // datum link shall be "<workcell_name>_workcell_link".
-                name: Some(NameInWorkcell(
-                    String::from(self.properties.name.0.clone() + "_workcell_link"))),
+                name: Some(NameInWorkcell(String::from(
+                    self.properties.name.0.clone() + "_workcell_link",
+                ))),
                 mesh_constraint: None,
                 marker: FrameMarker,
             };


### PR DESCRIPTION
Set the datum link to `<workcell_name>_workcell_link` if the workcell root has multiple children.