### PR TITLE
Implement RecallPlugin for RobotPropertyKind

### DIFF
--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
@@ -18,8 +18,8 @@
 use super::{
     get_selected_description_entity,
     inspect_robot_properties::{
-        serialize_and_change_robot_property, show_robot_property_widget, RobotProperty,
-        RobotPropertyKind, RobotPropertyWidgetRegistry,
+        serialize_and_change_robot_property, show_robot_property_widget, RecallPropertyKind,
+        RobotProperty, RobotPropertyKind, RobotPropertyWidgetRegistry,
     },
     ModelPropertyQuery,
 };
@@ -181,6 +181,32 @@ impl Default for CircleCollision {
 impl RobotPropertyKind for CircleCollision {
     fn label() -> String {
         "Circle Collision".to_string()
+    }
+}
+
+#[derive(Clone, Debug, Default, Component, PartialEq)]
+pub struct RecallCircleCollision {
+    pub radius: Option<f32>,
+    pub offset: Option<[f32; 2]>,
+}
+
+impl RecallPropertyKind for RecallCircleCollision {
+    type Kind = CircleCollision;
+
+    fn assume(&self) -> CircleCollision {
+        CircleCollision {
+            radius: self.radius.clone().unwrap_or_default(),
+            offset: self.offset.clone().unwrap_or_default(),
+        }
+    }
+}
+
+impl Recall for RecallCircleCollision {
+    type Source = CircleCollision;
+
+    fn remember(&mut self, source: &CircleCollision) {
+        self.radius = Some(source.radius);
+        self.offset = Some(source.offset);
     }
 }
 

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_mobility.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_mobility.rs
@@ -18,8 +18,8 @@
 use super::{
     get_selected_description_entity,
     inspect_robot_properties::{
-        serialize_and_change_robot_property, show_robot_property_widget, RobotProperty,
-        RobotPropertyKind, RobotPropertyWidgetRegistry,
+        serialize_and_change_robot_property, show_robot_property_widget, RecallPropertyKind,
+        RobotProperty, RobotPropertyKind, RobotPropertyWidgetRegistry,
     },
     ModelPropertyQuery,
 };
@@ -185,6 +185,38 @@ impl Default for DifferentialDrive {
 impl RobotPropertyKind for DifferentialDrive {
     fn label() -> String {
         "Differential Drive".to_string()
+    }
+}
+
+#[derive(Clone, Debug, Default, Component, PartialEq)]
+pub struct RecallDifferentialDrive {
+    pub bidirectional: Option<bool>,
+    pub rotation_center_offset: Option<[f32; 2]>,
+    pub translational_speed: Option<f32>,
+    pub rotational_speed: Option<f32>,
+}
+
+impl RecallPropertyKind for RecallDifferentialDrive {
+    type Kind = DifferentialDrive;
+
+    fn assume(&self) -> DifferentialDrive {
+        DifferentialDrive {
+            bidirectional: self.bidirectional.clone().unwrap_or_default(),
+            rotation_center_offset: self.rotation_center_offset.clone().unwrap_or_default(),
+            translational_speed: self.translational_speed.clone().unwrap_or_default(),
+            rotational_speed: self.rotational_speed.clone().unwrap_or_default(),
+        }
+    }
+}
+
+impl Recall for RecallDifferentialDrive {
+    type Source = DifferentialDrive;
+
+    fn remember(&mut self, source: &DifferentialDrive) {
+        self.bidirectional = Some(source.bidirectional);
+        self.rotation_center_offset = Some(source.rotation_center_offset);
+        self.translational_speed = Some(source.translational_speed);
+        self.rotational_speed = Some(source.rotational_speed);
     }
 }
 

--- a/rmf_site_editor/src/widgets/inspector/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/mod.rs
@@ -208,33 +208,30 @@ impl Plugin for StandardInspectorPlugin {
                 InspectModelDescriptionPlugin::default(),
                 InspectLiftPlugin::default(),
             ))
-            .add_plugins(
-                (
-                    // Required model properties
-                    InspectModelPropertyPlugin::<InspectModelScale, Scale>::new(
-                        "Scale".to_string(),
-                    ),
-                    InspectModelPropertyPlugin::<InspectModelAssetSource, AssetSource>::new(
-                        "Asset Source".to_string(),
-                    ),
-                    InspectRobotPropertiesPlugin::default(),
-                    InspectRobotPropertyPlugin::<InspectMobility, Mobility, RecallMobility>::new(),
-                    InspectRobotPropertyPlugin::<InspectCollision, Collision, RecallCollision>::new(
-                    ),
-                    InspectRobotPropertyKindPlugin::<
-                        InspectDifferentialDrive,
-                        DifferentialDrive,
-                        Mobility,
-                    >::new(),
-                    InspectRobotPropertyKindPlugin::<
-                        InspectCircleCollision,
-                        CircleCollision,
-                        Collision,
-                    >::new(),
-                    InspectTaskPlugin::default(),
-                    InspectDefaultTasksPlugin::default(),
+            .add_plugins((
+                // Required model properties
+                InspectModelPropertyPlugin::<InspectModelScale, Scale>::new("Scale".to_string()),
+                InspectModelPropertyPlugin::<InspectModelAssetSource, AssetSource>::new(
+                    "Asset Source".to_string(),
                 ),
-            );
+                InspectRobotPropertiesPlugin::default(),
+                InspectRobotPropertyPlugin::<InspectMobility, Mobility, RecallMobility>::new(),
+                InspectRobotPropertyPlugin::<InspectCollision, Collision, RecallCollision>::new(),
+                InspectRobotPropertyKindPlugin::<
+                    InspectDifferentialDrive,
+                    DifferentialDrive,
+                    Mobility,
+                    RecallDifferentialDrive,
+                >::new(),
+                InspectRobotPropertyKindPlugin::<
+                    InspectCircleCollision,
+                    CircleCollision,
+                    Collision,
+                    RecallCircleCollision,
+                >::new(),
+                InspectTaskPlugin::default(),
+                InspectDefaultTasksPlugin::default(),
+            ));
     }
 }
 


### PR DESCRIPTION
This PR implements Recall for RobotPropertyKinds such that if a Recall value is available in the world and `update_robot_property_kind_components` receives a default value of the RobotPropertyKind, the recalled value will be used to update property kind. Otherwise, we will insert the default value. The `RecallPropertyKind` trait is also introduced to enable access to the recalled value for each property kind via `assume()`.

This fixes the current behavior where the value resets to default if the property kind is re-selected or switched.