### PR TITLE
Fix migrate relative paths computation

### DIFF
--- a/rmf_site_format/src/asset_source.rs
+++ b/rmf_site_format/src/asset_source.rs
@@ -65,8 +65,8 @@ impl AssetSource {
             if Path::new(asset_path).is_relative() {
                 println!("Changing path for [{asset_path:?}]");
                 let new_path = diff_paths(
-                    &old_reference_path.with_file_name(asset_path.clone()),
-                    new_reference_path,
+                    old_reference_path.with_file_name(asset_path.clone()),
+                    new_reference_path.parent().ok_or(())?,
                 )
                 .ok_or(())?;
                 *asset_path = new_path.to_str().ok_or(())?.to_owned();


### PR DESCRIPTION
## Bug fix

### Fixed bug

_Mostly_ address #213.
Mostly because there is still an issue when migrating between a relative and an absolute path that is not addressed by this PR but that is a bit of a hairier one.

### Fix applied

When using the old file name as a path to migrate from, the path would have an additional `../`. The previous logic would substitute the filename in the old path and calculate a diff which wouldn't exactly work, for example

```
# Asset source is Local://scan.png
# OLD PATH:
folder/map/map.building.yaml
# OLD with asset name
folder/map/scan.png
# NEW
folder/map/new_map.site.ron
# Going from NEW path to OLD with asset name through path_diff:
../scan.png
```

This is wrong and I believe what we should be doing instead is setting `NEW` to be the _folder_ containing the file, so this PR changes to the following:

```
# OLD is unchanged
# NEW Is the parent of the passed file:
folder/map
# Diff between folder/map/scan.png and folder/map
scan.png
```

### Test it!

Just run the site editor opening a legacy map then hit `Ctrl-S` to save it as a site to a new file:

```
cargo run --release -- ~/rmf_ws/src/demonstrations/rmf_demos/rmf_demos_maps/maps/hotel/hotel.building.yaml
```

Without this PR, a bunch of errors will be printed showing failure to load the drawings (and the new `hotel.site.ron` file will have wrong paths:

```
2024-04-05T04:23:33.918477Z ERROR librmf_site_editor::site::drawing: Failed loading drawing "file://../hotel_L1.png"
2024-04-05T04:23:33.918507Z ERROR librmf_site_editor::site::drawing: Failed loading drawing "file://../hotel_L2.png"
2024-04-05T04:23:33.918516Z ERROR librmf_site_editor::site::drawing: Failed loading drawing "file://../hotel_L3.png"
```

With this PR the errors will not be present and the file will be correctly exported.