### PR TITLE
Early support for undo in `ChangePlugin`

### DIFF
--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -111,6 +111,9 @@ pub use site_visualizer::*;
 pub mod texture;
 pub use texture::*;
 
+pub mod undo_plugin;
+pub use undo_plugin::*;
+
 pub mod util;
 pub use util::*;
 
@@ -212,6 +215,7 @@ impl Plugin for SitePlugin {
             ChangePlugin::<Scale>::default(),
             ChangePlugin::<Distance>::default(),
             ChangePlugin::<Texture>::default(),
+            UndoPlugin::default()
         ))
         .add_plugins((
             ChangePlugin::<DoorType>::default(),

--- a/rmf_site_editor/src/site/undo_plugin.rs
+++ b/rmf_site_editor/src/site/undo_plugin.rs
@@ -1,0 +1,77 @@
+use bevy::{ecs::event, prelude::*};
+use bevy_impulse::event_streaming_service;
+use std::fmt::Debug;
+
+use crate::{EditMenu, MenuEvent, MenuItem};
+
+#[derive(Event, Debug, Clone, Copy)]
+pub struct UndoEvent {
+    pub action_id: usize
+}
+
+#[derive(Resource)]
+struct UndoMenu{
+    menu_entity: Entity
+}
+///TODO(arjo): Decouple
+impl FromWorld for UndoMenu {
+    fn from_world(world: &mut World) -> Self {
+        let undo_label = world.spawn(
+            MenuItem::Text("Undo".into())).id();
+        let edit_menu = world.resource::<EditMenu>().get();
+        world.entity_mut(edit_menu).push_children(&[undo_label]);
+        Self {
+            menu_entity: undo_label
+        }
+    }
+}
+
+fn watch_undo_click(
+    mut reader: EventReader<MenuEvent>,
+    menu_handle: Res<UndoMenu>,
+    mut undo_buffer: ResMut<UndoBuffer>,
+    mut event_writer: EventWriter<UndoEvent>)
+{
+    for menu_click in reader.read() {
+        if menu_click.clicked() && menu_click.source() == menu_handle.menu_entity {
+            let Some(undo_item) = undo_buffer.undo_last() else {
+                continue;
+            };
+            event_writer.send(UndoEvent {
+                action_id: undo_item
+            });
+        }
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct UndoBuffer {
+    pub prev_value: usize,
+    pub undo_stack: Vec<usize>
+}
+
+impl UndoBuffer {
+    pub fn get_next_revision(&mut self) -> usize {
+        self.prev_value += 1;
+        self.undo_stack.push(self.prev_value);
+        self.prev_value
+    }
+
+    pub fn undo_last(&mut self) -> Option<usize> {
+        self.undo_stack.pop()
+    }
+}
+
+#[derive(Default)]
+pub struct UndoPlugin;
+
+impl Plugin for UndoPlugin {
+    fn build(&self, app: &mut App) {
+        app
+        .init_resource::<EditMenu>()
+        .init_resource::<UndoMenu>()
+        .init_resource::<UndoBuffer>()
+        .add_event::<UndoEvent>()
+        .add_systems(Update,(watch_undo_click));
+    }
+}

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -183,6 +183,29 @@ impl FromWorld for ViewMenu {
     }
 }
 
+#[derive(Resource)]
+pub struct EditMenu {
+    /// Map of menu items
+    menu_item: Entity,
+}
+
+impl EditMenu {
+    pub fn get(&self) -> Entity {
+        return self.menu_item;
+    }
+}
+
+impl FromWorld for EditMenu {
+    fn from_world(world: &mut World) -> Self {
+        let menu_item = world
+            .spawn(Menu {
+                text: "Edit".to_string(),
+            })
+            .id();
+        Self { menu_item }
+    }
+}
+
 #[non_exhaustive]
 #[derive(Event)]
 pub enum MenuEvent {
@@ -304,6 +327,7 @@ fn top_menu_bar(
                     true,
                 );
             });
+
             ui.menu_button("View", |ui| {
                 render_sub_menu(
                     ui,


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This provides a POC version of undo for the `ChangePlugin`. We still have to implement undo for movement, adding and deleteing items. One thing to note is that the current architecture assumes a change at the individual component level. Also currently, we need `ResMut` access tot he undo buffer from all change plugins. There may come a time where we may want to change multiple components in a single operation.

#### TODO
- [ ] Deletion
- [ ] Addition of models

### Implementation description

