### PR TITLE
Move workspace loading to workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "bevy_impulse"
 version = "0.0.1"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=main#72e76388478a5bffca92e8baf7a5ea6396c84ebb"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=main#3e681a91033427c5ae24995f4e53d19f656f278f"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -783,7 +783,7 @@ dependencies = [
  "bevy_utils",
  "crossbeam",
  "futures",
- "itertools 0.12.1",
+ "itertools",
  "smallvec",
  "thiserror",
 ]
@@ -1315,7 +1315,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -2002,7 +2002,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
 dependencies = [
- "itertools 0.11.0",
+ "itertools",
  "num-traits",
 ]
 
@@ -2830,7 +2830,7 @@ dependencies = [
  "dirs",
  "ehttp",
  "futures-lite 2.2.0",
- "itertools 0.12.1",
+ "itertools",
  "serde",
  "serde_json",
 ]
@@ -3094,15 +3094,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4349,7 +4340,7 @@ dependencies = [
  "futures-lite 1.13.0",
  "geo",
  "gz-fuel",
- "itertools 0.12.1",
+ "itertools",
  "nalgebra",
  "pathdiff",
  "rfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_impulse"
+version = "0.0.1"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=main#ee7858aa7ff0a875980f48272fbb7fc889792cc2"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "backtrace",
+ "bevy",
+ "crossbeam",
+ "futures",
+ "itertools 0.11.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "bevy_infinite_grid"
 version = "0.10.0"
 source = "git+https://github.com/ForesightMiningSoftwareCorporation/bevy_infinite_grid?rev=86018dd#86018dd5708357067323931241ebc835fa73bf30"
@@ -1820,6 +1836,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +1872,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2289,10 +2327,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2326,6 +2400,47 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -3898,6 +4013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4204,6 +4325,7 @@ dependencies = [
  "bevy",
  "bevy_egui",
  "bevy_gltf_export",
+ "bevy_impulse",
  "bevy_infinite_grid",
  "bevy_mod_outline",
  "bevy_mod_raycast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "atk-sys"
@@ -767,15 +767,23 @@ dependencies = [
 [[package]]
 name = "bevy_impulse"
 version = "0.0.1"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=main#ee7858aa7ff0a875980f48272fbb7fc889792cc2"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=main#72e76388478a5bffca92e8baf7a5ea6396c84ebb"
 dependencies = [
  "anyhow",
  "arrayvec",
+ "async-task",
  "backtrace",
- "bevy",
+ "bevy_app",
+ "bevy_core",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_tasks",
+ "bevy_time",
+ "bevy_utils",
  "crossbeam",
  "futures",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "smallvec",
  "thiserror",
 ]
@@ -2821,8 +2829,8 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "ehttp",
- "futures-lite 1.13.0",
- "itertools 0.11.0",
+ "futures-lite 2.2.0",
+ "itertools 0.12.1",
  "serde",
  "serde_json",
 ]

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -22,7 +22,6 @@ bevy_mod_outline = "0.6"
 # PR merged after 0.10 but not released yet, bump to 0.10.1 once merged
 bevy_infinite_grid = { git = "https://github.com/ForesightMiningSoftwareCorporation/bevy_infinite_grid", rev = "86018dd" }
 bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export", branch = "luca/transform_api"}
-bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "main"}
 bevy_polyline = "0.8.1"
 bevy_stl = "0.12"
 bevy_obj = { version = "0.12.1", features = ["scene"] }
@@ -56,6 +55,8 @@ nalgebra = "0.32.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }
+bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "main" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
+bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "main", features = ["single_threaded_async"]}

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -22,6 +22,7 @@ bevy_mod_outline = "0.6"
 # PR merged after 0.10 but not released yet, bump to 0.10.1 once merged
 bevy_infinite_grid = { git = "https://github.com/ForesightMiningSoftwareCorporation/bevy_infinite_grid", rev = "86018dd" }
 bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export", branch = "luca/transform_api"}
+bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "main"}
 bevy_polyline = "0.8.1"
 bevy_stl = "0.12"
 bevy_obj = { version = "0.12.1", features = ["scene"] }

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -18,7 +18,7 @@
 use crate::{
     interaction::{ChangeMode, ChangeProjectionMode, InteractionMode, Selection},
     site::{AlignSiteDrawings, Delete},
-    CreateNewWorkspace, CurrentWorkspace, LoadWorkspace, SaveWorkspace,
+    CreateNewWorkspace, CurrentWorkspace, SaveWorkspace, WorkspaceLoadingServices,
 };
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_egui::EguiContexts;
@@ -42,6 +42,7 @@ impl Plugin for KeyboardInputPlugin {
 }
 
 fn handle_keyboard_input(
+    mut commands: Commands,
     keyboard_input: Res<Input<KeyCode>>,
     selection: Res<Selection>,
     current_mode: Res<InteractionMode>,
@@ -50,12 +51,12 @@ fn handle_keyboard_input(
     mut delete: EventWriter<Delete>,
     mut save_workspace: EventWriter<SaveWorkspace>,
     mut new_workspace: EventWriter<CreateNewWorkspace>,
-    mut load_workspace: EventWriter<LoadWorkspace>,
     mut change_camera_mode: EventWriter<ChangeProjectionMode>,
     mut debug_mode: ResMut<DebugMode>,
     mut align_site: EventWriter<AlignSiteDrawings>,
     current_workspace: Res<CurrentWorkspace>,
     primary_windows: Query<Entity, With<PrimaryWindow>>,
+    load_workspace: Res<WorkspaceLoadingServices>,
 ) {
     let Some(egui_context) = primary_windows
         .get_single()
@@ -122,7 +123,7 @@ fn handle_keyboard_input(
         }
 
         if keyboard_input.just_pressed(KeyCode::O) {
-            load_workspace.send(LoadWorkspace::Dialog);
+            load_workspace.load_from_dialog(&mut commands);
         }
     }
 }

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -18,7 +18,7 @@
 use crate::{
     interaction::{ChangeMode, ChangeProjectionMode, InteractionMode, Selection},
     site::{AlignSiteDrawings, Delete},
-    CreateNewWorkspace, CurrentWorkspace, SaveWorkspace, WorkspaceLoadingParams,
+    CreateNewWorkspace, CurrentWorkspace, SaveWorkspace, WorkspaceLoader,
 };
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_egui::EguiContexts;
@@ -55,7 +55,7 @@ fn handle_keyboard_input(
     mut align_site: EventWriter<AlignSiteDrawings>,
     current_workspace: Res<CurrentWorkspace>,
     primary_windows: Query<Entity, With<PrimaryWindow>>,
-    mut load_workspace: WorkspaceLoadingParams,
+    mut workspace_loader: WorkspaceLoader,
 ) {
     let Some(egui_context) = primary_windows
         .get_single()
@@ -122,7 +122,7 @@ fn handle_keyboard_input(
         }
 
         if keyboard_input.just_pressed(KeyCode::O) {
-            load_workspace.load_from_dialog();
+            workspace_loader.load_from_dialog();
         }
     }
 }

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -18,7 +18,7 @@
 use crate::{
     interaction::{ChangeMode, ChangeProjectionMode, InteractionMode, Selection},
     site::{AlignSiteDrawings, Delete},
-    CreateNewWorkspace, CurrentWorkspace, SaveWorkspace, WorkspaceLoadingServices,
+    CreateNewWorkspace, CurrentWorkspace, SaveWorkspace, WorkspaceLoadingParams,
 };
 use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_egui::EguiContexts;
