### PR TITLE
Fix inaccurate scenario count

### DIFF
--- a/rmf_site_editor/src/site/scenario.rs
+++ b/rmf_site_editor/src/site/scenario.rs
@@ -123,13 +123,13 @@ pub fn update_current_scenario(
                         } else {
                             error!(
                                 "Instance {:?} is included in the current scenario, but no visibility found! \
-                                Setting instance to included in current scenario.",
+                                Setting instance to hidden in current scenario.",
                                 name.0
                             );
                             update_instance.send(UpdateInstanceEvent {
                                 scenario: *scenario_entity,
                                 instance: entity,
-                                update: UpdateInstance::Include,
+                                update: UpdateInstance::Hide,
                             });
                             Visibility::Inherited
                         }

--- a/rmf_site_editor/src/site/scenario.rs
+++ b/rmf_site_editor/src/site/scenario.rs
@@ -59,6 +59,7 @@ pub fn update_current_scenario(
     mut change_current_scenario: EventReader<ChangeCurrentScenario>,
     mut current_scenario: ResMut<CurrentScenario>,
     mut instances: Query<(Entity, &NameInSite, &mut Pose, &mut Visibility), With<InstanceMarker>>,
+    mut update_instance: EventWriter<UpdateInstanceEvent>,
     children: Query<&Children>,
     instance_modifiers: Query<(&mut InstanceModifier, &Affiliation<Entity>)>,
     recall_instance: Query<&RecallInstance>,
@@ -125,6 +126,11 @@ pub fn update_current_scenario(
                                 Setting instance to included in current scenario.",
                                 name.0
                             );
+                            update_instance.send(UpdateInstanceEvent {
+                                scenario: *scenario_entity,
+                                instance: entity,
+                                update: UpdateInstance::Include,
+                            });
                             Visibility::Inherited
                         }
                     };
@@ -208,7 +214,7 @@ fn retrieve_parent_pose(
     parent_pose
 }
 
