### PR TITLE
Exit confirmation

### DIFF
--- a/rmf_site_editor/src/exit_confirmation.rs
+++ b/rmf_site_editor/src/exit_confirmation.rs
@@ -1,38 +1,52 @@
+use crate::AppState;
 use bevy::app::AppExit;
 use bevy::prelude::*;
 use bevy::window::WindowCloseRequested;
 use bevy_egui::{egui, EguiContexts};
 
 #[derive(Resource, Default)]
-pub struct QuitDialog {
+pub struct SiteChanged(pub bool);
+
+#[derive(Resource, Default)]
+pub struct ExitConfirmationDialog {
     pub visible: bool,
 }
 
-pub struct QuitPlugin;
+pub struct ExitConfirmationPlugin;
 
-impl Plugin for QuitPlugin {
+impl Plugin for ExitConfirmationPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<QuitDialog>()
-            .add_systems(Update, handle_quit_requests)
-            .add_systems(Update, show_quit_dialog);
+        app.init_resource::<SiteChanged>()
+            .init_resource::<ExitConfirmationDialog>()
+            .add_systems(Update, handle_exit_requests)
+            .add_systems(Update, show_exit_confirmation_dialog);
     }
 }
 
-fn handle_quit_requests(
-    mut quit_dialog: ResMut<QuitDialog>,
+fn handle_exit_requests(
+    mut exit_confirmation_dialog: ResMut<ExitConfirmationDialog>,
     mut close_events: EventReader<WindowCloseRequested>,
+    mut app_exit: EventWriter<AppExit>,
+    site_changed: Res<SiteChanged>,
+    app_state: Res<State<AppState>>,
 ) {
     for _ in close_events.read() {
-        quit_dialog.visible = true;
+        if app_state.get() == &AppState::MainMenu {
+            app_exit.send(AppExit);
+        }
+
+        if site_changed.0 == true {
+            exit_confirmation_dialog.visible = true;
+        }
     }
 }
 
-fn show_quit_dialog(
+fn show_exit_confirmation_dialog(
     mut contexts: EguiContexts,
-    mut quit_dialog: ResMut<QuitDialog>,
+    mut exit_confirmation_dialog: ResMut<ExitConfirmationDialog>,
     mut app_exit: EventWriter<AppExit>,
 ) {
-    if !quit_dialog.visible {
+    if !exit_confirmation_dialog.visible {
         return;
     }
     egui::Window::new("Exit Confirmation")
@@ -40,14 +54,14 @@ fn show_quit_dialog(
         .resizable(false)
         .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
         .show(contexts.ctx_mut(), |ui| {
-            ui.label("Are you sure you want to quit?");
+            ui.label("Are you sure you want to exit?");
             ui.separator();
             ui.horizontal(|ui| {
                 if ui.button("Yes").clicked() {
                     app_exit.send(AppExit);
                 }
                 if ui.button("Cancel").clicked() {
-                    quit_dialog.visible = false;
+                    exit_confirmation_dialog.visible = false;
                 }
             });
         });

--- a/rmf_site_editor/src/exit_confirmation.rs
+++ b/rmf_site_editor/src/exit_confirmation.rs
@@ -1,0 +1,54 @@
+use bevy::app::AppExit;
+use bevy::prelude::*;
+use bevy::window::WindowCloseRequested;
+use bevy_egui::{egui, EguiContexts};
+
+#[derive(Resource, Default)]
+pub struct QuitDialog {
+    pub visible: bool,
+}
+
+pub struct QuitPlugin;
+
+impl Plugin for QuitPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<QuitDialog>()
+            .add_systems(Update, handle_quit_requests)
+            .add_systems(Update, show_quit_dialog);
+    }
+}
+
+fn handle_quit_requests(
+    mut quit_dialog: ResMut<QuitDialog>,
+    mut close_events: EventReader<WindowCloseRequested>,
+) {
+    for _ in close_events.read() {
+        quit_dialog.visible = true;
+    }
+}
+
+fn show_quit_dialog(
+    mut contexts: EguiContexts,
+    mut quit_dialog: ResMut<QuitDialog>,
+    mut app_exit: EventWriter<AppExit>,
+) {
+    if !quit_dialog.visible {
+        return;
+    }
+    egui::Window::new("Exit Confirmation")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .show(contexts.ctx_mut(), |ui| {
+            ui.label("Are you sure you want to quit?");
+            ui.separator();
+            ui.horizontal(|ui| {
+                if ui.button("Yes").clicked() {
+                    app_exit.send(AppExit);
+                }
+                if ui.button("Cancel").clicked() {
+                    quit_dialog.visible = false;
+                }
+            });
+        });
+}

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -12,6 +12,9 @@ pub use autoload::*;
 pub mod asset_loaders;
 use asset_loaders::*;
 
+pub mod exit_confirmation;
+use exit_confirmation::QuitPlugin;
+
 // Bevy plugins that are public dependencies, mixing versions won't work for downstream users
 pub use bevy_egui;
 pub use bevy_mod_raycast;
@@ -163,6 +166,7 @@ impl Plugin for SiteEditor {
                     fit_canvas_to_parent: true,
                     ..default()
                 }),
+                close_when_requested: false,
                 ..default()
             })
         };
