### PR TITLE
Remove hard dependency on UserCameraDisplay for Interaction plugin

### DIFF
--- a/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
@@ -85,7 +85,7 @@ pub fn update_keyboard_command(
     immediate_raycast: Raycast,
     time: Res<Time>,
     primary_windows: Query<&Window, With<PrimaryWindow>>,
-    uncovered_window_area: Res<UserCameraDisplay>,
+    uncovered_window_area: Option<Res<UserCameraDisplay>>,
 ) {
     if let Ok(_) = primary_windows.get_single() {
         // User inputs

--- a/rmf_site_editor/src/interaction/camera_controls/utils.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/utils.rs
@@ -72,11 +72,16 @@ pub fn zoom_distance_factor(camera_translation: Vec3, target_translation: Vec3) 
 pub fn get_camera_selected_point(
     camera: &Camera,
     camera_global_transform: &GlobalTransform,
-    user_camera_display: Res<UserCameraDisplay>,
+    user_camera_display: Option<Res<UserCameraDisplay>>,
     mut immediate_raycast: Raycast,
 ) -> Option<Vec3> {
-    // Assume that the camera spans the full window, covered by egui panels
-    let available_viewport_center = user_camera_display.region.center();
+    let available_viewport_center = user_camera_display
+        // Assume that the camera spans the full window, covered by egui panels
+        .map(|display| display.region)
+        // If egui panels aren't being used, then use the center of the whole camera
+        .or_else(|| camera.logical_viewport_rect())?
+        .center();
+
     let camera_ray =
         camera.viewport_to_world(camera_global_transform, available_viewport_center)?;
     let camera_ray = Ray3d::new(camera_ray.origin, camera_ray.direction);

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -20,7 +20,6 @@ use crate::site::{
     FiducialMarker, FloorMarker, LaneMarker, LiftCabin, LiftCabinDoorMarker, LocationTags,
     MeasurementMarker, SiteUpdateSet, ToggleLiftDoorAvailability, VisualMeshMarker, WallMarker,
 };
-use crate::widgets::UserCameraDisplayPlugin;
 
 pub mod anchor;
 pub use anchor::*;
@@ -173,11 +172,7 @@ impl Plugin for InteractionPlugin {
                 CategoryVisibilityPlugin::<MeasurementMarker>::visible(true),
                 CategoryVisibilityPlugin::<WallMarker>::visible(true),
             ))
-            .add_plugins((
-                CameraControlsPlugin,
-                ModelPreviewPlugin,
-                UserCameraDisplayPlugin::default(),
-            ));
+            .add_plugins((CameraControlsPlugin, ModelPreviewPlugin));
 
         if !self.headless {
             app.add_plugins(SelectionPlugin::default())

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -162,6 +162,7 @@ impl Plugin for StandardUiPlugin {
                 DiagnosticsPlugin::default(),
                 ConsoleWidgetPlugin::default(),
                 WorkspaceMenuPlugin::default(),
+                UserCameraDisplayPlugin::default(),
                 #[cfg(not(target_arch = "wasm32"))]
                 SdfExportMenuPlugin::default(),
             ))


### PR DESCRIPTION
This PR does a soft decoupling of the Interaction and Widget plugins. I can foresee downstream users not wanting the Widget plugin at all, for example if they want to embed the site editor into an Angular frame where Angular takes care of providing widgets.

I tested this by replacing [this block](https://github.com/open-rmf/rmf_site/blob/d05474aeb428f27c2ffe9fe02f026cff6c073b48/rmf_site_editor/src/lib.rs#L221-L223) with just

```
app.add_plugins( MainMenuPlugin);
```

and then running

```
cargo run --release -- assets/demo_maps/office.building.yaml
```

and using Shift + arrow keys to see that the rotation is handled correctly.