### PR TITLE
Filter entities sent for deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5331,9 +5331,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5342,9 +5342,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -5369,9 +5369,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5379,9 +5379,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5392,9 +5392,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wayland-scanner"

--- a/rmf_site_editor/src/site/deletion.rs
+++ b/rmf_site_editor/src/site/deletion.rs
@@ -24,7 +24,10 @@ use crate::{
     },
     AppState, Issue,
 };
-use bevy::{ecs::system::{BoxedSystem, SystemParam, SystemState}, prelude::*};
+use bevy::{
+    ecs::system::{BoxedSystem, SystemParam, SystemState},
+    prelude::*,
+};
 use rmf_site_format::{ConstraintDependents, Edge, MeshConstraint, Path, Point};
 use std::collections::HashSet;
 
@@ -140,13 +143,10 @@ impl DeletionFilters {
     fn run_boxes(
         &mut self,
         mut pending_delete: HashSet<Delete>,
-        world: &mut World
+        world: &mut World,
     ) -> HashSet<Delete> {
         for boxed_system in self.boxed_systems.iter_mut() {
-            pending_delete = boxed_system.0.run(
-                pending_delete,
-                world
-            );
+            pending_delete = boxed_system.0.run(pending_delete, world);
         }
         pending_delete
     }
@@ -154,10 +154,7 @@ impl DeletionFilters {
 
 fn handle_deletion_requests(
     world: &mut World,
-    state: &mut SystemState<(
-        EventReader<Delete>,
-        DeletionParams,
-    )>,
+    state: &mut SystemState<(EventReader<Delete>, DeletionParams)>,
 ) {
     let (mut deletions, _) = state.get_mut(world);
     if deletions.is_empty() {

--- a/rmf_site_editor/src/site/deletion.rs
+++ b/rmf_site_editor/src/site/deletion.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     AppState, Issue,
 };
-use bevy::{ecs::system::SystemParam, prelude::*};
+use bevy::{ecs::system::{SystemParam, SystemState}, prelude::*};
 use rmf_site_format::{ConstraintDependents, Edge, MeshConstraint, Path, Point};
 use std::collections::HashSet;
 
@@ -114,7 +114,11 @@ impl Plugin for DeletionPlugin {
     }
 }
 
-fn handle_deletion_requests(mut deletions: EventReader<Delete>, mut params: DeletionParams) {
+fn handle_deletion_requests(
+    world: &mut World,
+    state: &mut SystemState<(EventReader<Delete>, DeletionParams)>,
+) {
+    let (mut deletions, mut params) = state.get_mut(world);
     for delete in deletions.read() {
         if delete.and_dependents {
             recursive_dependent_delete(delete.element, &mut params);
@@ -122,6 +126,7 @@ fn handle_deletion_requests(mut deletions: EventReader<Delete>, mut params: Dele
             cautious_delete(delete.element, &mut params);
         }
     }
+    state.apply(world);
 }
 
 fn cautious_delete(element: Entity, params: &mut DeletionParams) {


### PR DESCRIPTION
Currently when we select an entity to be deleted, it is sent as a `Delete` event to the `handle_deletion_requests` system and goes through a series of `if` conditions to filter out any entities that cannot/should not be deleted but processed in another manner. As we add in more plugins this system can become fairly bloated with various types of entities across the site editor.

This PR adds a series of BoxedSystems as a resource to the world that takes over some of the filtering work. The `Delete` events are read by the same `handle_deletion_systems` and goes through a vector of filter systems. If any entity should not be permanently deleted, e.g. temporarily removed or hidden, it can be filtered out in one of these systems. The set of entities left at the end of this filtering process will then be sent for deletion as usual.

An example of a BoxedSystem implementation is available [here](https://github.com/open-rmf/rmf_site/blob/xiyu/scenarios-with-deletion/rmf_site_editor/src/site/scenario.rs#L256) (updated) in relation to the scenarios PR https://github.com/open-rmf/rmf_site/pull/242. Here we demonstrate filtering out entities based on the current scenario using the BoxedSystem `filter_instance_deletion`.