### PR TITLE
Fix assigning site IDs to new lanes in lifts

### DIFF
--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -136,6 +136,7 @@ fn assign_site_ids(world: &mut World, site: Entity) -> Result<(), SiteGeneration
             ),
         >,
         Query<(), With<DrawingMarker>>,
+        Query<&ChildCabinAnchorGroup>,
         Query<&NextSiteID>,
         Query<&SiteID>,
         Query<&Children>,
@@ -148,6 +149,7 @@ fn assign_site_ids(world: &mut World, site: Entity) -> Result<(), SiteGeneration
         lifts,
         drawing_children,
         drawings,
+        cabin_anchor_groups,
         sites,
         site_ids,
         children,
@@ -209,6 +211,17 @@ fn assign_site_ids(world: &mut World, site: Entity) -> Result<(), SiteGeneration
         }
 
         if let Ok(lift) = lifts.get(*site_child) {
+            if let Ok(anchor_group) = cabin_anchor_groups.get(*site_child) {
+                if let Ok(anchor_children) = children.get(**anchor_group) {
+                    for anchor_child in anchor_children {
+                        if let Ok(e) = level_children.get(*anchor_child) {
+                            if !site_ids.contains(e) {
+                                new_entities.push(e);
+                            }
+                        }
+                    }
+                }
+            }
             if !site_ids.contains(lift) {
                 new_entities.push(lift);
             }

--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -137,6 +137,7 @@ fn assign_site_ids(world: &mut World, site: Entity) -> Result<(), SiteGeneration
         >,
         Query<(), With<DrawingMarker>>,
         Query<&ChildCabinAnchorGroup>,
+        Query<Entity, (With<Anchor>, Without<Pending>)>,
         Query<&NextSiteID>,
         Query<&SiteID>,
         Query<&Children>,
@@ -150,6 +151,7 @@ fn assign_site_ids(world: &mut World, site: Entity) -> Result<(), SiteGeneration
         drawing_children,
         drawings,
         cabin_anchor_groups,
+        cabin_anchor_group_children,
         sites,
         site_ids,
         children,
@@ -214,7 +216,7 @@ fn assign_site_ids(world: &mut World, site: Entity) -> Result<(), SiteGeneration
             if let Ok(anchor_group) = cabin_anchor_groups.get(*site_child) {
                 if let Ok(anchor_children) = children.get(**anchor_group) {
                     for anchor_child in anchor_children {
-                        if let Ok(e) = level_children.get(*anchor_child) {
+                        if let Ok(e) = cabin_anchor_group_children.get(*anchor_child) {
                             if !site_ids.contains(e) {
                                 new_entities.push(e);
                             }


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes #224 

### Fix applied

The function to assign site IDs to new entities was not being called for anchors that were children of lifts, hence the subsequent query to save the site would not find the anchor (its ID would be missing).
The fix is to make sure we assign a site ID to anchors that are children of the lift cabin.

To test:

* Create a new site.
* Create a lift.
* Add a lane that goes into the lift.
* Save the site.

Without this PR you should get this error:

```
ERROR librmf_site_editor::site::save: Unable to compile site: an object has a reference to an anchor that does not exist
```

With this PR it should save successfully.