### PR TITLE
replaced a few expects

### DIFF
--- a/rmf_site_editor/src/site/anchor.rs
+++ b/rmf_site_editor/src/site/anchor.rs
@@ -205,14 +205,13 @@ pub fn check_for_close_unconnected_anchors(
                     let poses = anchor_poses.entry(level).or_default();
                     poses.push((
                         e,
-                        match anchors
-                            .point_in_parent_frame_of(e, Category::General, level) {
-                                Ok(p) => p,
-                                Err(err) => {
-                                    error!("Failed fetching anchor pose {:?}", err);
-                                    continue;
-                                }
+                        match anchors.point_in_parent_frame_of(e, Category::General, level) {
+                            Ok(p) => p,
+                            Err(err) => {
+                                error!("Failed fetching anchor pose {:?}", err);
+                                continue;
                             }
+                        },
                     ));
                 }
             }

--- a/rmf_site_editor/src/site/anchor.rs
+++ b/rmf_site_editor/src/site/anchor.rs
@@ -205,9 +205,14 @@ pub fn check_for_close_unconnected_anchors(
                     let poses = anchor_poses.entry(level).or_default();
                     poses.push((
                         e,
-                        anchors
-                            .point_in_parent_frame_of(e, Category::General, level)
-                            .expect("Failed fetching anchor pose"),
+                        match anchors
+                            .point_in_parent_frame_of(e, Category::General, level) {
+                                Ok(p) => p,
+                                Err(err) => {
+                                    error!("Failed fetching anchor pose {:?}", err);
+                                    continue;
+                                }
+                            }
                     ));
                 }
             }

--- a/rmf_site_editor/src/site/drawing_editor/alignment.rs
+++ b/rmf_site_editor/src/site/drawing_editor/alignment.rs
@@ -111,9 +111,9 @@ pub fn align_site_drawings(
                         };
                         let in_meters = in_meters as f64;
                         let p0 =
-                            Vec2::from_slice(anchor0.translation_for_category(Category::Fiducial));
+                            Vec2::from_array(anchor0.translation_for_category(Category::Fiducial));
                         let p1 =
-                            Vec2::from_slice(anchor1.translation_for_category(Category::Fiducial));
+                            Vec2::from_array(anchor1.translation_for_category(Category::Fiducial));
                         let in_pixels = (p1 - p0).length() as f64;
                         drawing_variables.measurements.push(MeasurementVariables {
                             in_pixels,

--- a/rmf_site_editor/src/site/fuel_cache.rs
+++ b/rmf_site_editor/src/site/fuel_cache.rs
@@ -114,9 +114,9 @@ pub fn handle_update_fuel_cache_requests(
                 let res = fuel_client
                     .update_cache_with_progress(write_to_disk, Some(progress))
                     .await;
-                sender
-                    .send(FuelCacheUpdated(res))
-                    .expect("Failed sending fuel cache update event");
+                if let Err(err) = sender.send(FuelCacheUpdated(res)) {
+                    error!("Failed sending fuel cache update event {:?}", err);
+                };
             })
             .detach();
     }

--- a/rmf_site_editor/src/site_asset_io.rs
+++ b/rmf_site_editor/src/site_asset_io.rs
@@ -153,7 +153,9 @@ fn save_to_cache(name: &str, bytes: &[u8]) {
     asset_path.push(PathBuf::from(name));
     fs::create_dir_all(asset_path.parent().unwrap()).unwrap();
     if bytes.len() > 0 {
-        fs::write(asset_path, bytes).expect("unable to write to file");
+        if let Err(err) = std::fs::write(asset_path, bytes) {
+            error!("Unable to write to file {:?}", err);
+        };
     }
 }
 

--- a/rmf_site_format/src/anchor.rs
+++ b/rmf_site_format/src/anchor.rs
@@ -16,6 +16,7 @@
 */
 
 use crate::{Categorized, Category, Pose};
+use bevy::utils::tracing::error;
 #[cfg(feature = "bevy")]
 use bevy::{
     ecs::{query::QueryEntityError, system::SystemParam},
@@ -23,7 +24,6 @@ use bevy::{
 };
 use glam::{Vec2, Vec3};
 use serde::{Deserialize, Serialize};
-use bevy::utils::tracing::error;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 // TODO(MXG): Change this to untagged for a cleaner looking format once this
@@ -42,7 +42,9 @@ impl From<[f32; 2]> for Anchor {
     }
 }
 
