### PR TITLE
Fix embedded asset path panic

### DIFF
--- a/rmf_site_editor/src/site/assets.rs
+++ b/rmf_site_editor/src/site/assets.rs
@@ -19,9 +19,21 @@ use crate::{shapes::*, site::*};
 use bevy::{asset::embedded_asset, math::Affine3A, prelude::*};
 
 pub(crate) fn add_site_icons(app: &mut App) {
-    embedded_asset!(app, "icons/battery.png");
-    embedded_asset!(app, "icons/parking.png");
-    embedded_asset!(app, "icons/stopwatch.png");
+    // Taken from https://github.com/bevyengine/bevy/issues/10377#issuecomment-1858797002
+    // TODO(luca) remove once we migrate to Bevy 0.13 that includes the fix
+    #[cfg(any(not(target_family = "windows"), target_env = "gnu"))]
+    {
+        embedded_asset!(app, "src/", "icons/battery.png");
+        embedded_asset!(app, "src/", "icons/parking.png");
+        embedded_asset!(app, "src/", "icons/stopwatch.png");
+    }
+
+    #[cfg(all(target_family = "windows", not(target_env = "gnu")))]
+    {
+        embedded_asset!(app, "src\\", "icons\\battery.png");
+        embedded_asset!(app, "src\\", "icons\\parking.png");
+        embedded_asset!(app, "src\\", "icons\\stopwatch.png");
+    }
 }
 
 #[derive(Resource)]

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -98,27 +98,56 @@ pub struct PendingModel {
 pub struct StandardUiLayout;
 
 fn add_widgets_icons(app: &mut App) {
-    embedded_asset!(app, "icons/add.png");
-    embedded_asset!(app, "icons/alignment.png");
-    embedded_asset!(app, "icons/alpha.png");
-    embedded_asset!(app, "icons/confirm.png");
-    embedded_asset!(app, "icons/down.png");
-    embedded_asset!(app, "icons/edit.png");
-    embedded_asset!(app, "icons/empty.png");
-    embedded_asset!(app, "icons/exit.png");
-    embedded_asset!(app, "icons/global.png");
-    embedded_asset!(app, "icons/hidden.png");
-    embedded_asset!(app, "icons/hide.png");
-    embedded_asset!(app, "icons/merge.png");
-    embedded_asset!(app, "icons/opaque.png");
-    embedded_asset!(app, "icons/reject.png");
-    embedded_asset!(app, "icons/search.png");
-    embedded_asset!(app, "icons/select.png");
-    embedded_asset!(app, "icons/selected.png");
-    embedded_asset!(app, "icons/to_bottom.png");
-    embedded_asset!(app, "icons/to_top.png");
-    embedded_asset!(app, "icons/trash.png");
-    embedded_asset!(app, "icons/up.png");
+    // Taken from https://github.com/bevyengine/bevy/issues/10377#issuecomment-1858797002
+    // TODO(luca) remove once we migrate to Bevy 0.13 that includes the fix
+    #[cfg(any(not(target_family = "windows"), target_env = "gnu"))]
+    {
+        embedded_asset!(app, "src/", "icons/add.png");
+        embedded_asset!(app, "src/", "icons/alignment.png");
+        embedded_asset!(app, "src/", "icons/alpha.png");
+        embedded_asset!(app, "src/", "icons/confirm.png");
+        embedded_asset!(app, "src/", "icons/down.png");
+        embedded_asset!(app, "src/", "icons/edit.png");
+        embedded_asset!(app, "src/", "icons/empty.png");
+        embedded_asset!(app, "src/", "icons/exit.png");
+        embedded_asset!(app, "src/", "icons/global.png");
+        embedded_asset!(app, "src/", "icons/hidden.png");
+        embedded_asset!(app, "src/", "icons/hide.png");
+        embedded_asset!(app, "src/", "icons/merge.png");
+        embedded_asset!(app, "src/", "icons/opaque.png");
+        embedded_asset!(app, "src/", "icons/reject.png");
+        embedded_asset!(app, "src/", "icons/search.png");
+        embedded_asset!(app, "src/", "icons/select.png");
+        embedded_asset!(app, "src/", "icons/selected.png");
+        embedded_asset!(app, "src/", "icons/to_bottom.png");
+        embedded_asset!(app, "src/", "icons/to_top.png");
+        embedded_asset!(app, "src/", "icons/trash.png");
+        embedded_asset!(app, "src/", "icons/up.png");
+    }
+    #[cfg(all(target_family = "windows", not(target_env = "gnu")))]
+    {
+        embedded_asset!(app, "src\\", "icons\\add.png");
+        embedded_asset!(app, "src\\", "icons\\alignment.png");
+        embedded_asset!(app, "src\\", "icons\\alpha.png");
+        embedded_asset!(app, "src\\", "icons\\confirm.png");
+        embedded_asset!(app, "src\\", "icons\\down.png");
+        embedded_asset!(app, "src\\", "icons\\edit.png");
+        embedded_asset!(app, "src\\", "icons\\empty.png");
+        embedded_asset!(app, "src\\", "icons\\exit.png");
+        embedded_asset!(app, "src\\", "icons\\global.png");
+        embedded_asset!(app, "src\\", "icons\\hidden.png");
+        embedded_asset!(app, "src\\", "icons\\hide.png");
+        embedded_asset!(app, "src\\", "icons\\merge.png");
+        embedded_asset!(app, "src\\", "icons\\opaque.png");
+        embedded_asset!(app, "src\\", "icons\\reject.png");
+        embedded_asset!(app, "src\\", "icons\\search.png");
+        embedded_asset!(app, "src\\", "icons\\select.png");
+        embedded_asset!(app, "src\\", "icons\\selected.png");
+        embedded_asset!(app, "src\\", "icons\\to_bottom.png");
+        embedded_asset!(app, "src\\", "icons\\to_top.png");
+        embedded_asset!(app, "src\\", "icons\\trash.png");
+        embedded_asset!(app, "src\\", "icons\\up.png");
+    }
 }
 
 impl Plugin for StandardUiLayout {


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes #208.

### Fix applied

This is the upstream bug that tracks the reason for our panic https://github.com/bevyengine/bevy/issues/10377.
It has been fixed and released in 0.13 but we are on 0.12 as of now. As much as I'm always a big fan of updating we are cannot do it quite yet until `bevy_polyline` and `bevy_infinite_grid` are updated, and they seem to always lag about 1 version of bevy.

Luckily there seems to be a workaround in https://github.com/bevyengine/bevy/issues/10377#issuecomment-1858797002 that we can use until we migrate.

To test:

* Build the site editor in a colcon workspace (Note you might need to remove the root Cargo.toml file until https://github.com/colcon/colcon-cargo/pull/25 is solved.
* Try to run it with `ros2 run rmf_site_editor rmf_site_editor`.

Note that I could only test on Linux, if anyone could test on Windows that would also be great but since this is quite severe I wouldn't necessarily hold that as a blocker.

It should panic without this PR and work fine with it.