@@ -197,6 +201,7 @@ impl Plugin for SiteEditor {
                 LogHistoryPlugin,
                 AabbUpdatePlugin,
                 EguiPlugin,
+                QuitPlugin,
                 KeyboardInputPlugin,
                 SitePlugin,
                 InteractionPlugin::new().headless(self.headless_export.is_some()),

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -13,7 +13,7 @@ pub mod asset_loaders;
 use asset_loaders::*;
 
 pub mod exit_confirmation;
-use exit_confirmation::QuitPlugin;
+use exit_confirmation::ExitConfirmationPlugin;
 
 // Bevy plugins that are public dependencies, mixing versions won't work for downstream users
 pub use bevy_egui;
@@ -201,7 +201,7 @@ impl Plugin for SiteEditor {
                 LogHistoryPlugin,
                 AabbUpdatePlugin,
                 EguiPlugin,
-                QuitPlugin,
+                ExitConfirmationPlugin,
                 KeyboardInputPlugin,
                 SitePlugin,
                 InteractionPlugin::new().headless(self.headless_export.is_some()),

--- a/rmf_site_editor/src/site/change_plugin.rs
+++ b/rmf_site_editor/src/site/change_plugin.rs
@@ -15,6 +15,7 @@
  *
 */
 
+use crate::exit_confirmation::SiteChanged;
 use crate::site::SiteUpdateSet;
 use bevy::prelude::*;
 use std::fmt::Debug;
@@ -60,6 +61,8 @@ impl<T: Component + Clone + Debug> Default for ChangePlugin<T> {
 
 impl<T: Component + Clone + Debug> Plugin for ChangePlugin<T> {
     fn build(&self, app: &mut App) {
+        app.init_resource::<SiteChanged>();
+
         app.add_event::<Change<T>>().add_systems(
             PreUpdate,
             update_changed_values::<T>.in_set(SiteUpdateSet::ProcessChanges),
@@ -71,8 +74,11 @@ fn update_changed_values<T: Component + Clone + Debug>(
     mut commands: Commands,
     mut values: Query<&mut T>,
     mut changes: EventReader<Change<T>>,
+    mut site_changed: ResMut<SiteChanged>,
 ) {
     for change in changes.read() {
+        site_changed.0 = true;
+
         if let Ok(mut new_value) = values.get_mut(change.for_element) {
             *new_value = change.to_value.clone();
         } else {


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## New feature implementation

### Implemented feature

This Pull Request targets #225, by adding a prompt that asks the user if they really want to exit the app, whenever there are unsaved changes.

### Implementation description

In order to do that, I created an `ExitConfirmationPlugin`, that is responsible for handling the `WindowCloseRequested` events, by knowing when the user should be stopped or not. This plugin is also responsible for creating the window with the exit confirmation.

In order to keep track of the unsaved changes, as suggest by @mxgrey, I created a `SiteChanged` resource, and toggled it to `true` in the [update_changed_values](https://github.com/open-rmf/rmf_site/blob/c5f5a7a223cec8184e49580be9f762394861611d/rmf_site_editor/src/site/change_plugin.rs#L70) function.

As this is my first pull request and I am quite new to Bevy and to this project, I'll be glad to change anything needed.
