### PR TITLE
Making floor grid available to all edit modes

### DIFF
--- a/rmf_site_editor/src/floor_grid.rs
+++ b/rmf_site_editor/src/floor_grid.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::prelude::{Entity, Resource, World, FromWorld, Plugin, App};
+use bevy_infinite_grid::InfiniteGridPlugin;
+
+use crate::shapes::make_infinite_grid;
+
+#[derive(Resource)]
+pub struct FloorGrid {
+    entity: Entity,
+}
+
+impl FloorGrid {
+    pub fn get(&self) -> Entity {
+        self.entity
+    }
+}
+
+impl FromWorld for FloorGrid {
+    fn from_world(world: &mut World) -> Self {
+        let entity = world.spawn(make_infinite_grid(1.0, 100.0, None)).id();
+        Self { entity }
+    }
+}
+
+pub struct FloorGridPlugin;
+
+impl Plugin for FloorGridPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .add_plugins(InfiniteGridPlugin)
+            .init_resource::<FloorGrid>();
+    }
+}

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -53,6 +53,9 @@ use view_menu::*;
 pub mod wireframe;
 use wireframe::*;
 
+pub mod floor_grid;
+use floor_grid::*;
+
 use aabb::AabbUpdatePlugin;
 use animate::AnimationPlugin;
 use interaction::InteractionPlugin;
@@ -190,6 +193,7 @@ impl Plugin for SiteEditor {
                 AnimationPlugin,
                 OccupancyPlugin,
                 WorkspacePlugin,
+                FloorGridPlugin,
             ))
             // Note order matters, plugins that edit the menus must be initialized after the UI
             .add_plugins((

--- a/rmf_site_editor/src/shapes.rs
+++ b/rmf_site_editor/src/shapes.rs
@@ -1254,7 +1254,8 @@ pub(crate) fn make_infinite_grid(
     settings.fadeout_distance = fadeout_distance;
     settings.shadow_color = shadow_color;
     let transform = Transform::from_rotation(Quat::from_rotation_x(90_f32.to_radians()))
-        .with_scale(Vec3::splat(scale));
+        .with_scale(Vec3::splat(scale))
+        .with_translation(Vec3::new(0.0, 0.0, -0.005));
 
     InfiniteGridBundle {
         settings,

--- a/rmf_site_editor/src/workcell/mod.rs
+++ b/rmf_site_editor/src/workcell/mod.rs
@@ -42,42 +42,26 @@ pub mod workcell;
 pub use workcell::*;
 
 use bevy::prelude::*;
-use bevy_infinite_grid::{InfiniteGrid, InfiniteGridPlugin};
 
 use crate::AppState;
-use crate::{
-    shapes::make_infinite_grid,
-    site::{
-        clear_model_trashcan, handle_model_loaded_events, handle_new_primitive_shapes,
-        handle_update_fuel_cache_requests, make_models_selectable, propagate_model_render_layers,
-        read_update_fuel_cache_results, reload_failed_models_with_new_api_key,
-        update_anchor_transforms, update_model_scales, update_model_scenes,
-        update_model_tentative_formats, update_transforms_for_changed_poses,
-    },
+use crate::site::{
+    clear_model_trashcan, handle_model_loaded_events, handle_new_primitive_shapes,
+    handle_update_fuel_cache_requests, make_models_selectable, propagate_model_render_layers,
+    read_update_fuel_cache_results, reload_failed_models_with_new_api_key,
+    update_anchor_transforms, update_model_scales, update_model_scenes,
+    update_model_tentative_formats, update_transforms_for_changed_poses,
 };
 
 #[derive(Default)]
 pub struct WorkcellEditorPlugin;
 
-fn spawn_grid(mut commands: Commands) {
-    commands.spawn(make_infinite_grid(1.0, 100.0, None));
-}
-
-fn delete_grid(mut commands: Commands, grids: Query<Entity, With<InfiniteGrid>>) {
-    for grid in grids.iter() {
-        commands.entity(grid).despawn_recursive();
-    }
-}
-
 impl Plugin for WorkcellEditorPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(InfiniteGridPlugin)
+        app
             .add_event::<CreateJoint>()
             .add_event::<SaveWorkcell>()
             .add_event::<LoadWorkcell>()
             .add_event::<ChangeCurrentWorkcell>()
-            .add_systems(OnEnter(AppState::WorkcellEditor), spawn_grid)
-            .add_systems(OnExit(AppState::WorkcellEditor), delete_grid)
             .add_systems(
                 Update,
                 (


### PR DESCRIPTION
This PR adds a floor grid that can be seen in any edit mode to give users a better idea of where the floor is and what the orientation of the camera is.

The view drop-down menu provides a way to toggle the visibility of the floor grid on and off.

This will be in a draft PR until I can figure out why these changes are causing all outlining to be turned on at all times.