### PR TITLE
Use site ID to ensure unique file names

### DIFF
--- a/rmf_site_editor/src/site/sdf_exporter.rs
+++ b/rmf_site_editor/src/site/sdf_exporter.rs
@@ -132,9 +132,7 @@ pub fn collect_site_meshes(world: &mut World, site: Entity, folder: &Path) -> Re
     };
 
     let get_site_id = |e: Entity| -> Result<u32, String> {
-        q_site_ids.get(e)
-        .map(|id| id.0)
-        .map_err(|_| {
+        q_site_ids.get(e).map(|id| id.0).map_err(|_| {
             let backtrace = std::backtrace::Backtrace::force_capture();
             format!("Site ID was not available for entity {e:?}. Backtrace:\n{backtrace}")
         })
@@ -357,7 +355,11 @@ pub fn collect_site_meshes(world: &mut World, site: Entity, folder: &Path) -> Re
                     transform: None,
                 });
             }
-            let filename = format!("{}/lift_{}.glb", folder.display(), get_site_id(*site_child)?);
+            let filename = format!(
+                "{}/lift_{}.glb",
+                folder.display(),
+                get_site_id(*site_child)?
+            );
             write_meshes_to_file(
                 lift_data,
                 Some(format!("lift_{}", **lift_name)),
@@ -400,7 +402,12 @@ pub fn collect_site_meshes(world: &mut World, site: Entity, folder: &Path) -> Re
                         );
                         write_meshes_to_file(
                             vec![data],
-                            Some(format!("lift_{}_{}_{}", **lift_name, face.label(), segment_name)),
+                            Some(format!(
+                                "lift_{}_{}_{}",
+                                **lift_name,
+                                face.label(),
+                                segment_name
+                            )),
                             CompressGltfOptions::default(),
                             filename,
                         )?;

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -299,6 +299,8 @@ pub fn dispatch_load_workspace_events(
                             .send(LoadWorkspaceFile(Some(path.clone()), data))
                             .expect("Failed sending load event");
                     }
+                } else {
+                    warn!("Unable to read file [{path:?}] so it cannot be loaded");
                 }
             }
             LoadWorkspace::Data(data) => {

--- a/rmf_site_format/src/sdf.rs
+++ b/rmf_site_format/src/sdf.rs
@@ -545,10 +545,9 @@ impl Site {
             }
             // Now add all the doors
             for (door_id, door) in &level.doors {
-                // TODO(luca) doors into toggle floors
                 let left_anchor = get_anchor(door.anchors.left())?;
                 let right_anchor = get_anchor(door.anchors.right())?;
-                world.model.push(make_sdf_door(
+                let door_model = make_sdf_door(
                     left_anchor,
                     right_anchor,
                     Vec3::new(0.0, 0.0, level.properties.elevation.0),
@@ -556,8 +555,9 @@ impl Site {
                     &door.kind,
                     format!("door_{door_id}").as_str(),
                     door.name.0.as_str(),
-                )?);
-                level_model_names.push(door.name.0.clone());
+                )?;
+                level_model_names.push(door_model.name.clone());
+                world.model.push(door_model);
             }
             for model_name in level_model_names.into_iter() {
                 let model_element = XmlElement {

--- a/rmf_site_format/src/sdf.rs
+++ b/rmf_site_format/src/sdf.rs
@@ -226,7 +226,8 @@ fn make_sdf_door(
                 ..Default::default()
             }
             .to_sdf();
-            let (left_joint_name, right_joint_name) = ("empty_joint", model_name.to_owned() + "_joint");
+            let (left_joint_name, right_joint_name) =
+                ("empty_joint", model_name.to_owned() + "_joint");
             door_plugin_inner
                 .attributes
                 .insert("left_joint_name".into(), left_joint_name.into());
@@ -255,12 +256,14 @@ fn make_sdf_door(
             door_plugin_inner
                 .attributes
                 .insert("type".into(), "DoubleSlidingDoor".into());
-            door_plugin_inner
-                .attributes
-                .insert("left_joint_name".into(), model_name.to_owned() + "_left_joint");
-            door_plugin_inner
-                .attributes
-                .insert("right_joint_name".into(), model_name.to_owned() + "_right_joint");
+            door_plugin_inner.attributes.insert(
+                "left_joint_name".into(),
+                model_name.to_owned() + "_left_joint",
+            );
+            door_plugin_inner.attributes.insert(
+                "right_joint_name".into(),
+                model_name.to_owned() + "_right_joint",
+            );
             door_motion_params.push(("v_max_door", "0.2"));
             door_motion_params.push(("a_max_door", "0.2"));
             door_motion_params.push(("a_nom_door", "0.08"));
@@ -319,12 +322,14 @@ fn make_sdf_door(
             door_plugin_inner
                 .attributes
                 .insert("type".into(), "DoubleSwingDoor".into());
-            door_plugin_inner
-                .attributes
-                .insert("left_joint_name".into(), model_name.to_owned() + "_left_joint");
-            door_plugin_inner
-                .attributes
-                .insert("right_joint_name".into(), model_name.to_owned() + "_right_joint");
+            door_plugin_inner.attributes.insert(
+                "left_joint_name".into(),
+                model_name.to_owned() + "_left_joint",
+            );
+            door_plugin_inner.attributes.insert(
+                "right_joint_name".into(),
+                model_name.to_owned() + "_right_joint",
+            );
             door_motion_params.push(("v_max_door", "0.5"));
             door_motion_params.push(("a_max_door", "0.3"));
             door_motion_params.push(("a_nom_door", "0.15"));


### PR DESCRIPTION
This uses Site ID values in file names for the following benefits:
1. The filenames will be the same even as the names of entities change
2. The correct filenames will be produced even if duplicate names exist among different models