### PR TITLE
Fix legacy motion_axis_orientation type to f32

### DIFF
--- a/rmf_site_format/src/legacy/lift.rs
+++ b/rmf_site_format/src/legacy/lift.rs
@@ -14,7 +14,7 @@ use std::{
 #[derive(Deserialize, Serialize, Clone)]
 pub struct LiftDoor {
     pub door_type: i32,
-    pub motion_axis_orientation: i32,
+    pub motion_axis_orientation: f32,
     pub width: f64,
     pub x: f64,
     pub y: f64,


### PR DESCRIPTION
## Bug fix

### Fixed bug

The type of this legacy field is float not int. Stumbled upon this when importing the legacy `roscon_workshop` map, i.e. [here](https://github.com/open-rmf/roscon_workshop/blob/ab9f95e4ab38a7273737c728da59301bb168de78/roscon_maps/maps/workshop/workshop.building.yaml#L496), the following is returned:

```
2024-04-04T08:55:03.590297Z ERROR librmf_site_editor::workspace: Failed loading legacy building Message("invalid type: floating point `1.57`, expected i32", Some(Pos { marker: Marker { index: 55291, line: 496, col: 33 }, path: "lifts.lift.doors.door.motion_axis_orientation" }))
```

[Reference in traffic_editor where it is a double](https://github.com/open-rmf/rmf_traffic_editor/blob/a83d0e870aebfcbefe546985d55272e6024448bb/rmf_traffic_editor/gui/lift_door.h#L36)

### Fix applied

Fix its type, it's actually not used so this shouldn't have any side effects.