### PR TITLE
Add main menu option for creating new site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5833,3 +5833,7 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[patch.unused]]
+name = "rmf_site_format"
+version = "0.0.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5833,7 +5833,3 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-
-[[patch.unused]]
-name = "rmf_site_format"
-version = "0.0.1"

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -76,6 +76,10 @@ fn egui_ui(
                     _load_workspace.send(LoadWorkspace::Dialog);
                 }
 
+                if ui.button("Create new file").clicked() {
+                    _load_workspace.send(LoadWorkspace::BlankFromDialog);
+                }
+
                 // TODO(@mxgrey): Bring this back when we have finished developing
                 // the key features for workcell editing.
                 // if ui.button("Workcell Editor").clicked() {

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -38,22 +38,8 @@ pub struct LoadSite {
 impl LoadSite {
     #[allow(non_snake_case)]
     pub fn blank_L1(name: String, default_file: Option<PathBuf>) -> Self {
-        let mut site = rmf_site_format::Site::default();
-        site.properties.name = NameOfSite(name);
-        site.levels.insert(
-            1,
-            Level::new(
-                LevelProperties {
-                    name: NameInSite("L1".to_owned()),
-                    elevation: LevelElevation(0.0),
-                    ..Default::default()
-                },
-                RankingsInLevel::default(),
-            ),
-        );
-
         Self {
-            site,
+            site: rmf_site_format::Site::blank_L1(name),
             default_file,
             focus: true,
         }

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -40,16 +40,23 @@ impl LoadSite {
     pub fn blank_L1(name: String, default_file: Option<PathBuf>) -> Self {
         let mut site = rmf_site_format::Site::default();
         site.properties.name = NameOfSite(name);
-        site.levels.insert(1, Level::new(
-            LevelProperties {
-                name: NameInSite("L1".to_owned()),
-                elevation: LevelElevation(0.0),
-                ..Default::default()
-            },
-            RankingsInLevel::default(),
-        ));
+        site.levels.insert(
+            1,
+            Level::new(
+                LevelProperties {
+                    name: NameInSite("L1".to_owned()),
+                    elevation: LevelElevation(0.0),
+                    ..Default::default()
+                },
+                RankingsInLevel::default(),
+            ),
+        );
 
-        Self { site, default_file, focus: true }
+        Self {
+            site,
+            default_file,
+            focus: true,
+        }
     }
 }
 

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -35,6 +35,24 @@ pub struct LoadSite {
     pub default_file: Option<PathBuf>,
 }
 
+impl LoadSite {
+    #[allow(non_snake_case)]
+    pub fn blank_L1(name: String, default_file: Option<PathBuf>) -> Self {
+        let mut site = rmf_site_format::Site::default();
+        site.properties.name = NameOfSite(name);
+        site.levels.insert(1, Level::new(
+            LevelProperties {
+                name: NameInSite("L1".to_owned()),
+                elevation: LevelElevation(0.0),
+                ..Default::default()
+            },
+            RankingsInLevel::default(),
+        ));
+
+        Self { site, default_file, focus: true }
+    }
+}
+
 #[derive(ThisError, Debug)]
 #[error("The site has a broken internal reference: {broken}")]
 struct LoadSiteError {

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -25,7 +25,7 @@ use thiserror::Error as ThisError;
 #[derive(Component, Clone, Debug, Deref)]
 pub struct DefaultFile(pub PathBuf);
 
-#[derive(Event)]
+#[derive(Event, Clone)]
 pub struct LoadSite {
     /// The site data to load
     pub site: rmf_site_format::Site,

--- a/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
@@ -226,6 +226,8 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectFiducialWidget<'a, 'w1, 'w2, 's1, 's2> {
             {
                 new_affiliation = Affiliation(None);
             }
+
+            let mut clear_filter = false;
             ComboBox::from_id_source("fiducial_affiliation")
                 .selected_text(selected_text)
                 .show_ui(ui, |ui| {
@@ -239,7 +241,15 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectFiducialWidget<'a, 'w1, 'w2, 's1, 's2> {
                             ui.selectable_value(&mut new_affiliation, select_affiliation, name);
                         }
                     }
+
+                    if !self.events.change.search_for_fiducial.0.is_empty() {
+                        ui.selectable_value(&mut clear_filter, true, "<Clear Filter...>");
+                    }
                 });
+
+            if clear_filter {
+                self.events.change.search_for_fiducial.0.clear();
+            }
         });
 
         if new_affiliation != *affiliation {

--- a/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
@@ -243,7 +243,7 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectFiducialWidget<'a, 'w1, 'w2, 's1, 's2> {
                     }
 
                     if !self.events.change.search_for_fiducial.0.is_empty() {
-                        ui.selectable_value(&mut clear_filter, true, "<Clear Filter...>");
+                        ui.selectable_value(&mut clear_filter, true, "more...");
                     }
                 });
 

