### PR TITLE
Make the inner bundle of Parented transparent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bevy"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +509,7 @@ dependencies = [
  "futures-lite 1.13.0",
  "js-sys",
  "parking_lot",
- "ron",
+ "ron 0.8.1",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -1092,7 +1098,7 @@ dependencies = [
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
- "ron",
+ "ron 0.8.1",
  "serde",
  "thiserror",
  "uuid",
@@ -4067,7 +4073,7 @@ dependencies = [
  "glam",
  "once_cell",
  "pathdiff",
- "ron",
+ "ron 0.9.0-alpha.0",
  "sdformat_rs",
  "serde",
  "serde_json",
@@ -4106,6 +4112,18 @@ dependencies = [
  "bitflags 2.4.2",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "ron"
+version = "0.9.0-alpha.0"
+source = "git+https://github.com/ron-rs/ron?branch=master#74666478d5553592c6136e0dec12d11bbd10302e"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.4.2",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -13,7 +13,8 @@ serde_yaml = "0.8.23"
 serde_json = "*"
 strum = "*"
 strum_macros = "*"
-ron = "0.8"
+# We need ron v0.9 to be released before RON works correctly for structs with #[serde(flatten)]
+ron = { git = "https://github.com/ron-rs/ron", branch = "master" }
 thiserror = "*"
 glam = { version = "0.24", features = ["serde"] }
 uuid = { version = "1.1", features = ["v4", "serde"] }

--- a/rmf_site_format/src/misc.rs
+++ b/rmf_site_format/src/misc.rs
@@ -476,6 +476,7 @@ pub struct SiteID(pub u32);
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Parented<P: RefTrait, T> {
     pub parent: P,
+    #[serde(flatten)]
     pub bundle: T,
 }
 

--- a/rmf_site_format/src/model.rs
+++ b/rmf_site_format/src/model.rs
@@ -98,6 +98,7 @@ impl<T: RefTrait> OptionalModelProperty<T> {
 /// Defines a property in a model description, that will be added to all instances
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(Component))]
+#[serde(transparent)]
 pub struct OptionalModelProperties<T: RefTrait>(pub Vec<OptionalModelProperty<T>>);
 
 impl<T: RefTrait> Default for OptionalModelProperties<T> {

--- a/rmf_site_format/src/sdf.rs
+++ b/rmf_site_format/src/sdf.rs
@@ -870,6 +870,6 @@ mod tests {
             ..Default::default()
         };
         let s = yaserde::ser::to_string_with_config(&sdf, &config).unwrap();
-        std::fs::write("test.sdf", s);
+        std::fs::write("test.sdf", s).unwrap();
     }
 }

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -167,13 +167,21 @@ impl Site {
     pub fn to_writer_ron<W: io::Write>(&self, mut writer: W) -> ron::Result<()> {
         let mut contents = String::new();
         ron::ser::to_writer_pretty(&mut contents, self, default_style_config())?;
-        writer.write_all(contents.as_bytes()).map_err(ron::Error::from)
+        writer
+            .write_all(contents.as_bytes())
+            .map_err(ron::Error::from)
     }
 
-    pub fn to_writer_custom_ron<W: io::Write>(&self, mut writer: W, style: Style) -> ron::Result<()> {
+    pub fn to_writer_custom_ron<W: io::Write>(
+        &self,
+        mut writer: W,
+        style: Style,
+    ) -> ron::Result<()> {
         let mut contents = String::new();
         ron::ser::to_writer_pretty(&mut contents, self, style)?;
-        writer.write_all(contents.as_bytes()).map_err(ron::Error::from)
+        writer
+            .write_all(contents.as_bytes())
+            .map_err(ron::Error::from)
     }
 
     pub fn to_string_ron(&self) -> ron::Result<String> {

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -164,12 +164,16 @@ fn default_style_config() -> Style {
 }
 
 impl Site {
-    pub fn to_writer_ron<W: io::Write>(&self, writer: W) -> ron::Result<()> {
-        ron::ser::to_writer_pretty(writer, self, default_style_config())
+    pub fn to_writer_ron<W: io::Write>(&self, mut writer: W) -> ron::Result<()> {
+        let mut contents = String::new();
+        ron::ser::to_writer_pretty(&mut contents, self, default_style_config())?;
+        writer.write_all(contents.as_bytes()).map_err(ron::Error::from)
     }
 
-    pub fn to_writer_custom_ron<W: io::Write>(&self, writer: W, style: Style) -> ron::Result<()> {
-        ron::ser::to_writer_pretty(writer, self, style)
+    pub fn to_writer_custom_ron<W: io::Write>(&self, mut writer: W, style: Style) -> ron::Result<()> {
+        let mut contents = String::new();
+        ron::ser::to_writer_pretty(&mut contents, self, style)?;
+        writer.write_all(contents.as_bytes()).map_err(ron::Error::from)
     }
 
     pub fn to_string_ron(&self) -> ron::Result<String> {
@@ -260,6 +264,7 @@ mod tests {
         let data = std::fs::read("../assets/demo_maps/office.building.yaml").unwrap();
         let map = BuildingMap::from_bytes(&data).unwrap();
         let site_string = map.to_site().unwrap().to_string_ron().unwrap();
+        println!("{site_string}");
         Site::from_str_ron(&site_string).unwrap();
     }
 

--- a/rmf_site_format/src/site.rs
+++ b/rmf_site_format/src/site.rs
@@ -202,6 +202,18 @@ impl Site {
         serde_json::to_vec_pretty(self)
     }
 
+    pub fn to_bytes_json_pretty(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(self)
+    }
+
+    pub fn to_string_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+
+    pub fn to_string_json_pretty(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
     pub fn from_bytes_ron<'a>(s: &'a [u8]) -> ron::error::SpannedResult<Self> {
         ron::de::from_bytes(s)
     }
@@ -257,5 +269,13 @@ mod tests {
         let map = BuildingMap::from_bytes(&data).unwrap();
         let site_string = map.to_site().unwrap().to_bytes_json().unwrap();
         Site::from_bytes_json(&site_string).unwrap();
+    }
+
+    #[test]
+    fn produce_json_string() {
+        let data = std::fs::read("../assets/demo_maps/office.building.yaml").unwrap();
+        let map = BuildingMap::from_bytes(&data).unwrap();
+        let text = map.to_site().unwrap().to_string_json_pretty().unwrap();
+        println!("{text}");
     }
 }


### PR DESCRIPTION
A small tweak to how to things nested inside of `Parented` get serialized:

Before
```json
"166": {
    "parent": 1,
    "bundle": {
        "name": "tinyRobot2",
        "pose": {
            "trans": [
                20.423693,
                -5.312098,
                0.0
            ],
            "rot": {
                "yaw": {
                    "deg": 0.0
                }
            }
        },
        "description": 164,
        "optional_properties": []
    }
}
```

After
```json
"166": {
    "parent": 1,
    "name": "tinyRobot2",
    "pose": {
        "trans": [
            20.423693,
            -5.312098,
            0.0
        ],
        "rot": {
            "yaw": {
                "deg": 0.0
            }
        }
    },
    "description": 164,
    "optional_properties": []
}
```

This PR reduces some unnecessary struct nesting in the serialized output.