-fn to_slice(p: &[f32; 3]) -> [f32; 2] { [p[0], p[1]] }
+fn to_slice(p: &[f32; 3]) -> [f32; 2] {
+    [p[0], p[1]]
+}
 
 impl Anchor {
     pub fn translation_for_category(&self, category: Category) -> [f32; 2] {

--- a/rmf_site_format/src/anchor.rs
+++ b/rmf_site_format/src/anchor.rs
@@ -16,7 +16,6 @@
 */
 
 use crate::{Categorized, Category, Pose};
-use bevy::utils::tracing::error;
 #[cfg(feature = "bevy")]
 use bevy::{
     ecs::{query::QueryEntityError, system::SystemParam},
@@ -42,7 +41,7 @@ impl From<[f32; 2]> for Anchor {
     }
 }
 
-fn to_slice(p: &[f32; 3]) -> [f32; 2] {
+fn to_array2(p: &[f32; 3]) -> [f32; 2] {
     [p[0], p[1]]
 }
 
@@ -51,7 +50,7 @@ impl Anchor {
         match self {
             Self::Translate2D(v) => *v,
             Self::CategorizedTranslate2D(v) => *v.for_category(category),
-            Self::Pose3D(p) => to_slice(&p.trans),
+            Self::Pose3D(p) => to_array2(&p.trans),
         }
     }
 
@@ -74,7 +73,7 @@ impl Anchor {
                         return true;
                     }
                     Self::Pose3D(p) => {
-                        let p_right = Vec2::from_array(to_slice(&p.trans));
+                        let p_right = Vec2::from_array(to_array2(&p.trans));
                         return (p_left - p_right).length() <= dist;
                     }
                 }
@@ -97,7 +96,7 @@ impl Anchor {
                 }
                 Self::Pose3D(p) => {
                     let p_left = Vec2::from_array(*left_categories.for_general());
-                    let p_right = Vec2::from_array(to_slice(&p.trans));
+                    let p_right = Vec2::from_array(to_array2(&p.trans));
                     return (p_left - p_right).length() <= dist;
                 }
             },

--- a/rmf_site_format/src/anchor.rs
+++ b/rmf_site_format/src/anchor.rs
@@ -42,23 +42,14 @@ impl From<[f32; 2]> for Anchor {
     }
 }
 
-fn to_slice(p: &[f32]) -> &[f32; 2] {
-    match p.try_into() {
-        Ok(p) => p,
-        Err(e) => {
-            error!("Wrong array size {:?}", e);
-            // TODO what should this return be?
-            return &[0.0;2];
-        }
-    }
-}
+fn to_slice(p: &[f32; 3]) -> [f32; 2] { [p[0], p[1]] }
 
 impl Anchor {
-    pub fn translation_for_category(&self, category: Category) -> &[f32; 2] {
+    pub fn translation_for_category(&self, category: Category) -> [f32; 2] {
         match self {
-            Self::Translate2D(v) => v,
-            Self::CategorizedTranslate2D(v) => v.for_category(category),
-            Self::Pose3D(p) => to_slice(&p.trans[0..2]),
+            Self::Translate2D(v) => *v,
+            Self::CategorizedTranslate2D(v) => *v.for_category(category),
+            Self::Pose3D(p) => to_slice(&p.trans),
         }
     }
 
@@ -81,7 +72,7 @@ impl Anchor {
                         return true;
                     }
                     Self::Pose3D(p) => {
-                        let p_right = Vec2::from_array(*to_slice(&p.trans[0..2]));
+                        let p_right = Vec2::from_array(to_slice(&p.trans));
                         return (p_left - p_right).length() <= dist;
                     }
                 }
@@ -104,7 +95,7 @@ impl Anchor {
                 }
                 Self::Pose3D(p) => {
                     let p_left = Vec2::from_array(*left_categories.for_general());
-                    let p_right = Vec2::from_array(*to_slice(&p.trans[0..2]));
+                    let p_right = Vec2::from_array(to_slice(&p.trans));
                     return (p_left - p_right).length() <= dist;
                 }
             },