--- a/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
@@ -228,6 +228,7 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
                 new_affiliation = Affiliation(None);
             }
 
+            let mut clear_filter = false;
             ComboBox::from_id_source("texture_affiliation")
                 .selected_text(current_texture_name)
                 .show_ui(ui, |ui| {
@@ -237,13 +238,21 @@ impl<'a, 'w1, 'w2, 's1, 's2> InspectTextureAffiliation<'a, 'w1, 'w2, 's1, 's2> {
                         }
 
                         if let Ok((n, _)) = self.params.texture_groups.get(*child) {
-                            if n.0.contains(&*search) {
+                            if n.0.contains(&self.events.change.search_for_texture.0) {
                                 let select_affiliation = Affiliation(Some(*child));
                                 ui.selectable_value(&mut new_affiliation, select_affiliation, &n.0);
                             }
                         }
                     }
+
+                    if !self.events.change.search_for_texture.0.is_empty() {
+                        ui.selectable_value(&mut clear_filter, true, "more...");
+                    }
                 });
+
+            if clear_filter {
+                self.events.change.search_for_texture.0.clear();
+            }
         });
 
         if new_affiliation != *affiliation {

--- a/rmf_site_editor/src/widgets/view_levels.rs
+++ b/rmf_site_editor/src/widgets/view_levels.rs
@@ -17,8 +17,8 @@
 
 use crate::{
     site::{
-        Category, Change, Delete, LevelElevation, LevelProperties, NameInSite,
-        DrawingMarker, FloorMarker,
+        Category, Change, Delete, DrawingMarker, FloorMarker, LevelElevation, LevelProperties,
+        NameInSite,
     },
     widgets::{AppEvents, Icons},
     RecencyRanking,

--- a/rmf_site_editor/src/widgets/view_levels.rs
+++ b/rmf_site_editor/src/widgets/view_levels.rs
@@ -16,8 +16,12 @@
 */
 
 use crate::{
-    site::{Category, Change, Delete, LevelElevation, LevelProperties, NameInSite},
+    site::{
+        Category, Change, Delete, LevelElevation, LevelProperties, NameInSite,
+        DrawingMarker, FloorMarker,
+    },
     widgets::{AppEvents, Icons},
+    RecencyRanking,
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_egui::egui::{DragValue, ImageButton, Ui};
@@ -86,13 +90,17 @@ impl<'a, 'w1, 's1, 'w2, 's2> ViewLevels<'a, 'w1, 's1, 'w2, 's2> {
                 let new_level = self
                     .events
                     .commands
-                    .spawn(SpatialBundle::default())
-                    .insert(LevelProperties {
-                        elevation: LevelElevation(show_elevation),
-                        name: NameInSite(show_name.clone()),
-                        ..Default::default()
-                    })
-                    .insert(Category::Level)
+                    .spawn((
+                        SpatialBundle::default(),
+                        LevelProperties {
+                            elevation: LevelElevation(show_elevation),
+                            name: NameInSite(show_name.clone()),
+                            ..Default::default()
+                        },
+                        Category::Level,
+                        RecencyRanking::<DrawingMarker>::default(),
+                        RecencyRanking::<FloorMarker>::default(),
+                    ))
                     .id();
                 self.events.request.current_level.0 = Some(new_level);
             }

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -285,9 +285,9 @@ pub fn dispatch_load_workspace_events(
                     .detach();
             }
             LoadWorkspace::BlankFromDialog => {
+                let sender = load_channels.sender.clone();
                 #[cfg(not(target_arch = "wasm32"))]
                 {
-                    let sender = load_channels.sender.clone();
                     AsyncComputeTaskPool::get()
                         .spawn(async move {
                             if let Some(file) = AsyncFileDialog::new().save_file().await {

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -17,7 +17,6 @@
 
 use bevy::{prelude::*, tasks::AsyncComputeTaskPool};
 use rfd::AsyncFileDialog;
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::interaction::InteractionState;
@@ -25,7 +24,7 @@ use crate::site::{DefaultFile, LoadSite, SaveSite};
 use crate::workcell::{LoadWorkcell, SaveWorkcell};
 use crate::AppState;
 use rmf_site_format::legacy::building_map::BuildingMap;
-use rmf_site_format::{Level, NameOfSite, Site, Workcell};
+use rmf_site_format::{NameOfSite, Site, Workcell};
 
 use crossbeam_channel::{Receiver, Sender};
 
@@ -237,13 +236,8 @@ pub fn dispatch_new_workspace_events(
                 error!("Sent generic new workspace while in main menu");
             }
             AppState::SiteEditor | AppState::SiteDrawingEditor | AppState::SiteVisualizer => {
-                let mut levels = BTreeMap::new();
-                levels.insert(0, Level::default());
                 load_site.send(LoadSite {
-                    site: Site {
-                        levels,
-                        ..default()
-                    },
+                    site: Site::blank_L1("new".to_owned()),
                     focus: true,
                     default_file: None,
                 });
@@ -301,7 +295,7 @@ pub fn dispatch_load_workspace_events(
                                     name,
                                     Some(file.clone()),
                                 ));
-                                sender.send(LoadWorkspaceFile(Some(file), data));
+                                let _ = sender.send(LoadWorkspaceFile(Some(file), data));
                             }
                         })
                         .detach();

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -297,9 +297,10 @@ pub fn dispatch_load_workspace_events(
                                     .map(|s| s.to_str().map(|s| s.to_owned()))
                                     .flatten()
                                     .unwrap_or_else(|| "blank".to_owned());
-                                let data = WorkspaceData::LoadSite(
-                                    LoadSite::blank_L1(name, Some(file.clone()))
-                                );
+                                let data = WorkspaceData::LoadSite(LoadSite::blank_L1(
+                                    name,
+                                    Some(file.clone()),
+                                ));
                                 sender.send(LoadWorkspaceFile(Some(file), data));
                             }
                         })
@@ -307,9 +308,8 @@ pub fn dispatch_load_workspace_events(
                 }
                 #[cfg(target_arch = "wasm32")]
                 {
-                    let data = WorkspaceData::LoadSite(
-                        LoadSite::blank_L1("blank".to_owned(), None)
-                    );
+                    let data =
+                        WorkspaceData::LoadSite(LoadSite::blank_L1("blank".to_owned(), None));
                     sender.send(LoadWorkspaceFile(None, data));
                 }
             }

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -54,6 +54,7 @@ pub struct WorkspaceMarker;
 #[derive(Event)]
 pub enum LoadWorkspace {
     Dialog,
+    BlankFromDialog,
     Path(PathBuf),
     Data(WorkspaceData),
 }
@@ -64,6 +65,7 @@ pub enum WorkspaceData {
     Site(Vec<u8>),
     Workcell(Vec<u8>),
     WorkcellUrdf(Vec<u8>),
+    DeserializedSite(Site),
 }
 
 impl WorkspaceData {
@@ -281,6 +283,25 @@ pub fn dispatch_load_workspace_events(
                         }
                     })
                     .detach();
+            }
+            LoadWorkspace::BlankFromDialog => {
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let sender = load_channels.sender.clone();
+                    AsyncComputeTaskPool::get()
+                        .spawn(async move {
+                            if let Some(file) = AsyncFileDialog::new().save_file().await {
+                                let file = file.path().to_path_buf();
+                                if let Some(stem) = file.file_stem() {
+
+                                }
+                            }
+                        })
+                }
+                #[cfg(target_arch = "wasm32")]
+                {
+
+                }
             }
             LoadWorkspace::Path(path) => {
                 if let Ok(data) = std::fs::read(&path) {

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -189,6 +189,24 @@ impl Site {
             .get(&id)
             .or_else(|| self.levels.values().find_map(|l| l.anchors.get(&id)))
     }
+
+    #[allow(non_snake_case)]
+    pub fn blank_L1(name: String) -> Self {
+        let mut site = Site::default();
+        site.properties.name = NameOfSite(name);
+        site.levels.insert(
+            1,
+            Level::new(
+                LevelProperties {
+                    name: NameInSite("L1".to_owned()),
+                    elevation: LevelElevation(0.0),
+                    ..Default::default()
+                },
+                RankingsInLevel::default(),
+            ),
+        );
+        site
+    }
 }
 
 pub trait RefTrait: Ord + Eq + Copy + Send + Sync + Hash + 'static {}


### PR DESCRIPTION
The main purpose of this PR is to support creating new sites from scratch from the main menu. However I'm sneaking in a bug fix and a quality of life improvement that I came up with while testing the process of building sites from scratch:
* If a list of groups (e.g. fiducials, textures) is being filtered in the selection drop-down menu, include a `more...` item in the drop down menu that clears the filter
* Fix the level spawning UI to add all the components that are needed