### PR TITLE
Fix level alignment when levels have no measurements

### DIFF
--- a/rmf_site_format/src/alignment.rs
+++ b/rmf_site_format/src/alignment.rs
@@ -42,7 +42,7 @@ pub struct FiducialVariables<T: RefTrait> {
     pub position: DVec2,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct MeasurementVariables {
     pub in_pixels: f64,
     pub in_meters: f64,
@@ -135,6 +135,12 @@ pub fn align_legacy_building(building: &BuildingMap) -> HashMap<String, Alignmen
 
             initial_scale_numerator += m.in_meters / m.in_pixels;
         }
+        // If no measurements are available, default to a standard 5cm per pixel
+        let initial_scale = if !level.measurements.is_empty() {
+            initial_scale_numerator / level.measurements.len() as f64
+        } else {
+            0.05
+        };
         measurements.push(level_measurements);
 
         let mut level_fiducials = Vec::new();
@@ -148,12 +154,7 @@ pub fn align_legacy_building(building: &BuildingMap) -> HashMap<String, Alignmen
         }
         fiducials.push(level_fiducials);
 
-        u.extend([
-            0.0,
-            0.0,
-            0.0,
-            initial_scale_numerator / level.measurements.len() as f64,
-        ]);
+        u.extend([0.0, 0.0, 0.0, initial_scale]);
     }
 
     solve(&mut u, &fiducials, &measurements, false);


### PR DESCRIPTION
## Bug fix

### Fixed bug

Legacy traffic editor allows having levels with no measurements, it actually only uses measurements for the reference level and uses fiducials instead to compute the transform between other levels and the reference.
The code path would do a divide by 0 if there was a level with no measurements and result in a NaN alignment / silent failure in importing the project.

### Fix applied

This PR makes sure we don't divide by 0 and initializes the scale to the same "sensible" default that is used in traffic editor (5 cm per pixel).

To test it, try to run the site editor and import https://github.com/open-rmf/roscon_workshop/blob/main/roscon_maps/maps/workshop/workshop.building.yaml before and after this PR. The first will panic (panic is actually caused by an external library when we pass it NaN values, not the site editor), with the PR it should load correctly.

I checked and the map seems to be imported with the same scale as traffic editor after the fix.