@@ -141,8 +132,8 @@ impl Anchor {
         match category {
             Category::General => tf.translation(),
             category => {
-                let dp = Vec2::from(*self.translation_for_category(category))
-                    - Vec2::from(*self.translation_for_category(Category::General));
+                let dp = Vec2::from(self.translation_for_category(category))
+                    - Vec2::from(self.translation_for_category(Category::General));
                 tf.affine().transform_point3([dp.x, dp.y, 0.0].into())
             }
         }

--- a/rmf_site_format/src/anchor.rs
+++ b/rmf_site_format/src/anchor.rs
@@ -23,6 +23,7 @@ use bevy::{
 };
 use glam::{Vec2, Vec3};
 use serde::{Deserialize, Serialize};
+use bevy::utils::tracing::error;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 // TODO(MXG): Change this to untagged for a cleaner looking format once this
@@ -42,7 +43,14 @@ impl From<[f32; 2]> for Anchor {
 }
 
 fn to_slice(p: &[f32]) -> &[f32; 2] {
-    p.try_into().expect("Wrong array size")
+    match p.try_into() {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Wrong array size {:?}", e);
+            // TODO what should this return be?
+            return &[0.0;2];
+        }
+    }
 }
 
 impl Anchor {

--- a/rmf_site_format/src/camera_poses.rs
+++ b/rmf_site_format/src/camera_poses.rs
@@ -42,7 +42,7 @@ impl UserCameraPose {
         let mut count = 0;
         let mut trans = Vec3::default();
         for anchor in anchors {
-            let anchor_trans = *anchor.translation_for_category(Category::Level);
+            let anchor_trans = anchor.translation_for_category(Category::Level);
             trans[0] = trans[0] + anchor_trans[0];
             trans[1] = trans[1] + anchor_trans[1];
             count += 1;

--- a/rmf_site_format/src/legacy/nav_graph.rs
+++ b/rmf_site_format/src/legacy/nav_graph.rs
@@ -112,7 +112,7 @@ impl NavGraph {
                             yaw,
                             [center.trans[0], center.trans[1]].into(),
                         );
-                        let trans = lift_tf.transform_point2((*trans).into());
+                        let trans = lift_tf.transform_point2((trans).into());
                         let anchor = Anchor::Translate2D([trans[0], trans[1]]);
 
                         anchor_to_vertex.insert(*id, vertices.len());
@@ -158,7 +158,7 @@ impl NavGraph {
                         door_name.clone(),
                         NavDoor {
                             map: level.properties.name.0.clone(),
-                            endpoints: [*v0, *v1],
+                            endpoints: [v0, v1],
                         },
                     );
                 }
@@ -278,7 +278,7 @@ pub struct NavVertex(pub f32, pub f32, pub NavVertexProperties);
 
 impl NavVertex {
     fn from_anchor(anchor: &Anchor, location: Option<&Location<u32>>) -> Self {
-        let p = *anchor.translation_for_category(Category::General);
+        let p = anchor.translation_for_category(Category::General);
         Self(p[0], p[1], NavVertexProperties::from_location(location))
     }
 }

--- a/rmf_site_format/src/sdf.rs
+++ b/rmf_site_format/src/sdf.rs
@@ -18,13 +18,11 @@
 use crate::{
     Anchor, Angle, AssetSource, Category, DoorType, Level, LiftCabin, Pose, Rotation, Site, Swing,
 };
-use bevy::{prelude::*, utils::tracing};
 use glam::Vec3;
 use once_cell::sync::Lazy;
 use sdformat_rs::*;
 use std::collections::BTreeMap;
 use thiserror::Error;
-use tracing::error;
 
 const DEFAULT_CABIN_MASS: f64 = 1200.0;
 

--- a/rmf_site_format/src/sdf.rs
+++ b/rmf_site_format/src/sdf.rs
@@ -49,8 +49,8 @@ pub enum SdfConversionError {
     BrokenModelInstanceReference(u32),
     #[error("Entity [{0}] referenced a non existing model description")]
     BrokenModelDescriptionReference(u32),
-    #[error("Failed deserializing world template")]
-    CorruptedWorldTemplate,
+    #[error("Failed deserializing world template: {0}")]
+    CorruptedWorldTemplate(String),
 }
 
 impl Pose {
@@ -433,8 +433,9 @@ impl Site {
                 .get(&id)
                 .ok_or(SdfConversionError::BrokenLevelReference(id))
         };
-        let Ok(mut root) = WORLD_TEMPLATE.clone() else {
-            return Err(SdfConversionError::CorruptedWorldTemplate);
+        let mut root = match WORLD_TEMPLATE.clone() {
+            Ok(root) => root,
+            Err(err) => return Err(SdfConversionError::CorruptedWorldTemplate(err)),
         };
         let world = &mut root.world[0];
         let mut min_elevation = f32::MAX;

--- a/rmf_site_format/src/sdf.rs
+++ b/rmf_site_format/src/sdf.rs
@@ -18,19 +18,18 @@
 use crate::{
     Anchor, Angle, AssetSource, Category, DoorType, Level, LiftCabin, Pose, Rotation, Site, Swing,
 };
+use bevy::{prelude::*, utils::tracing};
 use glam::Vec3;
 use once_cell::sync::Lazy;
 use sdformat_rs::*;
 use std::collections::BTreeMap;
 use thiserror::Error;
-use bevy::{prelude::*, utils::tracing};
 use tracing::error;
 
 const DEFAULT_CABIN_MASS: f64 = 1200.0;
 
-static WORLD_TEMPLATE: Lazy<Result<SdfRoot, String>> = Lazy::new(|| {
-    yaserde::de::from_str(include_str!("templates/gz_world.sdf"))
-});
+static WORLD_TEMPLATE: Lazy<Result<SdfRoot, String>> =
+    Lazy::new(|| yaserde::de::from_str(include_str!("templates/gz_world.sdf")));
 
 #[derive(Debug, Error)]
 pub enum SdfConversionError {


### PR DESCRIPTION
## Bug fix
Replaced non-critical .expect()s, for instance, the ones that only prints out a failure if fails. I'm still not sure what's the best case to handle the expect()s that is inside a function returning an expected type.

An example:
https://github.com/open-rmf/rmf_site/blob/809f44c92502e26214fd8c5da41db0937ac9d9b3/rmf_site_editor/src/interaction/cursor.rs#L149C1-L153C11

Here, the trait FromWorld's implementation of from_world always expects the function to return the Self object, meaning that it cannot fail. However, in the case that there are errors in creating interaction or site assets, I think it should return an Err object, and handled properly by callers of the from_world function. The other option is to keep the return Self type, but provide default value in case of such errors.

### Fixed bug
Part of bugfix for https://github.com/open-rmf/rmf_site/issues/255
### Fix applied
Replaced a few of the expect()s with error! macros.