### PR TITLE
Fix floor gap on sides of lift that do not have doors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c6d3ec4f89e85294dc97334c5b271ddc301fdf67ac9bb994fe44d9273e6ed7"
 dependencies = [
- "bevy_dylib",
  "bevy_internal",
 ]
 
@@ -706,15 +705,6 @@ dependencies = [
  "bevy_time",
  "bevy_utils",
  "sysinfo",
-]
-
-[[package]]
-name = "bevy_dylib"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ea11f830028e1c9d37f8bc88c5873f1c4c0346661209c2ba015f899c51863c"
-dependencies = [
- "bevy_internal",
 ]
 
 [[package]]

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -131,7 +131,9 @@ fn make_floor_mesh(
             LiftCabin::Rect(params) => {
                 let w = params.thickness();
                 let gap_for_door = |d: &Option<LiftCabinDoorPlacement<Entity>>| -> f32 {
-                    d.map(|d| d.custom_gap.unwrap_or(params.gap())).unwrap_or(DEFAULT_CABIN_GAP) + w
+                    d.map(|d| d.custom_gap.unwrap_or(params.gap()))
+                        .unwrap_or(DEFAULT_CABIN_GAP)
+                        + w
                 };
                 let aabb = params.aabb();
                 let tf_cabin = *tf * Transform::from_translation(aabb.center.into());

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -131,7 +131,7 @@ fn make_floor_mesh(
             LiftCabin::Rect(params) => {
                 let w = params.thickness();
                 let gap_for_door = |d: &Option<LiftCabinDoorPlacement<Entity>>| -> f32 {
-                    d.and_then(|d| d.custom_gap).unwrap_or(params.gap()) + w
+                    d.map(|d| d.custom_gap.unwrap_or(params.gap())).unwrap_or(DEFAULT_CABIN_GAP) + w
                 };
                 let aabb = params.aabb();
                 let tf_cabin = *tf * Transform::from_translation(aabb.center.into());


### PR DESCRIPTION
Shortly after #196 was merged I noticed just one more detail about the gap generation that wasn't quite right.

For sides of the cabin that don't have a door, we should just use a minimal gap instead of the cabin's gap parameter. There's no reason to automatically create extra gap around the sides of the lift without any doors. If the user wants fine-grained control of the floor around the lift then they can manually edit the floor accordingly. For automatic hole generation we should stick to only cutting exactly what's needed for the lift to function correctly.

Before:
![gap_broken](https://github.com/open-rmf/rmf_site/assets/1307217/b67c19ad-b49d-46c4-94a4-abe33d4c1c97)

After:
![gap_fixed](https://github.com/open-rmf/rmf_site/assets/1307217/a9ec5719-fbea-4ce4-a981-3d5e7ab5234b)

It also seems we accidentally regressed the lockfile with the last PR, so this will fix that as well.