-fn retrieve_parent_visibility(
+pub fn retrieve_parent_visibility(
     instance_entity: Entity,
     scenario_entity: Entity,
     children: &Query<&Children>,
@@ -562,18 +568,26 @@ pub const HIDDEN_MODEL_INSTANCE_ISSUE_UUID: Uuid =
 
 pub fn check_for_hidden_model_instances(
     mut commands: Commands,
+    mut update_instance: EventWriter<UpdateInstanceEvent>,
     mut validate_events: EventReader<ValidateWorkspace>,
     children: Query<&Children>,
     instances: Query<
         (Entity, &NameInSite, &Affiliation<Entity>),
         (With<ModelMarker>, Without<Group>),
     >,
-    scenarios: Query<(Entity, &NameInSite, &Affiliation<Entity>), With<ScenarioMarker>>,
+    scenarios: Query<(Entity, &Affiliation<Entity>), With<ScenarioMarker>>,
     instance_modifiers: Query<(&mut InstanceModifier, &Affiliation<Entity>)>,
 ) {
     for root in validate_events.read() {
         for (instance_entity, instance_name, _) in instances.iter() {
-            if count_scenarios(&scenarios, instance_entity, &children, &instance_modifiers) > 0 {
+            if count_scenarios(
+                &scenarios,
+                instance_entity,
+                &children,
+                &instance_modifiers,
+                &mut update_instance,
+            ) > 0
+            {
                 continue;
             }
             let issue = Issue {

--- a/rmf_site_editor/src/widgets/view_model_instances.rs
+++ b/rmf_site_editor/src/widgets/view_model_instances.rs
@@ -43,12 +43,7 @@ impl Plugin for ViewModelInstancesPlugin {
 
 #[derive(SystemParam)]
 pub struct ViewModelInstances<'w, 's> {
-    scenarios: Query<
-        'w,
-        's,
-        (Entity, &'static NameInSite, &'static Affiliation<Entity>),
-        With<ScenarioMarker>,
-    >,
+    scenarios: Query<'w, 's, (Entity, &'static Affiliation<Entity>), With<ScenarioMarker>>,
     children: Query<'w, 's, &'static Children>,
     current_scenario: ResMut<'w, CurrentScenario>,
     icons: Res<'w, Icons>,
@@ -130,6 +125,7 @@ impl<'w, 's> ViewModelInstances<'w, 's> {
                                             instance_entity,
                                             &self.children,
                                             &self.instance_modifiers,
+                                            &mut self.update_instance,
                                         );
                                         show_model_instance(
                                             ui,
@@ -140,7 +136,6 @@ impl<'w, 's> ViewModelInstances<'w, 's> {
                                             &mut self.update_instance,
                                             scenario_instance_modifiers.get(&instance_entity),
                                             current_scenario_entity,
-                                            &self.scenarios,
                                             scenario_count,
                                             &self.icons,
                                         );
@@ -169,6 +164,7 @@ impl<'w, 's> ViewModelInstances<'w, 's> {
                                         *instance_entity,
                                         &self.children,
                                         &self.instance_modifiers,
+                                        &mut self.update_instance,
                                     );
                                     show_model_instance(
                                         ui,
@@ -179,7 +175,6 @@ impl<'w, 's> ViewModelInstances<'w, 's> {
                                         &mut self.update_instance,
                                         scenario_instance_modifiers.get(instance_entity),
                                         current_scenario_entity,
-                                        &self.scenarios,
                                         scenario_count,
                                         &self.icons,
                                     );
@@ -191,18 +186,60 @@ impl<'w, 's> ViewModelInstances<'w, 's> {
     }
 }
 
+fn check_instance_modifier_inclusion(
+    instance_modifier: &InstanceModifier,
+    instance_entity: Entity,
+    scenario_entity: Entity,
+    children: &Query<&Children>,
+    scenarios: &Query<(Entity, &Affiliation<Entity>), With<ScenarioMarker>>,
+    update_instance: &mut EventWriter<UpdateInstanceEvent>,
+    instance_modifiers: &Query<(&mut InstanceModifier, &Affiliation<Entity>)>,
+) -> bool {
+    instance_modifier.visibility().unwrap_or_else(|| {
+        retrieve_parent_visibility(
+            instance_entity,
+            scenario_entity,
+            children,
+            scenarios,
+            instance_modifiers,
+        )
+        .unwrap_or_else(|| {
+            error!(
+                "Unable to retrieve inherited visibility for instance {:?}.
+                Setting instance to be included in current scenario.",
+                instance_entity.index()
+            );
+            update_instance.send(UpdateInstanceEvent {
+                scenario: scenario_entity,
+                instance: instance_entity,
+                update: UpdateInstance::Include,
+            });
+            true
+        })
+    })
+}
+
+/// Count the number of scenarios a model instance is included in
 pub fn count_scenarios(
-    scenarios: &Query<(Entity, &NameInSite, &Affiliation<Entity>), With<ScenarioMarker>>,
+    scenarios: &Query<(Entity, &Affiliation<Entity>), With<ScenarioMarker>>,
     instance: Entity,
     children: &Query<&Children>,
     instance_modifiers: &Query<(&mut InstanceModifier, &Affiliation<Entity>)>,
+    update_instance: &mut EventWriter<UpdateInstanceEvent>,
 ) -> i32 {
-    scenarios.iter().fold(0, |x, (e, _, _)| {
+    scenarios.iter().fold(0, |x, (e, _)| {
         if find_modifier_for_instance(instance, e, &children, &instance_modifiers)
             .and_then(|modifier_entity| instance_modifiers.get(modifier_entity).ok())
-            .is_some_and(|(i, _)| match i {
-                InstanceModifier::Hidden => false,
-                _ => true,
+            .is_some_and(|(i, _)| {
+                check_instance_modifier_inclusion(
+                    i,
+                    instance,
+                    e,
+                    children,
+                    scenarios,
+                    update_instance,
+                    instance_modifiers,
+                )
             })
         {
             x + 1
@@ -222,7 +259,6 @@ fn show_model_instance(
     update_instance: &mut EventWriter<UpdateInstanceEvent>,
     instance_modifier: Option<&InstanceModifier>,
     scenario: Entity,
-    scenarios: &Query<(Entity, &NameInSite, &Affiliation<Entity>), With<ScenarioMarker>>,
     scenario_count: i32,
     icons: &Res<Icons>,
 ) {

--- a/rmf_site_editor/src/widgets/view_model_instances.rs
+++ b/rmf_site_editor/src/widgets/view_model_instances.rs
@@ -206,13 +206,13 @@ fn check_instance_modifier_inclusion(
         .unwrap_or_else(|| {
             error!(
                 "Unable to retrieve inherited visibility for instance {:?}.
-                Setting instance to be included in current scenario.",
+                Setting instance to be hidden in current scenario.",
                 instance_entity.index()
             );
             update_instance.send(UpdateInstanceEvent {
                 scenario: scenario_entity,
                 instance: instance_entity,
-                update: UpdateInstance::Include,
+                update: UpdateInstance::Hide,
             });
             true
         })


### PR DESCRIPTION
In the site editor, we can observe how many scenarios a model instance is included (visible) in by hovering over the model instance name. However, the current method of counting scenarios leads to an inaccurate result, as it takes `InstanceModifier::Inherited` as included, instead of checking what visibility the modifier is inheriting. This PR fixes the error. 

Additionally, in the unlikely case where visibility information for an instance cannot be found for the current scenario, the current editor sets it to visible but does not update the modifier data. This PR also updates that by sending an `UpdateInstance` event.