### PR TITLE
replace with fds

### DIFF
--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -187,11 +187,7 @@ impl Plugin for StandardUiPlugin {
             )
             .add_systems(
                 PostUpdate,
-                (
-                    resolve_light_export_file,
-                    resolve_nav_graph_import_export_files,
-                )
-                    .run_if(AppState::in_displaying_mode()),
+                (resolve_nav_graph_import_export_files,).run_if(AppState::in_displaying_mode()),
             );
     }
 }

--- a/rmf_site_editor/src/widgets/view_lights.rs
+++ b/rmf_site_editor/src/widgets/view_lights.rs
@@ -30,7 +30,6 @@ use crate::{
 };
 use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_egui::egui::{Button, CollapsingHeader, Ui};
-#[cfg(not(target_arch = "wasm32"))]
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 

--- a/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -219,8 +219,8 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
                         }
                         None => {
                             let file_dialog_filters = vec![FileDialogFilter {
-                                name: "Site".into(),
-                                extensions: vec!["site.ron".into(), "site.json".into()],
+                                name: "Nav Graph".into(),
+                                extensions: vec!["nav.yaml".into()],
                             }];
 
                             let promise = self


### PR DESCRIPTION
Part of https://github.com/open-rmf/rmf_site/issues/248.

Attempt to replace fds on view_nav_graphs.rs file:

Initializes the File Dialog Services (fds) as a resource during build(), and define fds under systemparam as a ResMut (mutable resource). Then, create file dialog filters and pass it as request input to file dialog service, and take the response when promise is completed.

Question:
- As for file dialog filters, what should the name of the file requested be and the extension?
- Is the usage of ResMut correct here? I was thinking of using it since it's a unique borrow, meaning only one person can borrow it at a time