@@ -42,7 +42,6 @@ impl Plugin for KeyboardInputPlugin {
 }
 
 fn handle_keyboard_input(
-    mut commands: Commands,
     keyboard_input: Res<Input<KeyCode>>,
     selection: Res<Selection>,
     current_mode: Res<InteractionMode>,
@@ -56,7 +55,7 @@ fn handle_keyboard_input(
     mut align_site: EventWriter<AlignSiteDrawings>,
     current_workspace: Res<CurrentWorkspace>,
     primary_windows: Query<Entity, With<PrimaryWindow>>,
-    load_workspace: Res<WorkspaceLoadingServices>,
+    mut load_workspace: WorkspaceLoadingParams,
 ) {
     let Some(egui_context) = primary_windows
         .get_single()
@@ -123,7 +122,7 @@ fn handle_keyboard_input(
         }
 
         if keyboard_input.just_pressed(KeyCode::O) {
-            load_workspace.load_from_dialog(&mut commands);
+            load_workspace.load_from_dialog();
         }
     }
 }

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -230,6 +230,7 @@ impl Plugin for SiteEditor {
                 OccupancyPlugin,
                 WorkspacePlugin,
                 IssuePlugin,
+                bevy_impulse::ImpulsePlugin::default(),
             ));
 
         if self.headless_export.is_none() {

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -16,15 +16,14 @@
 */
 
 use super::demo_world::*;
-use crate::{AppState, Autoload, WorkspaceData, WorkspaceLoadingServices};
+use crate::{AppState, Autoload, WorkspaceData, WorkspaceLoadingParams};
 use bevy::{app::AppExit, prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
 
 fn egui_ui(
-    mut commands: Commands,
     mut egui_context: EguiContexts,
     mut _exit: EventWriter<AppExit>,
-    load_workspace: Res<WorkspaceLoadingServices>,
+    mut load_workspace: WorkspaceLoadingParams,
     mut _app_state: ResMut<State<AppState>>,
     autoload: Option<ResMut<Autoload>>,
     primary_windows: Query<Entity, With<PrimaryWindow>>,
@@ -33,7 +32,7 @@ fn egui_ui(
         #[cfg(not(target_arch = "wasm32"))]
         {
             if let Some(filename) = autoload.filename.take() {
-                load_workspace.load_from_path(&mut commands, filename);
+                load_workspace.load_from_path(filename);
             }
         }
         return;
@@ -58,18 +57,15 @@ fn egui_ui(
 
             ui.horizontal(|ui| {
                 if ui.button("View demo map").clicked() {
-                    load_workspace.load_from_data(
-                        &mut commands,
-                        WorkspaceData::LegacyBuilding(demo_office()),
-                    );
+                    load_workspace.load_from_data(WorkspaceData::LegacyBuilding(demo_office()));
                 }
 
                 if ui.button("Open a file").clicked() {
-                    load_workspace.load_from_dialog(&mut commands);
+                    load_workspace.load_from_dialog();
                 }
 
                 if ui.button("Create new file").clicked() {
-                    load_workspace.create_empty_from_dialog(&mut commands);
+                    load_workspace.create_empty_from_dialog();
                 }
 
                 // TODO(@mxgrey): Bring this back when we have finished developing

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -16,14 +16,15 @@
 */
 
 use super::demo_world::*;
-use crate::{AppState, Autoload, LoadWorkspace, WorkspaceData};
+use crate::{AppState, Autoload, WorkspaceData, WorkspaceLoadingServices};
 use bevy::{app::AppExit, prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
 
 fn egui_ui(
+    mut commands: Commands,
     mut egui_context: EguiContexts,
     mut _exit: EventWriter<AppExit>,
-    mut _load_workspace: EventWriter<LoadWorkspace>,
+    load_workspace: Res<WorkspaceLoadingServices>,
     mut _app_state: ResMut<State<AppState>>,
     autoload: Option<ResMut<Autoload>>,
     primary_windows: Query<Entity, With<PrimaryWindow>>,
@@ -32,7 +33,7 @@ fn egui_ui(
         #[cfg(not(target_arch = "wasm32"))]
         {
             if let Some(filename) = autoload.filename.take() {
-                _load_workspace.send(LoadWorkspace::Path(filename));
+                load_workspace.load_from_path(&mut commands, filename);
             }
         }
         return;
@@ -57,23 +58,24 @@ fn egui_ui(
 
             ui.horizontal(|ui| {
                 if ui.button("View demo map").clicked() {
-                    _load_workspace.send(LoadWorkspace::Data(WorkspaceData::LegacyBuilding(
-                        demo_office(),
-                    )));
+                    load_workspace.load_from_data(
+                        &mut commands,
+                        WorkspaceData::LegacyBuilding(demo_office()),
+                    );
                 }
 
                 if ui.button("Open a file").clicked() {
-                    _load_workspace.send(LoadWorkspace::Dialog);
+                    load_workspace.load_from_dialog(&mut commands);
                 }
 
                 if ui.button("Create new file").clicked() {
-                    _load_workspace.send(LoadWorkspace::BlankFromDialog);
+                    load_workspace.create_empty_from_dialog(&mut commands);
                 }
 
                 // TODO(@mxgrey): Bring this back when we have finished developing
                 // the key features for workcell editing.
                 // if ui.button("Workcell Editor").clicked() {
-                //     _load_workspace.send(LoadWorkspace::Data(WorkspaceData::Workcell(
+                //     load_workspace.send(LoadWorkspace::Data(WorkspaceData::Workcell(
                 //         demo_workcell(),
                 //     )));
                 // }

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -16,14 +16,14 @@
 */
 
 use super::demo_world::*;
-use crate::{AppState, Autoload, WorkspaceData, WorkspaceLoadingParams};
+use crate::{AppState, Autoload, WorkspaceData, WorkspaceLoader};
 use bevy::{app::AppExit, prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
 
 fn egui_ui(
     mut egui_context: EguiContexts,
     mut _exit: EventWriter<AppExit>,
-    mut load_workspace: WorkspaceLoadingParams,
+    mut workspace_loader: WorkspaceLoader,
     mut _app_state: ResMut<State<AppState>>,
     autoload: Option<ResMut<Autoload>>,
     primary_windows: Query<Entity, With<PrimaryWindow>>,
@@ -32,7 +32,7 @@ fn egui_ui(
         #[cfg(not(target_arch = "wasm32"))]
         {
             if let Some(filename) = autoload.filename.take() {
-                load_workspace.load_from_path(filename);
+                workspace_loader.load_from_path(filename);
             }
         }
         return;
@@ -57,21 +57,21 @@ fn egui_ui(
 
             ui.horizontal(|ui| {
                 if ui.button("View demo map").clicked() {
-                    load_workspace.load_from_data(WorkspaceData::LegacyBuilding(demo_office()));
+                    workspace_loader.load_from_data(WorkspaceData::LegacyBuilding(demo_office()));
                 }
 
                 if ui.button("Open a file").clicked() {
-                    load_workspace.load_from_dialog();
+                    workspace_loader.load_from_dialog();
                 }
 
                 if ui.button("Create new file").clicked() {
-                    load_workspace.create_empty_from_dialog();
+                    workspace_loader.create_empty_from_dialog();
                 }
 
                 // TODO(@mxgrey): Bring this back when we have finished developing
                 // the key features for workcell editing.
                 // if ui.button("Workcell Editor").clicked() {
-                //     load_workspace.send(LoadWorkspace::Data(WorkspaceData::Workcell(
+                //     workspace_loader.send(LoadWorkspace::Data(WorkspaceData::Workcell(
                 //         demo_workcell(),
                 //     )));
                 // }

--- a/rmf_site_editor/src/site/sdf_exporter.rs
+++ b/rmf_site_editor/src/site/sdf_exporter.rs
@@ -11,7 +11,7 @@ use crate::{
         ChildLiftCabinGroup, CollisionMeshMarker, DoorSegments, DrawingMarker, FloorSegments,
         LiftDoormat, ModelSceneRoot, TentativeModelFormat, VisualMeshMarker,
     },
-    Autoload, LoadWorkspace,
+    Autoload, WorkspaceLoadingServices,
 };
 use rmf_site_format::{
     IsStatic, LevelElevation, LiftCabin, ModelMarker, NameInSite, NameOfSite, SiteID, WallMarker,
@@ -51,11 +51,11 @@ pub fn headless_sdf_export(
     sites: Query<(Entity, &NameOfSite)>,
     drawings: Query<Entity, With<DrawingMarker>>,
     autoload: Option<ResMut<Autoload>>,
-    mut load_workspace: EventWriter<LoadWorkspace>,
+    load_workspace: Res<WorkspaceLoadingServices>,
 ) {
     if let Some(mut autoload) = autoload {
         if let Some(filename) = autoload.filename.take() {
-            load_workspace.send(LoadWorkspace::Path(filename));
+            load_workspace.load_from_path(&mut commands, filename);
         }
     } else {
         error!("Cannot perform a headless export since no site file was specified for loading");

--- a/rmf_site_editor/src/site/sdf_exporter.rs
+++ b/rmf_site_editor/src/site/sdf_exporter.rs
@@ -11,7 +11,7 @@ use crate::{
         ChildLiftCabinGroup, CollisionMeshMarker, DoorSegments, DrawingMarker, FloorSegments,
         LiftDoormat, ModelSceneRoot, TentativeModelFormat, VisualMeshMarker,
     },
-    Autoload, WorkspaceLoadingServices,
+    Autoload, WorkspaceLoadingParams,
 };
 use rmf_site_format::{
     IsStatic, LevelElevation, LiftCabin, ModelMarker, NameInSite, NameOfSite, SiteID, WallMarker,
@@ -51,11 +51,11 @@ pub fn headless_sdf_export(
     sites: Query<(Entity, &NameOfSite)>,
     drawings: Query<Entity, With<DrawingMarker>>,
     autoload: Option<ResMut<Autoload>>,
-    load_workspace: Res<WorkspaceLoadingServices>,
+    mut load_workspace: WorkspaceLoadingParams,
 ) {
     if let Some(mut autoload) = autoload {
         if let Some(filename) = autoload.filename.take() {
-            load_workspace.load_from_path(&mut commands, filename);
+            load_workspace.load_from_path(filename);
         }
     } else {
         error!("Cannot perform a headless export since no site file was specified for loading");

--- a/rmf_site_editor/src/site/sdf_exporter.rs
+++ b/rmf_site_editor/src/site/sdf_exporter.rs
@@ -11,7 +11,7 @@ use crate::{
         ChildLiftCabinGroup, CollisionMeshMarker, DoorSegments, DrawingMarker, FloorSegments,
         LiftDoormat, ModelSceneRoot, TentativeModelFormat, VisualMeshMarker,
     },
-    Autoload, WorkspaceLoadingParams,
+    Autoload, WorkspaceLoader,
 };
 use rmf_site_format::{
     IsStatic, LevelElevation, LiftCabin, ModelMarker, NameInSite, NameOfSite, SiteID, WallMarker,
@@ -51,11 +51,11 @@ pub fn headless_sdf_export(
     sites: Query<(Entity, &NameOfSite)>,
     drawings: Query<Entity, With<DrawingMarker>>,
     autoload: Option<ResMut<Autoload>>,
-    mut load_workspace: WorkspaceLoadingParams,
+    mut workspace_loader: WorkspaceLoader,
 ) {
     if let Some(mut autoload) = autoload {
         if let Some(filename) = autoload.filename.take() {
-            load_workspace.load_from_path(filename);
+            workspace_loader.load_from_path(filename);
         }
     } else {
         error!("Cannot perform a headless export since no site file was specified for loading");

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -15,7 +15,9 @@
  *
 */
 
-use crate::{widgets::prelude::*, AppState, CreateNewWorkspace, LoadWorkspace, SaveWorkspace};
+use crate::{
+    widgets::prelude::*, AppState, CreateNewWorkspace, SaveWorkspace, WorkspaceLoadingServices,
+};
 
 use bevy::ecs::query::Has;
 use bevy::prelude::*;
@@ -275,9 +277,10 @@ struct MenuParams<'w, 's> {
 
 fn top_menu_bar(
     In(input): In<PanelWidgetInput>,
+    mut commands: Commands,
     mut new_workspace: EventWriter<CreateNewWorkspace>,
     mut save: EventWriter<SaveWorkspace>,
-    mut load_workspace: EventWriter<LoadWorkspace>,
+    load_workspace: Res<WorkspaceLoadingServices>,
     file_menu: Res<FileMenu>,
     top_level_components: Query<(), Without<Parent>>,
     children: Query<&Children>,
@@ -308,7 +311,7 @@ fn top_menu_bar(
                     .add(Button::new("Open").shortcut_text("Ctrl+O"))
                     .clicked()
                 {
-                    load_workspace.send(LoadWorkspace::Dialog);
+                    load_workspace.load_from_dialog(&mut commands);
                 }
 
                 render_sub_menu(

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-    widgets::prelude::*, AppState, CreateNewWorkspace, SaveWorkspace, WorkspaceLoadingServices,
+    widgets::prelude::*, AppState, CreateNewWorkspace, SaveWorkspace, WorkspaceLoadingParams,
 };
 
 use bevy::ecs::query::Has;
@@ -277,10 +277,9 @@ struct MenuParams<'w, 's> {
 
 fn top_menu_bar(
     In(input): In<PanelWidgetInput>,
-    mut commands: Commands,
     mut new_workspace: EventWriter<CreateNewWorkspace>,
     mut save: EventWriter<SaveWorkspace>,
-    load_workspace: Res<WorkspaceLoadingServices>,
+    mut load_workspace: WorkspaceLoadingParams,
     file_menu: Res<FileMenu>,
     top_level_components: Query<(), Without<Parent>>,
     children: Query<&Children>,
@@ -311,7 +310,7 @@ fn top_menu_bar(
                     .add(Button::new("Open").shortcut_text("Ctrl+O"))
                     .clicked()
                 {
-                    load_workspace.load_from_dialog(&mut commands);
+                    load_workspace.load_from_dialog();
                 }
 
                 render_sub_menu(

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -15,9 +15,7 @@
  *
 */
 
-use crate::{
-    widgets::prelude::*, AppState, CreateNewWorkspace, SaveWorkspace, WorkspaceLoadingParams,
-};
+use crate::{widgets::prelude::*, AppState, CreateNewWorkspace, SaveWorkspace, WorkspaceLoader};
 
 use bevy::ecs::query::Has;
 use bevy::prelude::*;
@@ -279,7 +277,7 @@ fn top_menu_bar(
     In(input): In<PanelWidgetInput>,
     mut new_workspace: EventWriter<CreateNewWorkspace>,
     mut save: EventWriter<SaveWorkspace>,
-    mut load_workspace: WorkspaceLoadingParams,
+    mut workspace_loader: WorkspaceLoader,
     file_menu: Res<FileMenu>,
     top_level_components: Query<(), Without<Parent>>,
     children: Query<&Children>,
@@ -310,7 +308,7 @@ fn top_menu_bar(
                     .add(Button::new("Open").shortcut_text("Ctrl+O"))
                     .clicked()
                 {
-                    load_workspace.load_from_dialog();
+                    workspace_loader.load_from_dialog();
                 }
 
                 render_sub_menu(

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -468,7 +468,7 @@ impl FromWorld for WorkspaceLoadingServices {
     }
 }
 
-impl<'w, 's> WorkspaceLoadingParams<'w, 's> {
+impl<'w, 's> WorkspaceLoader<'w, 's> {
     /// Request to spawn a dialog and load a workspace
     pub fn load_from_dialog(&mut self) {
         self.commands
@@ -503,7 +503,7 @@ impl<'w, 's> WorkspaceLoadingParams<'w, 's> {
 
 /// `SystemParam` used to request for workspace loading operations
 #[derive(SystemParam)]
-pub struct WorkspaceLoadingParams<'w, 's> {
+pub struct WorkspaceLoader<'w, 's> {
     workspace_loading: Res<'w, WorkspaceLoadingServices>,
     commands: Commands<'w, 's>,
 }

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -366,13 +366,13 @@ pub fn process_load_workspace_files(
 /// Services that deal with workspace loading
 pub struct WorkspaceLoadingServices {
     /// Service that spawns an open file dialog and loads a site accordingly.
-    pub load_workspace_from_dialog: Service<(), (), ()>,
+    pub load_workspace_from_dialog: Service<(), ()>,
     /// Service that spawns a save file dialog then creates a site with an empty level.
-    pub create_empty_workspace_from_dialog: Service<(), (), ()>,
+    pub create_empty_workspace_from_dialog: Service<(), ()>,
     /// Loads the workspace at the requested path
-    pub load_workspace_from_path: Service<PathBuf, (), ()>,
+    pub load_workspace_from_path: Service<PathBuf, ()>,
     /// Loads the workspace from the requested data
-    pub load_workspace_from_data: Service<WorkspaceData, (), ()>,
+    pub load_workspace_from_data: Service<WorkspaceData, ()>,
 }
 
 impl FromWorld for WorkspaceLoadingServices {


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Refactor workspace loading to use `bevy_impulse` workflows.

### Implementation description

As noted in the title, first try at using the library so happy to hear ways I can do it better / more efficiently.
Previously we created channels and used a system that spawns a detached async task that sends messages to a channel (for file dialogs) and one that continuously polls that channel to see if any event has been received.
By contrast, now this is done in a workflow where the output of the file selecting is piped into the function that will use it.

I went for an API that removes events altogether and uses workflows instead.
This has, to my understanding, a few benefits:

* We can avoid the overhead of running systems that do nothing 99.99% of the time, note how this PR removes all workspace loading systems.
* We can just use a `Res<>` instead of an `EventWriter` (which is a `ResMut` behind the scenes), potentially increasing parallelism.
* The workflows can be used in a more flexible way. For example, we can trigger a workflow from any system and it will be ran in the next command flush, rather than having them in only one point of the schedule.
* More of a future point but this architecture should be more flexible, we can reuse workflows or part of them in different apps and don't necessarily have to do a single event reading processing kind of architecture, which is a bit harder to extend.

I was on the fence on how to save workflows in the app, I went for a single resource for "all workspace loading workflows" but we can play with modularity and, for example, have one resource per workflow, use marker components, split the services, etc. but that is a whole different discussion.

If this looks good I'll tackle workspace saving next, then go for the really complex one of model handling