### PR TITLE
Update readme so bindgen installation matches what we need

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Make sure you install rust from the main rust website. Cargo should take care of
 These are only needed if you're going to build a WebAssembly binary:
 ```bash
 $ sudo apt install binaryen
-$ cargo install wasm-bindgen-cli basic-http-server
+$ cargo install -f wasm-bindgen-cli --version 0.2.93
+$ cargo install basic-http-server
 $ rustup target add wasm32-unknown-unknown
 ```
 

--- a/rmf_site_editor_web/Cargo.toml
+++ b/rmf_site_editor_web/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["cdylib", "rlib"]
 name = "librmf_site_editor_web"
 
 [dependencies]
-wasm-bindgen = "=0.2.93"
+wasm-bindgen = "=0.2.93" # Remember to update the README if we change this version number
 rmf_site_editor = { path = "../rmf_site_editor" }
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
Following up on #253 this updates the README so users know which specific version of bindgen to install.