### PR TITLE
Migration to Bevy 0.15

### DIFF
--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: cargo-deps
       run: |
-        cargo install -f wasm-bindgen-cli --version 0.2.93
+        cargo install -f wasm-bindgen-cli --version 0.2.100
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci_web.yaml
+++ b/.github/workflows/ci_web.yaml
@@ -23,11 +23,18 @@ jobs:
     - name: apt-deps
       run: |
         sudo apt-get update
-        sudo apt-get install libasound2-dev libudev-dev binaryen
+        sudo apt-get install libasound2-dev libudev-dev
+
+    - name: wasm-opt
+      uses: sigoden/install-binary@v1
+      with:
+        repo: WebAssembly/binaryen
+        tag: version_123
+        name: wasm-opt
 
     - name: cargo-deps
       run: |
-        cargo install -f wasm-bindgen-cli --version 0.2.100
+        cargo install -f wasm-bindgen-cli --version 0.2.97
 
     - uses: actions/checkout@v3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -3152,7 +3152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3651,7 +3651,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.54.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3852,7 +3852,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows 0.54.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3917,7 +3917,7 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "ehttp",
- "futures-lite 1.13.0",
+ "futures-lite 2.6.0",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -4382,7 +4382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5877,7 +5877,7 @@ version = "0.0.1"
 dependencies = [
  "bevy",
  "float_eq",
- "glam 0.27.0",
+ "glam 0.29.3",
  "once_cell",
  "pathdiff",
  "ron 0.9.0-alpha.0",
@@ -5980,7 +5980,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,54 +20,57 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb10ed32c63247e4e39a8f42e8e30fb9442fbf7878c8e4a9849e7e381619bea"
+checksum = "6cf780eb737f2d4a49ffbd512324d53ad089070f813f7be7f99dbd5123a7f448"
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.16.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c17cca53c09fbd7288667b22a201274b9becaa27f0b91bf52a526db95de45e6"
+checksum = "3bdfa1638ddd6eb9c752def95568df8b3ad832df252e9156d2eb783b201ca8a9"
 dependencies = [
  "accesskit",
+ "immutable-chunkmap",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.10.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3b6ae1eabbfbced10e840fd3fce8a93ae84f174b3e4ba892ab7bcb42e477a7"
+checksum = "c236a84ff1111defc280cee755eaa953d0b24398786851b9d28322c6d3bb1ebd"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "once_cell",
 ]
 
 [[package]]
 name = "accesskit_windows"
-version = "0.15.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcae27ec0974fc7c3b0b318783be89fd1b2e66dd702179fe600166a38ff4a0b"
+checksum = "5d7f43d24b16b3e76bef248124fbfd2493c3a9860edb5aae1010c890e826de5e"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "once_cell",
  "paste",
  "static_assertions",
- "windows 0.48.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.15.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e39fcec2e10971e188730b7a76bab60647dacc973d4591855ebebcadfaa738"
+checksum = "755535e6bf711a42dac28b888b884b10fc00ff4010d9d3bd871c5f5beae5aa78"
 dependencies = [
  "accesskit",
  "accesskit_macos",
  "accesskit_windows",
+ "raw-window-handle 0.6.2",
  "winit",
 ]
 
@@ -93,10 +96,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -107,6 +110,12 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
 name = "allocator-api2"
@@ -121,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37fe60779335388a88c01ac6c3be40304d1e349de3ada3b15f7808bb90fa9dce"
 dependencies = [
  "alsa-sys",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -137,20 +146,23 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64529721f27c2314ced0890ce45e469574a73e5e6fdd6e9da1860eb29285f5e0"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 1.3.2",
+ "bitflags 2.9.0",
  "cc",
+ "cesu8",
+ "jni",
  "jni-sys",
  "libc",
  "log",
- "ndk 0.7.0",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys 0.4.1+23.1.7779620",
- "num_enum 0.6.1",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -238,22 +250,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
 name = "arboard"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2041f1943049c7978768d84e6d0fd95de98b76d6c4727b09e78ec253d29fa58"
 dependencies = [
  "clipboard-win",
- "core-graphics 0.23.1",
- "image",
+ "core-graphics",
+ "image 0.24.9",
  "log",
  "objc",
  "objc-foundation",
  "objc_id",
  "parking_lot",
- "thiserror",
+ "thiserror 1.0.69",
  "windows-sys 0.48.0",
  "x11rb",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -264,9 +293,15 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
@@ -289,17 +324,6 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
@@ -313,11 +337,10 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.8.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
 dependencies = [
- "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
@@ -327,23 +350,13 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "1.6.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
- "async-lock 2.8.0",
- "autocfg",
+ "async-lock",
  "blocking",
- "futures-lite 1.13.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
+ "futures-lite 2.2.0",
 ]
 
 [[package]]
@@ -397,6 +410,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "av1-grain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,12 +449,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -431,18 +461,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bc7e09282a82a48d70ade0c4c1154b0fd7882a735a39c66766a5d0f4718ea9"
+checksum = "043c9ad4b6fc4ca52d779873a8ca792a4e37842d07fce95363c9e17e36a1d8a0"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68080288c932634f6563d3a8299efe0ddc9ea6787539c4c771ba250d089a94f0"
+checksum = "ae1a976cb539d6a5a3ff579cdb78187a6bcfbffa7e8224ea28f23d8b983d9389"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -452,52 +482,64 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa37683b1281e1ba8cf285644e6e3f0704f14b3901c5ee282067ff7ff6f4a56"
+checksum = "93aef7d21a0342c24b05059493aa31d58f1798d34a2236569a8789b74df5a475"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_core",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_hierarchy",
+ "bevy_log",
  "bevy_math",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
+ "blake3",
+ "fixedbitset 0.5.7",
+ "petgraph",
+ "ron 0.8.1",
+ "serde",
+ "thiserror 1.0.69",
+ "thread_local",
+ "uuid",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41731817993f92e4363dd3335558e779e290bc71eefc0b5547052b85810907e"
+checksum = "a5361d0f8a8677a5d0102cfe7321a7ecd2a8b9a4f887ce0dde1059311cf9cd42"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
+ "console_error_panic_hook",
  "downcast-rs",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "bevy_asset"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935984568f75867dd7357133b06f4b1502cd2be55e4642d483ce597e46e63bff"
+checksum = "60ec5ea257e1ebd3d411f669e29acf60beb715bebc7e1f374c17f49cd3aad46c"
 dependencies = [
  "async-broadcast",
  "async-fs",
- "async-lock 2.8.0",
+ "async-lock",
  "bevy_app",
  "bevy_asset_macros",
  "bevy_ecs",
- "bevy_log",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
@@ -506,12 +548,13 @@ dependencies = [
  "crossbeam-channel",
  "downcast-rs",
  "futures-io",
- "futures-lite 1.13.0",
+ "futures-lite 2.2.0",
  "js-sys",
  "parking_lot",
  "ron 0.8.1",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -519,148 +562,176 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f48b9bbe4ec605e4910b5cd1e1a0acbfbe0b80af5f3bcc4489a9fdd1e80058c"
+checksum = "c9eb05ce838d282f09d83380b4d6432aec7519d421dee8c75cc20e6148237e6e"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_audio"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a69889e1bfa4dbac4e641536b94f91c441da55796ad9832e77836b8264688b"
+checksum = "8ee31312a0e67f288fe12a1d9aa679dd0ba8a49e1e6fe5fcd2ba1aa1ea34e5ed"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
  "bevy_transform",
  "bevy_utils",
- "oboe 0.5.0",
+ "cpal",
  "rodio",
 ]
 
 [[package]]
-name = "bevy_core"
-version = "0.12.1"
+name = "bevy_color"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3daa24502a14839509f02407bc7e48299fe84d260877de23b60662de0f4f4b6c"
+checksum = "04842e9d38a93f0c75ab46f7f404ea24ef57ad83dbd159e5b4b35318b02257bb"
+dependencies = [
+ "bevy_math",
+ "bevy_reflect",
+ "bytemuck",
+ "encase",
+ "serde",
+ "thiserror 1.0.69",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de706862871a1fe99ea619bff2f99d73e43ad82f19ef866a9e19a14c957c8537"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_math",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bytemuck",
+ "uuid",
 ]
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b77c4fca6e90edbe2e72da7bc9aa7aed7dfdfded0920ae0a0c845f5e11084a"
+checksum = "2f6e1e122ada4cd811442e083fb5ad3e325c59a87271d5ef57193f1c2cad7f8c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_core",
  "bevy_derive",
  "bevy_ecs",
- "bevy_log",
  "bevy_math",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
+ "nonmax",
  "radsort",
  "serde",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f484318350462c58ba3942a45a656c1fd6b6e484a6b6b7abc3a787ad1a51e500"
+checksum = "3fbfc33a4c6b80760bb8bf850a2cc65a1e031da62fd3ca8b552189104dc98514"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa38ca5967d335cc1006a0e0f1a86c350e2f15fd1878449f61d04cd57a7c4060"
+checksum = "bebb154e0cc78e3bbfbfdb42fb502b14c1cd47e72f16e6d4228dfe6233ba6cbd"
 dependencies = [
  "bevy_app",
  "bevy_core",
  "bevy_ecs",
- "bevy_log",
+ "bevy_tasks",
  "bevy_time",
  "bevy_utils",
+ "const-fnv1a-hash",
  "sysinfo",
 ]
 
 [[package]]
 name = "bevy_ecs"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709fbd22f81fb681534cd913c41e1cd18b17143368743281195d7f024b61aea"
+checksum = "9ee4222406637f3c8e3991a99788cfcde76097bf997c311f1b6297364057483f"
 dependencies = [
- "async-channel 1.9.0",
+ "arrayvec",
  "bevy_ecs_macros",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "downcast-rs",
- "event-listener 2.5.3",
- "fixedbitset",
- "rustc-hash",
+ "bitflags 2.9.0",
+ "concurrent-queue",
+ "fixedbitset 0.5.7",
+ "nonmax",
+ "petgraph",
  "serde",
- "thiserror",
- "thread_local",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8843aa489f159f25cdcd9fee75cd7d221a7098a71eaa72cb2d6b40ac4e3f1ba"
+checksum = "36b573430b67aff7bde8292257494f39343401379bfbda64035ba4918bba7b20"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_egui"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85450af551b7e1cb766f710763b60a12a82ffd6323945a8f776c6334c59ccdc1"
+checksum = "5e4a90f30f2849a07d91e393b10c0cc05df09b5773c010ddde57dd8b583be230"
 dependencies = [
  "arboard",
  "bevy",
+ "bytemuck",
+ "console_log",
+ "crossbeam-channel",
  "egui",
+ "js-sys",
+ "log",
  "thread_local",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "webbrowser",
+ "winit",
 ]
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5328a3715e933ebbff07d0e99528dc423c4f7a53590ed1ac19a120348b028990"
+checksum = "d06c9693847a2a6ea61d6b86288dd4d8b6a79f05d4bf6e27b96d4f5c8d552fe4"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -668,55 +739,69 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b81ca2ebf66cbc7f998f1f142b15038ffe3c4ae1d51f70adda26dcf51b0c4ca"
+checksum = "0422ccb3ce0f79b264100cf064fdc5ef65cef5c7d51bf6378058f9b96fea4183"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
- "bevy_log",
  "bevy_time",
  "bevy_utils",
  "gilrs",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db232274ddca2ae452eb2731b98267b795d133ddd14013121bc7daddde1c7491"
+checksum = "dfe32af0666d8d8a7fd6eb6b5e41eceefdc6f2e5441c74b812e8f0902a9d7f52"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_core",
+ "bevy_color",
  "bevy_core_pipeline",
  "bevy_ecs",
+ "bevy_gizmos_macros",
  "bevy_math",
  "bevy_pbr",
  "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
+ "bevy_time",
  "bevy_transform",
  "bevy_utils",
+ "bytemuck",
+]
+
+[[package]]
+name = "bevy_gizmos_macros"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "906b052f8cf3f3983f0f6df625fb10cbd9b27d44e362a327dc1ed51300d362bc"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_gltf"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85adc6b1fc86687bf67149e0bafaa4d6da432232fa956472d1b37f19121d3ace"
+checksum = "d6adbd325b90e3c700d0966b5404e226c7deec1b8bda8f36832788d7b435b9b8"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_core",
  "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_hierarchy",
- "bevy_log",
  "bevy_math",
  "bevy_pbr",
  "bevy_reflect",
@@ -729,36 +814,37 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "thiserror",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_gltf_export"
 version = "0.1.0"
-source = "git+https://github.com/luca-della-vedova/bevy_gltf_export?branch=luca%2Ftransform_api#a896bca4148648b44212d4a9e6be98dd64cc3d8f"
+source = "git+https://github.com/luca-della-vedova/bevy_gltf_export?branch=bevy_0.14#21294b4bbb144fdee13be7daebea787333f8cf7a"
 dependencies = [
  "bevy_asset",
+ "bevy_color",
  "bevy_pbr",
  "bevy_render",
  "bevy_transform",
  "gltf",
  "gltf-json",
- "image",
+ "image 0.25.6",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bd477152ce2ae1430f5e0a4f19216e5785c22fee1ab23788b5982dc59d1a55"
+checksum = "a88b912b37e1bc4dbb2aa40723199f74c8b06c4fbb6da0bb4585131df28ef66e"
 dependencies = [
  "bevy_app",
  "bevy_core",
  "bevy_ecs",
- "bevy_log",
  "bevy_reflect",
  "bevy_utils",
  "smallvec",
@@ -766,8 +852,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_impulse"
-version = "0.0.2"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=main#3d5425de69f6e9ded7d80df317a0df91df9ebf91"
+version = "0.2.0"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.2#2e5e7162dad955dd0308e8aabb914650496e9725"
 dependencies = [
  "anyhow",
  "async-task",
@@ -784,44 +870,49 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "bevy_impulse_derive"
 version = "0.0.2"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=main#3d5425de69f6e9ded7d80df317a0df91df9ebf91"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.2#2e5e7162dad955dd0308e8aabb914650496e9725"
 dependencies = [
+ "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab9a599189b2a694c182d60cd52219dd9364f9892ff542d87799b8e45d9e6dc"
+checksum = "8dd3a54e67cc3ba17971de7b1a7e64eda84493c1e7bb6bfa11c6cf8ac124377b"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
  "bevy_reflect",
  "bevy_utils",
- "thiserror",
+ "smol_str",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_internal"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f124bece9831afd80897815231072d51bfe3ac58c6bb58eca8880963b6d0487c"
+checksum = "45d435cac77c568f3aef65f786a5fee0e53c81950c5258182dd2c1d6cd6c4fec"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
  "bevy_audio",
+ "bevy_color",
  "bevy_core",
  "bevy_core_pipeline",
  "bevy_derive",
@@ -840,6 +931,7 @@ dependencies = [
  "bevy_render",
  "bevy_scene",
  "bevy_sprite",
+ "bevy_state",
  "bevy_tasks",
  "bevy_text",
  "bevy_time",
@@ -852,73 +944,77 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc10ba1d225a8477b9e80a1bf797d8a8b8274e83c9b24fb4d9351aec9229755"
+checksum = "67240c7596c8f0653e50fce35a60196516817449235193246599facba9002e02"
 dependencies = [
  "android_log-sys",
  "bevy_app",
  "bevy_ecs",
  "bevy_utils",
- "console_error_panic_hook",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
  "tracing-wasm",
 ]
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e566640c6b6dced73d2006c764c2cffebe1a82be4809486c4a5d7b4b50efed4d"
+checksum = "bfc65e570012e64a21f3546df68591aaede8349e6174fb500071677f54f06630"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc-hash",
- "syn 2.0.52",
- "toml_edit 0.20.7",
+ "syn 2.0.100",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ddc2b76783939c530178f88e5711a1b01044d7b02db4033e2eb8b43b6cf4ec"
+checksum = "5421792749dda753ab3718e77d27bfce38443daf1850b836b97530b6245a4581"
 dependencies = [
+ "bevy_reflect",
  "glam",
+ "rand",
  "serde",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec4962977a746d870170532fc92759e04d3dbcae8b7b82e7ca3bb83b1d75277"
+checksum = "66cf695a264b043f2c4edb92dd5c742e6892180d2b30dac870012d153f8557ea"
 dependencies = [
  "glam",
 ]
 
 [[package]]
 name = "bevy_mod_outline"
-version = "0.6.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35d72134cd809630e78bc953318156f37ff2839a50bebb148bc5c3a669e133e0"
+checksum = "96a262553297f0a22d21b1b01d6b377ef0c904d261fe52d09ec7d2ad967a6a26"
 dependencies = [
  "bevy",
  "bitfield",
  "interpolation",
- "thiserror",
+ "nonmax",
+ "thiserror 1.0.69",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_mod_raycast"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b127622dcbfd9e6a1661219af65965625901c2549b434f0c44c4460dd055dce"
+checksum = "d9e4ff45885c4716771a9f55977d8ce69596502a5241da55bf608d7cd71a9cb3"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_derive",
  "bevy_ecs",
  "bevy_gizmos",
@@ -934,30 +1030,31 @@ dependencies = [
 
 [[package]]
 name = "bevy_obj"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308882b319e5d4809655429d95c8d162b5ed5426f7882ed7c522440754e580ac"
+checksum = "891c44dd1ed9aa3fc80d55e9019f61771307c1a6eb4cae3117cef25bd9fcfcee"
 dependencies = [
- "anyhow",
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_ecs",
  "bevy_pbr",
  "bevy_render",
  "bevy_scene",
  "bevy_utils",
- "thiserror",
+ "thiserror 1.0.69",
  "tobj",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520bfd2a898c74f84ea52cfb8eb061f37373ad15e623489d5f75d27ebd6138fe"
+checksum = "4dccaa3c945f19834dcf7cd8eb358236dbf0fc4000dacbc7710564e7856714db"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
@@ -967,79 +1064,81 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "bytemuck",
- "fixedbitset",
- "naga_oil",
+ "fixedbitset 0.5.7",
+ "nonmax",
  "radsort",
  "smallvec",
- "thread_local",
+ "static_assertions",
 ]
 
 [[package]]
 name = "bevy_polyline"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6824e97e332fafcbfe31d169b2b9073b9ba568b2a9f59cfd3ac4697982b4bf"
+checksum = "f54091a26c01aa225f771e1a9b12eb2eadabfec359b67aeab75a46f7d3437647"
 dependencies = [
  "bevy",
- "bitflags 2.4.2",
- "naga",
+ "bitflags 2.9.0",
+ "bytemuck",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77ec20c8fafcdc196508ef5ccb4f0400a8d193cb61f7b14a36ed9a25ad423cf"
+checksum = "61baa1bdc1f4a7ac2c18217570a7cc04e1cd54d38456e91782f0371c79afe0a8"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7921f15fc944c9c8ad01d7dbcea6505b8909c6655cd9382bab1407181556038"
+checksum = "2508785a4a5809f25a237eec4fee2c91a4dbcf81324b2bbc2d6c52629e603781"
 dependencies = [
- "bevy_math",
  "bevy_ptr",
  "bevy_reflect_derive",
  "bevy_utils",
  "downcast-rs",
  "erased-serde",
  "glam",
+ "petgraph",
  "serde",
  "smallvec",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a8c5475f216e751ef4452a1306b00711f33d2d04d9f149e4c845dfeb6753a0"
+checksum = "967d5da1882ec3bb3675353915d3da909cafac033cbf31e58727824a1ad2a288"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_render"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdefdd3737125b0d94a6ff20bb70fa8cfe9d7d5dcd72ba4dfe6c5f1d30d9f6e4"
+checksum = "836cf8a513db013cbe7d55a331060088efd407e49fd5b05c8404700cd82e7619"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel",
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_core",
  "bevy_derive",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_encase_derive",
  "bevy_hierarchy",
- "bevy_log",
  "bevy_math",
  "bevy_mikktspace",
  "bevy_reflect",
@@ -1049,23 +1148,24 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "bytemuck",
  "codespan-reporting",
  "downcast-rs",
  "encase",
- "futures-lite 1.13.0",
+ "futures-lite 2.2.0",
  "hexasphere",
- "image",
+ "image 0.25.6",
  "js-sys",
  "ktx2",
  "naga",
  "naga_oil",
+ "nonmax",
  "ruzstd",
+ "send_wrapper",
  "serde",
  "smallvec",
- "thiserror",
- "thread_local",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu",
@@ -1073,21 +1173,21 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d86bfc5a1e7fbeeaec0c4ceab18155530f5506624670965db3415f75826bea"
+checksum = "cbc24e0e95061a38a7744218b9c7e52e4c08b53f1499f33480e2b749f3864432"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_scene"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7df078b5e406e37c8a1c6ba0d652bf105fde713ce3c3efda7263fe27467eee5"
+checksum = "8ec57a72d75273bdbb6154390688fd07ba79ae9f6f99476d1937f799c736c2da"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1098,74 +1198,97 @@ dependencies = [
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
- "ron 0.8.1",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_sprite"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cc0c9d946e17e3e0aaa202f182837bc796c4f862b2e5a805134f873f21cf7f"
+checksum = "e045b4d8cc8e7422a4c29b1eadbe224f5cc42f170b88d43e7535892fcede3840"
 dependencies = [
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
- "bevy_log",
  "bevy_math",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "bytemuck",
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "guillotiere",
  "radsort",
  "rectangle-pack",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bevy_state"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25335bfa58cc22371182335c3b133017293bc9b6d3308402fd4d1f978b83f937"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_reflect",
+ "bevy_state_macros",
+ "bevy_utils",
+]
+
+[[package]]
+name = "bevy_state_macros"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee600b659c739f1911f997a81611fec0a1832cf731727956e5fa4e7532b4dd5"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_stl"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b503a4a2a4e15456ae19e7f467b7f3447ccdcf9bbb10de9f4f3c1b2e88e12cdd"
+checksum = "d3ca2d994225ab4429b450eb32dc1b49bf795b3b1bf88d4ddee39012195f201c"
 dependencies = [
- "anyhow",
  "bevy",
- "futures-lite 2.2.0",
  "stl_io",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_tasks"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fefa7fe0da8923525f7500e274f1bd60dbd79918a25cf7d0dfa0a6ba15c1cf"
+checksum = "77865f310b1fc48fb05b7c4adbe76607ec01d0c14f8ab4caba4d714c86439946"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel",
  "async-executor",
- "async-task",
  "concurrent-queue",
- "futures-lite 1.13.0",
+ "futures-lite 2.2.0",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9a79d49ca06170d69149949b134c14e8b99ace1444c1ca2cd4743b19d5b055"
+checksum = "b661db828fd423fc41a4ccf43aa4d1b8e50e75057ec40453317d0d761e8ad62d"
 dependencies = [
  "ab_glyph",
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_ecs",
  "bevy_math",
  "bevy_reflect",
@@ -1176,52 +1299,52 @@ dependencies = [
  "bevy_window",
  "glyph_brush_layout",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_time"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6250d76eed3077128b6a3d004f9f198b01107800b9824051e32bb658054e837"
+checksum = "f4e4d53ec32a1b16492396951d04de0d2d90e924bf9adcb8d1adacab5ab6c17c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_reflect",
  "bevy_utils",
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_transform"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d541e0c292edbd96afae816ee680e02247422423ccd5dc635c1e211a20ed64be"
+checksum = "d5493dce84427d00a9266e8e4386d738a72ee8640423b62dfcecb6dfccbfe0d2"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_ui"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d785e3b75dabcb2a8ad0d50933f8f3446d59e512cabc2d2a145e28c2bb8792ba"
+checksum = "56d2cba6603b39a3765f043212ae530e25550af168a7eec6b23b9b93c19bc5f7"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
  "bevy_asset",
+ "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
  "bevy_hierarchy",
  "bevy_input",
- "bevy_log",
  "bevy_math",
  "bevy_reflect",
  "bevy_render",
@@ -1231,62 +1354,59 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "bytemuck",
- "serde",
+ "nonmax",
  "smallvec",
  "taffy",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7915222f4a08ccc782e08d10b751b42e5f9d786e697d0cb3fd09333cb7e8b6ea"
+checksum = "ffb0ec333b5965771153bd746f92ffd8aeeb9d008a8620ffd9ed474859381a5e"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
- "getrandom",
+ "getrandom 0.2.12",
  "hashbrown 0.14.3",
- "instant",
- "nonmax",
- "petgraph",
- "thiserror",
+ "thread_local",
  "tracing",
- "uuid",
+ "web-time",
 ]
 
 [[package]]
 name = "bevy_utils_proc_macros"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aafecc952b6b8eb1a93c12590bd867d25df2f4ae1033a01dfdfc3c35ebccfff"
+checksum = "38f1ab8f2f6f58439d260081d89a42b02690e5fdd64f814edc9417d33fcf2857"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ee72bf7f974000e9b31bb971a89387f1432ba9413f35c4fef59fef49767260"
+checksum = "c89e88a20db64ea8204540afb4699295947c454738fd50293f7b32ab8be857a6"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
  "bevy_ecs",
- "bevy_input",
  "bevy_math",
  "bevy_reflect",
  "bevy_utils",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
+ "smol_str",
 ]
 
 [[package]]
 name = "bevy_winit"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb71f287eca9006dda998784c7b931e400ae2cc4c505da315882a8b082f21ad"
+checksum = "d0bef8ec3e4b45db943ad4d1c0bf59b09e382ce0651a706e2f33a70fa955303c"
 dependencies = [
  "accesskit_winit",
  "approx",
@@ -1296,12 +1416,15 @@ dependencies = [
  "bevy_ecs",
  "bevy_hierarchy",
  "bevy_input",
+ "bevy_log",
  "bevy_math",
+ "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
  "bevy_window",
+ "cfg-if",
  "crossbeam-channel",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "wasm-bindgen",
  "web-sys",
  "winit",
@@ -1313,10 +1436,10 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1324,7 +1447,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1350,9 +1473,9 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitfield"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
 
 [[package]]
 name = "bitflags"
@@ -1362,12 +1485,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "blake3"
@@ -1389,22 +1518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
-name = "block-sys"
-version = "0.1.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
 name = "block2"
-version = "0.2.0-alpha.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "block-sys",
- "objc2-encode",
+ "objc2",
 ]
 
 [[package]]
@@ -1413,8 +1532,8 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
- "async-channel 2.2.0",
- "async-lock 3.3.0",
+ "async-channel",
+ "async-lock",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
@@ -1424,6 +1543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+
+[[package]]
 name = "bumpalo"
 version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,9 +1556,9 @@ checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1446,7 +1571,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1454,6 +1579,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1469,6 +1600,32 @@ checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.9.0",
+ "log",
+ "polling",
+ "rustix",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -1519,6 +1676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,7 +1723,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1601,10 +1764,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "com-rs"
-version = "0.2.1"
+name = "com"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "combine"
@@ -1636,6 +1824,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
 name = "const_panic"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,9 +1859,9 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "constgebra"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd23e864550e6dafc1e41ac78ce4f1ccddc8672b40c403524a04ff3f0518420"
+checksum = "e1aaf9b65849a68662ac6c0810c8893a765c960b907dd7cfab9c4a50bf764fbc"
 dependencies = [
  "const_soft_float",
 ]
@@ -1689,19 +1893,6 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
@@ -1709,7 +1900,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1760,7 +1951,7 @@ dependencies = [
  "mach2",
  "ndk 0.8.0",
  "ndk-context",
- "oboe 0.6.1",
+ "oboe",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1823,12 +2014,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "d3d12"
-version = "0.7.0"
+name = "cursor-icon"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
+checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
+
+[[package]]
+name = "d3d12"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "libloading 0.8.3",
  "winapi",
 ]
@@ -1873,6 +2070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading 0.8.3",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +2094,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dpi"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+
+[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,20 +2111,22 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.23.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf4e52dbbb615cfd30cf5a5265335c217b5fd8d669593cea74a517d9c605af"
+checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
 dependencies = [
  "bytemuck",
+ "emath",
 ]
 
 [[package]]
 name = "egui"
-version = "0.23.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd69fed5fcf4fbb8225b24e80ea6193b61e17a625db105ef0c4d71dde6eb8b7"
+checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
 dependencies = [
  "ahash",
+ "emath",
  "epaint",
  "nohash-hasher",
 ]
@@ -1923,7 +2137,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e598cc2bfc28612f26426259ed99a978270e9433d63ae6d2843e30fb0974cd02"
 dependencies = [
- "async-channel 2.2.0",
+ "async-channel",
  "document-features",
  "js-sys",
  "ureq",
@@ -1940,50 +2154,50 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "emath"
-version = "0.23.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef2b29de53074e575c18b694167ccbe6e5191f7b25fe65175a0d905a32eeec0"
+checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "encase"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fce2eeef77fd4a293a54b62aa00ac9daebfbcda4bf8998c5a815635b004aa1c"
+checksum = "5a9299a95fa5671ddf29ecc22b00e121843a65cb9ff24911e394b4ae556baf36"
 dependencies = [
  "const_panic",
  "encase_derive",
  "glam",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "encase_derive"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e520cde08cbf4f7cc097f61573ec06ce467019803de8ae82fb2823fa1554a0e"
+checksum = "07e09decb3beb1fe2db6940f598957b2e1f7df6206a804d438ff6cb2a9cddc10"
 dependencies = [
  "encase_derive_impl",
 ]
 
 [[package]]
 name = "encase_derive_impl"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
+checksum = "fd31dbbd9743684d339f907a87fe212cb7b51d75b9e8e74181fe363199ee9b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "epaint"
-version = "0.23.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58067b840d009143934d91d8dcb8ded054d8301d7c11a517ace0a99bb1e1595e"
+checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2002,18 +2216,19 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
  "serde",
+ "typeid",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2129,6 +2344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,13 +2396,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -2190,7 +2408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2201,14 +2419,8 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2309,7 +2521,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2429,8 +2641,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2497,12 +2721,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "glam"
-version = "0.24.2"
+name = "gl_generator"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
 dependencies = [
  "bytemuck",
+ "rand",
  "serde",
 ]
 
@@ -2524,9 +2760,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glow"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2555,7 +2791,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2568,6 +2804,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+dependencies = [
+ "gl_generator",
 ]
 
 [[package]]
@@ -2598,7 +2843,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "gpu-alloc-types",
 ]
 
@@ -2608,47 +2853,47 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
 name = "gpu-allocator"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8"
+checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
- "backtrace",
  "log",
- "thiserror",
+ "presser",
+ "thiserror 1.0.69",
  "winapi",
- "windows 0.44.0",
+ "windows 0.52.0",
 ]
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "dcf29e94d6d243368b7a56caa16bc213e4f9f8ed38c4d9557069527b5d5281ca"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "gpu-descriptor-types",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
 name = "grid"
-version = "0.10.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec1c01eb1de97451ee0d60de7d81cf1e72aabefb021616027f3d1c3ec1c723c"
+checksum = "be136d9dacc2a13cc70bb6c8f902b414fb2641f8db1314637c6b7933411a8f82"
 
 [[package]]
 name = "gtk-sys"
@@ -2729,16 +2974,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "hassle-rs"
-version = "0.10.0"
+name = "hashbrown"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "bitflags 1.3.2",
- "com-rs",
+ "foldhash",
+]
+
+[[package]]
+name = "hassle-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
+dependencies = [
+ "bitflags 2.9.0",
+ "com",
  "libc",
- "libloading 0.7.4",
- "thiserror",
+ "libloading 0.8.3",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -2772,10 +3026,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hexasphere"
-version = "9.1.0"
+name = "hermit-abi"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb3df16a7bcb1b5bc092abd55e14f77ca70aea14445026e264586fc62889a10"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hexasphere"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd6b038160f086b0a7496edae34169ae22f328793cbe2b627a5a3d8373748ec"
 dependencies = [
  "constgebra",
  "glam",
@@ -2815,13 +3075,57 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
+name = "image"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
  "exr",
  "gif",
- "jpeg-decoder",
+ "image-webp",
  "num-traits",
  "png",
  "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77d01e822461baa8409e156015a1d91735549f0f2c17691bd2d996bef238f7f"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+
+[[package]]
+name = "immutable-chunkmap"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f97096f508d54f8f8ab8957862eee2ccd628847b6217af1a335e1c44dee578"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -2877,16 +3181,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "interpolation"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b7357d2bbc5ee92f8e899ab645233e43d21407573cceb37fed8bc3dede2c02"
+checksum = "e9c13ae9d91148fcb4aab6654c4c2a7d02a15395ea9e23f65170f175f8b269ce"
 
 [[package]]
 name = "io-kit-sys"
@@ -2903,6 +3215,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2933,7 +3254,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -2958,9 +3279,6 @@ name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "js-sys"
@@ -2973,14 +3291,20 @@ dependencies = [
 
 [[package]]
 name = "khronos-egl"
-version = "4.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.3",
  "pkg-config",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "ktx2"
@@ -3022,9 +3346,19 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -3058,9 +3392,9 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3069,9 +3403,9 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3092,9 +3426,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litrs"
@@ -3117,6 +3451,15 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "mach2"
@@ -3156,21 +3499,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "metal"
-version = "0.26.0"
+name = "memmap2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
- "bitflags 2.4.2",
+ "libc",
+]
+
+[[package]]
+name = "metal"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
+dependencies = [
+ "bitflags 2.9.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -3193,54 +3555,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "naga"
-version = "0.13.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
+ "arrayvec",
  "bit-set",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "log",
  "num-traits",
  "pp-rs",
  "rustc-hash",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
 [[package]]
 name = "naga_oil"
-version = "0.10.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac54c77b3529887f9668d3dd81e955e58f252b31a333f836e3548c06460b958"
+checksum = "275d9720a7338eedac966141089232514c84d76a246a58ef501af88c5edf402f"
 dependencies = [
  "bit-set",
  "codespan-reporting",
  "data-encoding",
- "indexmap 1.9.3",
+ "indexmap 2.2.5",
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
  "rustc-hash",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-ident",
 ]
@@ -3274,30 +3625,31 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
-dependencies = [
- "bitflags 1.3.2",
- "jni-sys",
- "ndk-sys 0.4.1+23.1.7779620",
- "num_enum 0.5.11",
- "raw-window-handle",
- "thiserror",
-]
-
-[[package]]
-name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "jni-sys",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
- "num_enum 0.7.2",
- "thiserror",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.9.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "raw-window-handle 0.6.2",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3305,15 +3657,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.4.1+23.1.7779620"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -3325,12 +3668,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "cfg-if",
  "libc",
 ]
@@ -3358,6 +3716,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,6 +3741,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,24 +3761,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3423,6 +3786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3439,53 +3803,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
- "num_enum_derive 0.7.2",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -3494,10 +3816,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3507,7 +3829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -3523,37 +3844,205 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.2.0-beta.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.3.patch-leaks.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
- "block2",
  "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
-name = "objc2-encode"
-version = "2.0.0-pre.2"
+name = "objc2-app-kit"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "objc-sys",
+ "bitflags 2.9.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
+name = "objc2-cloud-kit"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "cc",
+ "bitflags 2.9.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "dispatch",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3576,17 +4065,6 @@ dependencies = [
 
 [[package]]
 name = "oboe"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868cc237ee02e2d9618539a23a8d228b9bb3fc2e7a5b11eed3831de77c395d0"
-dependencies = [
- "num-derive 0.3.3",
- "num-traits",
- "oboe-sys 0.5.0",
-]
-
-[[package]]
-name = "oboe"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
@@ -3594,18 +4072,9 @@ dependencies = [
  "jni",
  "ndk 0.8.0",
  "ndk-context",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
- "oboe-sys 0.6.1",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f44155e7fb718d3cfddcf70690b2b51ac4412f347cd9e4fbe511abe9cd7b5f2"
-dependencies = [
- "cc",
+ "oboe-sys",
 ]
 
 [[package]]
@@ -3698,7 +4167,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -3727,8 +4196,30 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.2.5",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3774,6 +4265,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "pp-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,14 +4289,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "zerocopy 0.8.24",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
@@ -3803,9 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -3815,6 +4326,19 @@ name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "qoi"
@@ -3823,6 +4347,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3835,10 +4374,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radsort"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.12",
+]
 
 [[package]]
 name = "range-alloc"
@@ -3847,10 +4422,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "system-deps",
+ "thiserror 1.0.69",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5f31fcf7500f9401fea858ea4ab5525c99f2322cfcee732c0e6c74208c0c6"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rawpointer"
@@ -3886,15 +4517,6 @@ checksum = "a0d463f2884048e7153449a55166f91028d5b0ea53c79377099ce4e8cf0cf9bb"
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -3908,9 +4530,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
  "libredox 0.0.1",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3953,12 +4575,6 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
-
-[[package]]
-name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
@@ -3985,12 +4601,18 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
@@ -4000,7 +4622,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "libc",
  "spin",
  "untrusted",
@@ -4039,12 +4661,13 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.12",
  "thread_local",
  "tracing",
  "tracing-subscriber",
  "urdf-rs",
  "utm",
+ "uuid",
  "yaserde",
 ]
 
@@ -4071,7 +4694,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.12",
  "urdf-rs",
  "uuid",
  "yaserde",
@@ -4085,12 +4708,13 @@ checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
 name = "rodio"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1bb7b48ee48471f55da122c0044fcc7600cfcc85db88240b89cb832935e611"
+checksum = "d1fceb9d127d515af1586d8d0cc601e1245bdb0af38e75c865a156290184f5b3"
 dependencies = [
  "cpal",
  "lewton",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4100,7 +4724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "serde",
  "serde_derive",
 ]
@@ -4111,7 +4735,7 @@ version = "0.9.0-alpha.0"
 source = "git+https://github.com/ron-rs/ron?branch=master#74666478d5553592c6136e0dec12d11bbd10302e"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "serde",
  "serde_derive",
  "unicode-ident",
@@ -4151,11 +4775,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4195,12 +4819,10 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.4.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
 dependencies = [
- "byteorder",
- "thiserror-core",
  "twox-hash",
 ]
 
@@ -4229,10 +4851,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
 
 [[package]]
 name = "sdformat_rs"
@@ -4253,6 +4894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,7 +4916,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4339,6 +4986,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4361,8 +5017,30 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "serde",
+ "bitflags 2.9.0",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
 ]
 
 [[package]]
@@ -4397,12 +5075,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.2.0+1.5.4"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 1.3.2",
- "num-traits",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4426,6 +5103,12 @@ dependencies = [
  "byteorder",
  "float-cmp",
 ]
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
@@ -4458,9 +5141,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4469,16 +5152,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
  "libc",
  "ntapi",
  "once_cell",
- "winapi",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -4496,13 +5179,14 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.3.18"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2287b6d7f721ada4cddf61ade5e760b2c6207df041cac9bfaa192897362fd3"
+checksum = "9cb893bff0f80ae17d3a57e030622a967b8dbc90e38284d9b4b1442e23873c94"
 dependencies = [
  "arrayvec",
  "grid",
  "num-traits",
+ "serde",
  "slotmap",
 ]
 
@@ -4523,42 +5207,42 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
-name = "thiserror-core"
-version = "1.0.50"
+name = "thiserror"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-core-impl",
-]
-
-[[package]]
-name = "thiserror-core-impl"
-version = "1.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4580,6 +5264,31 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -4626,7 +5335,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.6",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -4636,28 +5345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -4673,9 +5360,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.5",
  "serde",
@@ -4686,9 +5373,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4697,34 +5384,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -4753,7 +5429,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4782,6 +5458,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -4842,7 +5524,7 @@ checksum = "98e716107a1f06d9261b044b3c0518b1884f9fb4b2b2e124aad43a53d206c7fd"
 dependencies = [
  "once_cell",
  "regex",
- "thiserror",
+ "thiserror 1.0.69",
  "yaserde",
  "yaserde_derive",
 ]
@@ -4889,12 +5571,25 @@ checksum = "95b09e3b3a0abd1ccb77673a6b7b8875d9d1c80626154add451cf18392dc4c3c"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.2",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4944,6 +5639,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4965,7 +5669,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -4999,7 +5703,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5011,14 +5715,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
-name = "wayland-scanner"
-version = "0.29.5"
+name = "wayland-backend"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
+checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
+dependencies = [
+ "bitflags 2.9.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.9.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
+dependencies = [
+ "rustix",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0781cf46869b37e36928f7b432273c0995aa8aed9552c556fb18754420541efc"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccaacc76703fefd6763022ac565b590fcade92202492381c95b2edfdf7d46b3"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248a02e6f595aad796561fa82d25601bd2c8c3b145b1c7453fc8f94c1a58f8b2"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
 dependencies = [
  "proc-macro2",
+ "quick-xml",
  "quote",
- "xml-rs",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5032,18 +5834,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "webbrowser"
-version = "0.8.13"
+name = "web-time"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b04c569c83a9bb971dd47ec6fd48753315f4bf989b9b04a2e7ca4d7f0dc950"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
+dependencies = [
+ "block2",
  "core-foundation",
  "home",
  "jni",
  "log",
  "ndk-context",
- "objc",
- "raw-window-handle",
+ "objc2",
+ "objc2-foundation",
  "url",
  "web-sys",
 ]
@@ -5065,18 +5878,20 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "0.17.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752e44d3998ef35f71830dd1ad3da513e628e2e4d4aedb0ab580f850827a0b41"
+checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
 dependencies = [
  "arrayvec",
  "cfg-if",
+ "cfg_aliases 0.1.1",
+ "document-features",
  "js-sys",
  "log",
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -5089,22 +5904,26 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.17.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8a44dd301a30ceeed3c27d8c0090433d3da04d7b2a4042738095a424d12ae7"
+checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
+ "cfg_aliases 0.1.1",
  "codespan-reporting",
+ "document-features",
+ "indexmap 2.2.5",
  "log",
  "naga",
+ "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "rustc-hash",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "web-sys",
  "wgpu-hal",
  "wgpu-types",
@@ -5112,19 +5931,21 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.17.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a80bf0e3c77399bb52850cb0830af9bad073d5cfcb9dd8253bef8125c42db17"
+checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "block",
+ "cfg_aliases 0.1.1",
  "core-graphics-types",
  "d3d12",
  "glow",
+ "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
@@ -5136,15 +5957,17 @@ dependencies = [
  "log",
  "metal",
  "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
  "objc",
+ "once_cell",
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle",
+ "raw-window-handle 0.6.2",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -5153,11 +5976,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.9.0",
  "js-sys",
  "web-sys",
 ]
@@ -5211,26 +6034,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
@@ -5246,6 +6049,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
+ "windows-implement",
+ "windows-interface",
  "windows-targets 0.52.4",
 ]
 
@@ -5270,24 +6075,24 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.48.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
+checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.48.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
+checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5499,32 +6304,54 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winit"
-version = "0.28.7"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
+checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
 dependencies = [
+ "ahash",
  "android-activity",
- "bitflags 1.3.2",
- "cfg_aliases",
+ "atomic-waker",
+ "bitflags 2.9.0",
+ "block2",
+ "bytemuck",
+ "calloop",
+ "cfg_aliases 0.2.1",
+ "concurrent-queue",
  "core-foundation",
- "core-graphics 0.22.3",
- "dispatch",
- "instant",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
  "libc",
- "log",
- "mio",
- "ndk 0.7.0",
+ "memmap2",
+ "ndk 0.9.0",
  "objc2",
- "once_cell",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
- "raw-window-handle",
- "redox_syscall 0.3.5",
+ "pin-project",
+ "raw-window-handle 0.6.2",
+ "redox_syscall",
+ "rustix",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
  "wasm-bindgen",
- "wayland-scanner",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
  "web-sys",
- "windows-sys 0.45.0",
+ "web-time",
+ "windows-sys 0.52.0",
  "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
 ]
 
 [[package]]
@@ -5546,6 +6373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5562,7 +6398,11 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
+ "libc",
+ "libloading 0.8.3",
+ "once_cell",
  "rustix",
  "x11rb-protocol",
 ]
@@ -5574,10 +6414,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
+name = "xcursor"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
+
+[[package]]
 name = "xi-unicode"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.9.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
@@ -5633,7 +6498,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -5644,7 +6518,18 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5654,10 +6539,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "bevy_impulse"
 version = "0.3.0"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#3d5d44310dd092c56eb8bed373da61bad87ed796"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#03b6e63007960d27a104f01d5f34f8bd455ac8e9"
 dependencies = [
  "anyhow",
  "async-task",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "bevy_impulse_derive"
 version = "0.0.2"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#3d5d44310dd092c56eb8bed373da61bad87ed796"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#03b6e63007960d27a104f01d5f34f8bd455ac8e9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "c236a84ff1111defc280cee755eaa953d0b24398786851b9d28322c6d3bb1ebd"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "once_cell",
 ]
 
@@ -257,20 +257,21 @@ checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arboard"
-version = "3.3.2"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2041f1943049c7978768d84e6d0fd95de98b76d6c4727b09e78ec253d29fa58"
+checksum = "c1df21f715862ede32a0c525ce2ca4d52626bb0007f8c18b87a384503ac33e70"
 dependencies = [
  "clipboard-win",
- "core-graphics",
- "image 0.24.9",
+ "image",
  "log",
- "objc",
- "objc-foundation",
- "objc_id",
+ "objc2 0.6.1",
+ "objc2-app-kit 0.3.1",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.1",
  "parking_lot",
- "thiserror 1.0.69",
- "windows-sys 0.48.0",
+ "percent-encoding",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -830,7 +831,7 @@ dependencies = [
  "bevy_transform",
  "gltf",
  "gltf-json",
- "image 0.25.6",
+ "image",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1155,7 +1156,7 @@ dependencies = [
  "encase",
  "futures-lite 2.2.0",
  "hexasphere",
- "image 0.25.6",
+ "image",
  "js-sys",
  "ktx2",
  "naga",
@@ -1523,7 +1524,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -1734,9 +1735,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clipboard-win"
-version = "5.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9a0700e0127ba15d1d52dd742097f821cd9c65939303a44d970465040a297"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
 ]
@@ -2070,6 +2071,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.1",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "euclid"
@@ -3068,20 +3079,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "num-traits",
- "png",
- "tiff",
-]
-
-[[package]]
-name = "image"
 version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
@@ -3859,6 +3856,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,11 +3873,23 @@ dependencies = [
  "bitflags 2.9.0",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.1",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.1",
 ]
 
 [[package]]
@@ -3882,9 +3900,9 @@ checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.9.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3894,8 +3912,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3906,8 +3924,32 @@ checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.9.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+ "dispatch2",
+ "objc2 0.6.1",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
+dependencies = [
+ "bitflags 2.9.0",
+ "dispatch2",
+ "objc2 0.6.1",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3917,8 +3959,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -3929,9 +3971,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3950,7 +3992,29 @@ dependencies = [
  "block2",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
+dependencies = [
+ "bitflags 2.9.0",
+ "objc2 0.6.1",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3960,9 +4024,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3973,8 +4037,8 @@ checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.9.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3985,8 +4049,8 @@ checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.9.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -3996,8 +4060,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4008,12 +4072,12 @@ checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.9.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
@@ -4028,8 +4092,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4040,9 +4104,9 @@ checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.9.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5855,8 +5919,8 @@ dependencies = [
  "jni",
  "log",
  "ndk-context",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "url",
  "web-sys",
 ]
@@ -6325,9 +6389,9 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk 0.9.0",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.23"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225"
+checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -79,18 +79,18 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -100,17 +100,17 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.2.12",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
- "zerocopy 0.7.32",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -123,18 +123,19 @@ checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fe60779335388a88c01ac6c3be40304d1e349de3ada3b15f7808bb90fa9dce"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
  "bitflags 2.9.0",
+ "cfg-if",
  "libc",
 ]
 
@@ -177,9 +178,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_log-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_system_properties"
@@ -192,57 +193,59 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -287,14 +290,14 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -325,7 +328,7 @@ checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -345,21 +348,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener-strategy 0.5.4",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.11.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.0.1",
+ "fastrand 2.3.0",
  "futures-lite 2.6.0",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -376,12 +380,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener 5.4.0",
+ "event-listener-strategy",
  "pin-project-lite",
 ]
 
@@ -393,9 +397,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "atk-sys"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251e0b7d90e33e0ba930891a505a9a35ece37b2dd37a14f3ffc306c13b980009"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -430,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "av1-grain"
@@ -459,17 +463,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -486,18 +490,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2a21c9f3306676077a88700bb8f354be779cf9caba9c21e94da9e696751af4"
+checksum = "2eaad7fe854258047680c51c3cacb804468553c04241912f6254c841c67c0198"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96642402d2cd7c8e58c5994bbd14a2e44ca72dd7e460a2edad82aa3bf0348f9"
+checksum = "245a938f754f70a380687b89f1c4dac75b62d58fae90ae969fcfb8ecd91ed879"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -508,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03064ab96e15b2fda5bd58eac2055692d731c1fba3e211fd1ba48472cced75c3"
+checksum = "41e2b3e4e6cb4df085b941b105f2c790901e34c8571e02342f8e96acdf7cf7d1"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -540,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454a8cfd134864dcdcba6ee56fb958531b981021bba6bb2037c9e3df6046603c"
+checksum = "a0ac033a388b8699d241499a43783a09e6a3bab2430f1297c6bd4974095efb3f"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -559,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d762dd4422fb6219fd904e514a4a5d1d451711a0a8e1d6495dea15a545f04f3"
+checksum = "73fd901b3be016088c4dda2f628bda96b7cb578b9bc8ae684bbf30bec0a9483e"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -603,14 +607,14 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "bevy_audio"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d13715401172d7616b376362a46bba125ec9ccc73ab262153a43a2402537ca"
+checksum = "30af4b6a91c8e08f623b0cdc53ce5b8f731c78af6ef728cdfc06dc61eda164c4"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -627,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00aa2966c7ca0c7dd39f5ba8f3b1eaa5c2005a93ffdefb7a4090150d8327678"
+checksum = "a87b7137ffa9844ae542043769fb98c35efbf2f8a8429ff2a73d8ef30e58baaa"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -642,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff28118f5ae3193f7f6cab30d4fd4246ba1802776910ab256dc7c20e8696381"
+checksum = "1e9ce8da8e4016f63c1d361b52e61aaf4348c569829c74f1a5bbedfd8d3d57a3"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -656,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c0eea548a55fd04acf01d351bd16da4d1198037cb9c7b98dea6519f5d7dade"
+checksum = "ee0ff0f4723f30a5a6578915dbfe0129f2befaec8438dde70ac1fb363aee01f5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -689,14 +693,14 @@ checksum = "57d94761ce947b0a2402fd949fe1e7a5b1535293130ba4cd9893be6295d4680a"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fe41b22fdf47bf11f0a3ca3e61975b003e86fa44d87e070f2dc7e752dd99f5"
+checksum = "5e83c65979f063b593917ab9b1d7328c5854dba4b6ddf1ab78156c0105831fdf"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -710,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b747210d7db09dfacc237707d4fd31c8b43d7744cd5e5829e2c4ca86b9e47baf"
+checksum = "1597106cc01e62e6217ccb662e0748b2ce330893f27c7dc17bac33e0bb99bca9"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -740,7 +744,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -792,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20320bd21f379ba4ec885b8217cb7c2c57eb0be014ba29509959e252480c3e9"
+checksum = "a737451ccd6be5da68fbba5d984328b8a82eebd16c1fda0bec840090a3d454fd"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -807,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca821905afffe1f3aaf33b496903a24a0c980e4c83fa7523fb41eac16892a57a"
+checksum = "c1614516d0922ad60e87cc39658422286ed684aaf4b3162d25051bc105eed814"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -838,14 +842,14 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "bevy_gltf"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38b79c0e43c6387699d6a332d12f98ed895bcf69dd70c462d5e49ad76d44d1f"
+checksum = "aa8364f34bc08fe067ce32418e22ee96e177101dbf1bc00803aaeb2b262615be"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -894,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9aab2cd1684d30f2eedf953b6377a6416fd6b482f8145b6c05f4684bd60c3e"
+checksum = "19ced04e04437d0a439fe4722544c2a4678c1fe3412b57ee489d817c11884045"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -909,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5942a7d681b81aa9723bb1d918135c2f88e7871331f5676119c86c01984759"
+checksum = "4b384d1ce9c87f6151292a76233897a628c2a50b3560487c4d74472225d49826"
 dependencies = [
  "bevy_asset",
  "bevy_color",
@@ -932,7 +936,7 @@ dependencies = [
 [[package]]
 name = "bevy_impulse"
 version = "0.3.0"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#603e60e8c0d2bbb2f2534117676778cbd1f43992"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#3d5d44310dd092c56eb8bed373da61bad87ed796"
 dependencies = [
  "anyhow",
  "async-task",
@@ -958,18 +962,18 @@ dependencies = [
 [[package]]
 name = "bevy_impulse_derive"
 version = "0.0.2"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#603e60e8c0d2bbb2f2534117676778cbd1f43992"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#3d5d44310dd092c56eb8bed373da61bad87ed796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bbf39c1d2d33350e03354a67bebee5c21973c5203b1456a9a4b90a5e6f8e75"
+checksum = "d52589939ca09695c69d629d166c5edf1759feaaf8f2078904aae9c33d08f5c3"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -983,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7fc4db9a1793ee71f79abb15e7a8fcfe4e2081e5f18ed91b802bf6cf30e088"
+checksum = "f1e0c1d980d276e11558184d0627c8967ad8b70dab3e54a0f377bb53b98515b6"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1026,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774238dcf70a0ef4d82aa2860b24b1cffdd4633f3694d3bcbfbb05c4f17ae4fe"
+checksum = "b381a22e01f24af51536ef1eace94298dd555d06ffcf368125d16317f5f179cb"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1048,15 +1052,15 @@ checksum = "8bb6ded1ddc124ea214f6a2140e47a78d1fe79b0638dad39419cdeef2e1133f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "toml_edit 0.22.12",
+ "syn 2.0.101",
+ "toml_edit",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edec18d90e6bab27b5c6131ee03172ece75b7edd0abe4e482a26d6db906ec357"
+checksum = "1c2650169161b64f9a93e41f13253701fdf971dc95265ed667d17bea6d2a334f"
 dependencies = [
  "bevy_reflect",
  "derive_more",
@@ -1070,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183abae7c6695a80d7408c860bd737410cd66d2a9f910dafc914485da06e43dc"
+checksum = "760f3c41b4c61a5f0d956537f454c49f79b8ed0fd0781b1a879ead8e69d95283"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1102,13 +1106,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_mod_outline"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380a62f1c85e631a884b642e380d3ad2dbb15d4fbeb9cb35bcbd97efa8de1136"
+checksum = "a8be81a7b5640918fbf627a34e0df4b80ddfb6d8c6fdc65829d1c43918ebb0a9"
 dependencies = [
  "bevy",
- "bevy_image",
- "bitfield",
+ "bitfield 0.15.0",
  "interpolation",
  "nonmax",
  "thiserror 1.0.69",
@@ -1129,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_pbr"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f17067399cf00f4441e93d39fb4c391a16cc223e0d35346ac388e66712c418"
+checksum = "a4d54c840d4352dac51f2a27cf915ac99b2f93db008d8fb1be8d23b09d522acf"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1158,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_picking"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125e0c7327ec155c566c044c6eefd1a02e904134fa5dc0ba54665e06a35297b0"
+checksum = "2091a495c0f9c8962abb1e30f9d99696296c332b407e1f6fe1fe28aab96a8629"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1199,9 +1202,9 @@ checksum = "89fe0b0b919146939481a3a7c38864face2c6d0fd2c73ab3d430dc693ecd9b11"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab3264acc3b6f48bc23fbd09fdfea6e5d9b7bfec142e4f3333f532acf195bca"
+checksum = "3ddbca0a39e88eff2c301dc794ee9d73a53f4b08d47b2c9b5a6aac182fae6217"
 dependencies = [
  "assert_type_match",
  "bevy_ptr",
@@ -1221,22 +1224,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f83876a322130ab38a47d5dcf75258944bf76b3387d1acdb3750920fda63e2"
+checksum = "d62affb769db17d34ad0b75ff27eca94867e2acc8ea350c5eca97d102bd98709"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_render"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b14d77d8ff589743237c98502c0e47fd31059cf348ab86a265c4f90bb5e2a22"
+checksum = "c4aa9d7df5c2b65540093b8402aceec0a55d67b54606e57ce2969abe280b4c48"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1288,14 +1291,14 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "bevy_scene"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd00a08d01a190a826a5f6ad0fcb3dbf7bd1bd4f64ebe6108c38384691a21111"
+checksum = "bdfe819202aa97bbb206d79fef83504b34d45529810563aafc2fe02cc10e3ee4"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1313,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c7d22da88e562fb2ae8fe7f8cc749d3024caa4dcb57a777d070ef9141577aa"
+checksum = "27411a31704117002787c9e8cc1f2f89babf5e67572508aa029366d4643f8d01"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1343,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd10c8b01a982642596406fc4486fcd52239aa9c4aa47fed27abab93a69fba59"
+checksum = "243a72266f81452412f7a3859e5d11473952a25767dc29c8d285660330f007ba"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1364,7 +1367,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1395,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ee0b5f52946d222521f93773a6230f42e868548f881c4c5bddb1393a96298b"
+checksum = "872b0b627cedf6d1bd97b75bc4d59c16f67afdd4f2fed8f7d808a258d6cb982e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1423,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3108ed1ef864bc40bc859ba4c9c3844213c7be3674f982203cf5d87c656848"
+checksum = "1b2051ec56301b994f7c182a2a6eb1490038149ad46d95eee715e1a922acdfd9"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1436,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056fabcedbf0503417af69447d47a983e18c7cfb5e6b6728636be3ec285cbcfa"
+checksum = "a8109b1234b0e58931f51df12bc8895daa69298575cf92da408848f79a4ce201"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1450,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4556fc2202c6339f95e0c24ca4c96ee959854b702e23ecf73e05fb20e67d67b0"
+checksum = "e534590222d044c875bf3511e5d0b3da78889bb21ad797953484ce011af77b46"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1489,8 +1492,8 @@ checksum = "63c2174d43a0de99f863c98a472370047a2bfa7d1e5cec8d9d647fb500905d9d"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
- "getrandom 0.2.12",
- "hashbrown 0.14.3",
+ "getrandom 0.2.16",
+ "hashbrown 0.14.5",
  "thread_local",
  "tracing",
  "web-time",
@@ -1504,14 +1507,14 @@ checksum = "94847541f6dd2e28f54a9c2b0e857da5f2631e2201ebc25ce68781cdcb721391"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36139955777cc9e7a40a97833ff3a95b7401ce525a3dbac05fc52557968b31a7"
+checksum = "c1e1e7c6713c04404a3e7cede48a9c47b76c30efc764664ec1246147f6fb9878"
 dependencies = [
  "android-activity",
  "bevy_a11y",
@@ -1527,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e84e7f94583cac93de4ba641029eb0b6551d35e559c829209f2b1b9fe532d8"
+checksum = "e158a73d6d896b1600a61bc115017707ecb467d1a5ad49231c5e58294f6f6e13"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1560,26 +1563,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
@@ -1595,7 +1578,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1641,6 +1624,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
 
 [[package]]
+name = "bitfield"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786e53b0c071573a28956cec19a92653e42de34c683e2f6e86c197a349fba318"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07805405d3f1f3a55aab895718b488821d40458f9188059909091ae0935c344a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,9 +1666,9 @@ checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1691,18 +1694,15 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
  "async-channel",
- "async-lock",
  "async-task",
- "fastrand 2.0.1",
  "futures-io",
  "futures-lite 2.6.0",
  "piper",
- "tracing",
 ]
 
 [[package]]
@@ -1713,28 +1713,28 @@ checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.5.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1751,9 +1751,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cairo-sys-rs"
@@ -1793,12 +1793,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1818,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa50868b64a9a6fda9d593ce778849ea8715cd2a3d2cc17ffdb4a2f2f2f1961d"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -1846,9 +1847,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -1857,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1867,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1879,21 +1880,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clipboard-win"
@@ -1922,15 +1923,15 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
-version = "4.6.6"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
@@ -1976,16 +1977,16 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "const_panic"
-version = "0.2.8"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
+checksum = "2459fc9262a1aa204eb4b5764ad4f189caec88aea9634389c0a25f8be7f6265e"
 
 [[package]]
 name = "const_soft_float"
@@ -1995,9 +1996,9 @@ checksum = "87ca1caa64ef4ed453e68bb3db612e51cf1b2f5b871337f0fcab1c8f87cc3dff"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "constgebra"
@@ -2045,9 +2046,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
@@ -2080,11 +2081,11 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f01585027057ff5f0a5bf276174ae4c1594a2c5bde93d5f46a016d76270f5a9"
+checksum = "2ce857aa0b77d77287acc1ac3e37a05a8c95a2af3647d23b15f263bdaeb7562b"
 dependencies = [
- "bindgen 0.69.4",
+ "bindgen",
 ]
 
 [[package]]
@@ -2135,33 +2136,33 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2178,15 +2179,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "ctrlc"
@@ -2212,9 +2213,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "derive_more"
@@ -2233,7 +2234,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -2243,7 +2244,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -2254,8 +2264,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2272,6 +2294,17 @@ checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.0",
  "objc2 0.6.1",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2300,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -2403,7 +2436,7 @@ checksum = "f97b51c5cc57ef7c5f7a0c57c250251c49ee4c28f819f87ac32f4aceabc36792"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2431,9 +2464,9 @@ checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
@@ -2463,9 +2496,9 @@ checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "euclid"
-version = "0.22.9"
+version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787"
+checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
 dependencies = [
  "num-traits",
 ]
@@ -2478,33 +2511,12 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -2514,18 +2526,17 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.2.0",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "exr"
-version = "1.72.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
+checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
 dependencies = [
  "bit_field",
- "flume",
  "half",
  "lebe",
  "miniz_oxide",
@@ -2545,15 +2556,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
@@ -2572,9 +2583,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2600,15 +2611,6 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
-
-[[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "fnv"
@@ -2672,7 +2674,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2692,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2707,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2717,15 +2719,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2734,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2759,7 +2761,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
- "fastrand 2.0.1",
+ "fastrand 2.3.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -2768,32 +2770,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2822,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-sys"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ff856cb3386dae1703a920f803abafcc580e9b5f711ca62ed1620c25b51ff2"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -2856,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.13"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+checksum = "62ddb1950450d67efee2bbc5e429c68d052a822de3aad010d28b351fbb705224"
 dependencies = [
  "approx",
  "num-traits",
@@ -2887,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2951,14 +2953,14 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.58.0",
+ "windows 0.61.1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio-sys"
@@ -3007,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "glow"
@@ -3025,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "gltf"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b78f069cf941075835822953c345b9e1edd67ae347b81ace3aea9de38c2ef33"
+checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
 dependencies = [
  "byteorder",
  "gltf-json",
@@ -3037,21 +3039,21 @@ dependencies = [
 
 [[package]]
 name = "gltf-derive"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438ffe1a5540d75403feaf23636b164e816e93f6f03131674722b3886ce32a57"
+checksum = "14070e711538afba5d6c807edb74bcb84e5dbb9211a3bf5dea0dfab5b24f4c51"
 dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "gltf-json"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655951ba557f2bc69ea4b0799446bae281fa78efae6319968bdd2c3e9a06d8e1"
+checksum = "e6176f9d60a7eab0a877e8e96548605dedbde9190a7ae1e80bbcc1c9af03ab14"
 dependencies = [
  "gltf-derive",
  "serde",
@@ -3138,9 +3140,9 @@ checksum = "be136d9dacc2a13cc70bb6c8f902b414fb2641f8db1314637c6b7933411a8f82"
 
 [[package]]
 name = "gtk-sys"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771437bf1de2c1c0b496c11505bdf748e26066bbe942dfc8f614c9460f6d7722"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
 dependencies = [
  "atk-sys",
  "cairo-sys-rs",
@@ -3170,19 +3172,19 @@ version = "0.1.0"
 source = "git+https://github.com/open-rmf/gz-fuel-rs?branch=main#cbdb4b587834ac9af78d0018c6dcd9ab3efd3cb2"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "ehttp",
  "futures-lite 2.6.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3205,9 +3207,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -3220,6 +3222,8 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -3247,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3276,21 +3280,150 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -3371,12 +3504,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -3407,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -3422,7 +3555,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3440,6 +3573,12 @@ dependencies = [
  "core-foundation-sys",
  "mach2",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -3469,10 +3608,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.10"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -3498,10 +3646,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -3552,15 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lebe"
@@ -3597,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -3607,30 +3750,19 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "libredox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
-dependencies = [
- "bitflags 2.9.0",
- "libc",
- "redox_syscall",
+ "redox_syscall 0.5.11",
 ]
 
 [[package]]
@@ -3656,6 +3788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
 name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,9 +3801,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -3673,9 +3811,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loop9"
@@ -3715,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -3735,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -3771,11 +3909,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
- "adler",
+ "adler2",
  "simd-adler32",
 ]
 
@@ -3791,7 +3929,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.2.5",
+ "indexmap 2.9.0",
  "log",
  "pp-rs",
  "rustc-hash",
@@ -3810,11 +3948,11 @@ dependencies = [
  "bit-set 0.5.3",
  "codespan-reporting",
  "data-encoding",
- "indexmap 2.2.5",
+ "indexmap 2.9.0",
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.5",
  "rustc-hash",
  "thiserror 1.0.69",
  "tracing",
@@ -3823,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea4908d4f23254adda3daa60ffef0f1ac7b8c3e9a864cf3cc154b251908a2ef"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -3839,13 +3977,13 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3978,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
@@ -3993,7 +4131,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4007,11 +4145,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -4019,9 +4156,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -4029,23 +4166,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4349,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -4412,11 +4549,11 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
+checksum = "ba0b26cec2e24f08ed8bb31519a9333140a6599b867dac464bb150bdb796fd43"
 dependencies = [
- "libredox 0.0.2",
+ "libredox",
 ]
 
 [[package]]
@@ -4427,11 +4564,11 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.20.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
+checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
 dependencies = [
- "ttf-parser 0.20.0",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -4448,15 +4585,15 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -4464,28 +4601,28 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.11",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -4495,12 +4632,12 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.2.5",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
 ]
@@ -4522,14 +4659,14 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -4539,26 +4676,26 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.0.1",
+ "fastrand 2.3.0",
  "futures-io",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
-version = "0.17.13"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -4569,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.2"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -4579,7 +4716,7 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4612,7 +4749,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -4628,16 +4765,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4665,7 +4802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4685,18 +4822,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.4"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -4709,9 +4846,9 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radsort"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
+checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
@@ -4740,7 +4877,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -4755,9 +4892,9 @@ dependencies = [
 
 [[package]]
 name = "range-alloc"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
+checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
 
 [[package]]
 name = "rangemap"
@@ -4879,26 +5016,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.4"
+name = "redox_syscall"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "getrandom 0.2.12",
- "libredox 0.0.1",
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.3"
+name = "redox_users"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4912,13 +5069,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4929,9 +5086,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "renderdoc-sys"
@@ -4970,15 +5127,14 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom 0.2.16",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4996,15 +5152,15 @@ dependencies = [
  "bevy_obj",
  "bevy_polyline",
  "bevy_stl",
- "bitfield",
+ "bitfield 0.19.0",
  "clap",
  "crossbeam-channel",
- "dirs",
+ "dirs 5.0.1",
  "ehttp",
  "futures-lite 1.13.0",
  "geo",
  "gz-fuel",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "nalgebra",
  "pathdiff",
  "rfd",
@@ -5042,7 +5198,7 @@ dependencies = [
  "glam",
  "once_cell",
  "pathdiff",
- "ron 0.9.0-alpha.0",
+ "ron 0.10.1",
  "sdformat_rs",
  "serde",
  "serde_json",
@@ -5084,8 +5240,8 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.9.0-alpha.0"
-source = "git+https://github.com/ron-rs/ron?branch=master#74666478d5553592c6136e0dec12d11bbd10302e"
+version = "0.10.1"
+source = "git+https://github.com/ron-rs/ron?branch=master#3159534d8111a31d33791826aef2132308cc032c"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.0",
@@ -5113,9 +5269,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -5125,9 +5281,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -5147,11 +5303,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -5161,15 +5318,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5210,15 +5367,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
@@ -5277,9 +5434,9 @@ checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "send_wrapper"
@@ -5289,40 +5446,41 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -5412,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -5443,20 +5601,20 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "spade"
-version = "2.6.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61addf9117b11d1f5b4bf6fe94242ba25f59d2d4b2080544b771bd647024fd00"
+checksum = "1ece03ff43cd2a9b57ebf776ea5e78bd30b3b4185a619f041079f4109f385034"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
  "num-traits",
  "robust",
  "smallvec",
@@ -5516,21 +5674,21 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svg_fmt"
-version = "0.4.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
+checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
@@ -5556,13 +5714,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5584,17 +5753,17 @@ dependencies = [
  "libc",
  "memchr",
  "ntapi",
- "windows 0.54.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
 name = "system-deps"
-version = "6.2.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
  "cfg-expr",
- "heck 0.4.1",
+ "heck 0.5.0",
  "pkg-config",
  "toml",
  "version-compare",
@@ -5615,9 +5784,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "termcolor"
@@ -5654,7 +5823,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5665,7 +5834,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5724,6 +5893,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5750,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -5760,47 +5939,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.12",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.2.5",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
-dependencies = [
- "indexmap 2.2.5",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow",
 ]
 
 [[package]]
@@ -5822,7 +5990,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5852,7 +6020,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "cc",
  "cfg-if",
  "once_cell",
@@ -5863,9 +6031,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5903,6 +6071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5920,15 +6094,15 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-bidi-mirroring"
@@ -5944,24 +6118,15 @@ checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-properties"
@@ -5977,15 +6142,15 @@ checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -6014,26 +6179,25 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.9.6"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "url",
  "webpki-roots",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6041,10 +6205,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.1"
+name = "utf16_iter"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utm"
@@ -6054,12 +6230,11 @@ checksum = "95b09e3b3a0abd1ccb77673a6b7b8875d9d1c80626154add451cf18392dc4c3c"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom 0.3.2",
- "js-sys",
+ "getrandom 0.2.16",
  "serde",
  "wasm-bindgen",
 ]
@@ -6077,9 +6252,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vec_map"
@@ -6089,21 +6264,21 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -6152,7 +6327,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -6187,7 +6362,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6203,9 +6378,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
+checksum = "c2bea670be0e24795f39416e5461ccef0185b47df2749ed2b226b8a7557ac871"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -6217,9 +6392,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.8"
+version = "0.31.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
+checksum = "5029b0ff4f7be961c326169ee8e247d534d8507dbe390cac6aa3d2cc7c268825"
 dependencies = [
  "bitflags 2.9.0",
  "rustix",
@@ -6240,9 +6415,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.8"
+version = "0.31.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
+checksum = "28d6ec438d7c38bde05a10e80c3e3a1212d85f941be9fc9f80c86e6f5f498252"
 dependencies = [
  "rustix",
  "wayland-client",
@@ -6251,9 +6426,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.6"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0781cf46869b37e36928f7b432273c0995aa8aed9552c556fb18754420541efc"
+checksum = "ba8de1f9dda5e589d08848af3ad4cd694bbfd059c3eb3c6d89c7120e8c0efa71"
 dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
@@ -6263,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccaacc76703fefd6763022ac565b590fcade92202492381c95b2edfdf7d46b3"
+checksum = "87e10c27e3290310d7e0d3221bc4e945d9b296b249577af2eb595726b546a3f8"
 dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
@@ -6276,9 +6451,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248a02e6f595aad796561fa82d25601bd2c8c3b145b1c7453fc8f94c1a58f8b2"
+checksum = "9f3334ee752fbe3c228adfda339a9e7a03e0ba65a78806d8d464b69928cf4ef2"
 dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
@@ -6332,27 +6507,26 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
+checksum = "d5df295f8451142f1856b1bd86a606dfe9587d439bc036e319c827700dbd555e"
 dependencies = [
- "block2",
- "core-foundation 0.9.4",
+ "core-foundation 0.10.0",
  "home",
  "jni",
  "log",
  "ndk-context",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.1",
+ "objc2-foundation 0.3.1",
  "url",
  "web-sys",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6399,7 +6573,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.2.5",
+ "indexmap 2.9.0",
  "log",
  "naga",
  "once_cell",
@@ -6471,9 +6645,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.15"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89beec544f246e679fc25490e3f8e08003bc4bf612068f325120dad4cea02c1c"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -6497,11 +6671,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6522,6 +6696,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -6531,12 +6715,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-result 0.1.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -6546,11 +6764,45 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6561,7 +6813,29 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6572,14 +6846,41 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6594,6 +6895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6601,6 +6911,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6819,9 +7138,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.5"
+version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
+checksum = "a809eacf18c8eca8b6635091543f02a5a06ddf3dad846398795460e6e0ae3cc0"
 dependencies = [
  "ahash",
  "android-activity",
@@ -6848,7 +7167,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "raw-window-handle 0.6.2",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "rustix",
  "sctk-adwaita",
  "smithay-client-toolkit",
@@ -6871,18 +7190,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -6897,6 +7207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6909,9 +7231,9 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
@@ -6924,9 +7246,9 @@ dependencies = [
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xcursor"
@@ -6955,9 +7277,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.19"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmltree"
@@ -7008,6 +7330,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
 
 [[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "synstructure",
+]
+
+[[package]]
 name = "zeno"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7015,49 +7361,92 @@ checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive 0.7.32",
+ "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,25 +20,9 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf780eb737f2d4a49ffbd512324d53ad089070f813f7be7f99dbd5123a7f448"
-
-[[package]]
-name = "accesskit"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
-
-[[package]]
-name = "accesskit_consumer"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdfa1638ddd6eb9c752def95568df8b3ad832df252e9156d2eb783b201ca8a9"
-dependencies = [
- "accesskit 0.14.0",
- "immutable-chunkmap",
-]
 
 [[package]]
 name = "accesskit_consumer"
@@ -46,23 +30,9 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
 dependencies = [
- "accesskit 0.17.1",
+ "accesskit",
  "hashbrown 0.15.2",
  "immutable-chunkmap",
-]
-
-[[package]]
-name = "accesskit_macos"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c236a84ff1111defc280cee755eaa953d0b24398786851b9d28322c6d3bb1ebd"
-dependencies = [
- "accesskit 0.14.0",
- "accesskit_consumer 0.22.0",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
- "once_cell",
 ]
 
 [[package]]
@@ -71,8 +41,8 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
 dependencies = [
- "accesskit 0.17.1",
- "accesskit_consumer 0.26.0",
+ "accesskit",
+ "accesskit_consumer",
  "hashbrown 0.15.2",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
@@ -81,25 +51,12 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7f43d24b16b3e76bef248124fbfd2493c3a9860edb5aae1010c890e826de5e"
-dependencies = [
- "accesskit 0.14.0",
- "accesskit_consumer 0.22.0",
- "paste",
- "static_assertions",
- "windows 0.54.0",
-]
-
-[[package]]
-name = "accesskit_windows"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
 dependencies = [
- "accesskit 0.17.1",
- "accesskit_consumer 0.26.0",
+ "accesskit",
+ "accesskit_consumer",
  "hashbrown 0.15.2",
  "paste",
  "static_assertions",
@@ -109,26 +66,13 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755535e6bf711a42dac28b888b884b10fc00ff4010d9d3bd871c5f5beae5aa78"
-dependencies = [
- "accesskit 0.14.0",
- "accesskit_macos 0.15.0",
- "accesskit_windows 0.20.0",
- "raw-window-handle 0.6.2",
- "winit",
-]
-
-[[package]]
-name = "accesskit_winit"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
 dependencies = [
- "accesskit 0.17.1",
- "accesskit_macos 0.18.1",
- "accesskit_windows 0.24.1",
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_windows",
  "raw-window-handle 0.6.2",
  "winit",
 ]
@@ -366,20 +310,11 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
-dependencies = [
- "libloading 0.7.4",
-]
-
-[[package]]
-name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.8.3",
+ "libloading",
 ]
 
 [[package]]
@@ -560,27 +495,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_a11y"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a976cb539d6a5a3ff579cdb78187a6bcfbffa7e8224ea28f23d8b983d9389"
-dependencies = [
- "accesskit 0.14.0",
- "bevy_app 0.14.2",
- "bevy_derive 0.14.2",
- "bevy_ecs 0.14.2",
-]
-
-[[package]]
-name = "bevy_a11y"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f96642402d2cd7c8e58c5994bbd14a2e44ca72dd7e460a2edad82aa3bf0348f9"
 dependencies = [
- "accesskit 0.17.1",
- "bevy_app 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_reflect 0.15.1",
+ "accesskit",
+ "bevy_app",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_reflect",
 ]
 
 [[package]]
@@ -589,20 +512,20 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03064ab96e15b2fda5bd58eac2055692d731c1fba3e211fd1ba48472cced75c3"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
- "bevy_log 0.15.1",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_time 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_log",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
  "blake3",
  "derive_more",
  "downcast-rs",
@@ -617,70 +540,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5361d0f8a8677a5d0102cfe7321a7ecd2a8b9a4f887ce0dde1059311cf9cd42"
-dependencies = [
- "bevy_derive 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_tasks 0.14.2",
- "bevy_utils 0.14.2",
- "console_error_panic_hook",
- "downcast-rs",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "bevy_app"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "454a8cfd134864dcdcba6ee56fb958531b981021bba6bb2037c9e3df6046603c"
 dependencies = [
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_tasks 0.15.3",
- "bevy_utils 0.15.3",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
  "console_error_panic_hook",
  "ctrlc",
  "derive_more",
  "downcast-rs",
  "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "bevy_asset"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60ec5ea257e1ebd3d411f669e29acf60beb715bebc7e1f374c17f49cd3aad46c"
-dependencies = [
- "async-broadcast",
- "async-fs",
- "async-lock",
- "bevy_app 0.14.2",
- "bevy_asset_macros 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_tasks 0.14.2",
- "bevy_utils 0.14.2",
- "bevy_winit 0.14.2",
- "blake3",
- "crossbeam-channel",
- "downcast-rs",
- "futures-io",
- "futures-lite 2.6.0",
- "js-sys",
- "parking_lot",
- "ron 0.8.1",
- "serde",
- "thiserror 1.0.69",
- "uuid",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -694,13 +567,13 @@ dependencies = [
  "async-fs",
  "async-lock",
  "atomicow",
- "bevy_app 0.15.1",
- "bevy_asset_macros 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_tasks 0.15.3",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_app",
+ "bevy_asset_macros",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "bevy_window",
  "bitflags 2.9.0",
  "blake3",
  "crossbeam-channel",
@@ -723,23 +596,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9eb05ce838d282f09d83380b4d6432aec7519d421dee8c75cc20e6148237e6e"
-dependencies = [
- "bevy_macro_utils 0.14.2",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "bevy_asset_macros"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6725a785789ece8d8c73bba25fdac5e50494d959530e89565bbcea9f808b7181"
 dependencies = [
- "bevy_macro_utils 0.15.3",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -751,32 +612,17 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d13715401172d7616b376362a46bba125ec9ccc73ab262153a43a2402537ca"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_transform",
+ "bevy_utils",
  "cpal",
  "rodio",
-]
-
-[[package]]
-name = "bevy_color"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04842e9d38a93f0c75ab46f7f404ea24ef57ad83dbd159e5b4b35318b02257bb"
-dependencies = [
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bytemuck",
- "encase 0.8.0",
- "serde",
- "thiserror 1.0.69",
- "wgpu-types 0.20.0",
 ]
 
 [[package]]
@@ -785,27 +631,13 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00aa2966c7ca0c7dd39f5ba8f3b1eaa5c2005a93ffdefb7a4090150d8327678"
 dependencies = [
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
+ "bevy_math",
+ "bevy_reflect",
  "bytemuck",
  "derive_more",
- "encase 0.10.0",
+ "encase",
  "serde",
- "wgpu-types 23.0.0",
-]
-
-[[package]]
-name = "bevy_core"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de706862871a1fe99ea619bff2f99d73e43ad82f19ef866a9e19a14c957c8537"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_tasks 0.14.2",
- "bevy_utils 0.14.2",
- "uuid",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -814,37 +646,12 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff28118f5ae3193f7f6cab30d4fd4246ba1802776910ab256dc7c20e8696381"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_tasks 0.15.3",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
  "uuid",
-]
-
-[[package]]
-name = "bevy_core_pipeline"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f6e1e122ada4cd811442e083fb5ad3e325c59a87271d5ef57193f1c2cad7f8c"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_asset 0.14.2",
- "bevy_color 0.14.3",
- "bevy_core 0.14.2",
- "bevy_derive 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_render 0.14.2",
- "bevy_transform 0.14.2",
- "bevy_utils 0.14.2",
- "bitflags 2.9.0",
- "nonmax",
- "radsort",
- "serde",
- "smallvec",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -853,19 +660,19 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0c0eea548a55fd04acf01d351bd16da4d1198037cb9c7b98dea6519f5d7dade"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core",
+ "bevy_derive",
+ "bevy_ecs",
  "bevy_image",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
  "bitflags 2.9.0",
  "derive_more",
  "nonmax",
@@ -876,39 +683,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbfc33a4c6b80760bb8bf850a2cc65a1e031da62fd3ca8b552189104dc98514"
-dependencies = [
- "bevy_macro_utils 0.14.2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "bevy_derive"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d94761ce947b0a2402fd949fe1e7a5b1535293130ba4cd9893be6295d4680a"
 dependencies = [
- "bevy_macro_utils 0.15.3",
+ "bevy_macro_utils",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "bevy_diagnostic"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebb154e0cc78e3bbfbfdb42fb502b14c1cd47e72f16e6d4228dfe6233ba6cbd"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_core 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_tasks 0.14.2",
- "bevy_time 0.14.2",
- "bevy_utils 0.14.2",
- "const-fnv1a-hash",
 ]
 
 [[package]]
@@ -917,34 +698,14 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21fe41b22fdf47bf11f0a3ca3e61975b003e86fa44d87e070f2dc7e752dd99f5"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_core 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_tasks 0.15.3",
- "bevy_time 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_core",
+ "bevy_ecs",
+ "bevy_tasks",
+ "bevy_time",
+ "bevy_utils",
  "const-fnv1a-hash",
  "sysinfo",
-]
-
-[[package]]
-name = "bevy_ecs"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee4222406637f3c8e3991a99788cfcde76097bf997c311f1b6297364057483f"
-dependencies = [
- "bevy_ecs_macros 0.14.2",
- "bevy_ptr 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_tasks 0.14.2",
- "bevy_utils 0.14.2",
- "bitflags 2.9.0",
- "concurrent-queue",
- "fixedbitset 0.5.7",
- "nonmax",
- "petgraph",
- "serde",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -954,11 +715,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b747210d7db09dfacc237707d4fd31c8b43d7744cd5e5829e2c4ca86b9e47baf"
 dependencies = [
  "arrayvec",
- "bevy_ecs_macros 0.15.3",
- "bevy_ptr 0.15.3",
- "bevy_reflect 0.15.1",
- "bevy_tasks 0.15.3",
- "bevy_utils 0.15.3",
+ "bevy_ecs_macros",
+ "bevy_ptr",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
  "bitflags 2.9.0",
  "concurrent-queue",
  "derive_more",
@@ -972,23 +733,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b573430b67aff7bde8292257494f39343401379bfbda64035ba4918bba7b20"
-dependencies = [
- "bevy_macro_utils 0.14.2",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "bevy_ecs_macros"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f453adf07712b39826bc5845e5b0887ce03204ee8359bbe6b40a9afda60564a1"
 dependencies = [
- "bevy_macro_utils 0.15.3",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1001,25 +750,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45fa3f22e775175244a36b50615c0c71df9e0847e297283e5ec62ec5f99439a0"
 dependencies = [
  "arboard",
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
  "bevy_image",
- "bevy_input 0.15.1",
- "bevy_log 0.15.1",
- "bevy_math 0.15.1",
+ "bevy_input",
+ "bevy_log",
+ "bevy_math",
  "bevy_picking",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_time 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
- "bevy_winit 0.15.1",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_time",
+ "bevy_utils",
+ "bevy_window",
+ "bevy_winit",
  "bytemuck",
  "crossbeam-channel",
  "egui",
- "encase 0.10.0",
+ "encase",
  "image 0.25.6",
  "js-sys",
  "thread_local",
@@ -1027,18 +776,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webbrowser",
- "wgpu-types 23.0.0",
+ "wgpu-types",
  "winit",
-]
-
-[[package]]
-name = "bevy_encase_derive"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06c9693847a2a6ea61d6b86288dd4d8b6a79f05d4bf6e27b96d4f5c8d552fe4"
-dependencies = [
- "bevy_macro_utils 0.14.2",
- "encase_derive_impl 0.8.0",
 ]
 
 [[package]]
@@ -1047,8 +786,8 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37ad69d36bb9e8479a88d481ef9748f5d7ab676040531d751d3a44441dcede7"
 dependencies = [
- "bevy_macro_utils 0.15.3",
- "encase_derive_impl 0.10.0",
+ "bevy_macro_utils",
+ "encase_derive_impl",
 ]
 
 [[package]]
@@ -1057,34 +796,13 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20320bd21f379ba4ec885b8217cb7c2c57eb0be014ba29509959e252480c3e9"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_input 0.15.1",
- "bevy_time 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_time",
+ "bevy_utils",
  "derive_more",
  "gilrs",
-]
-
-[[package]]
-name = "bevy_gizmos"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe32af0666d8d8a7fd6eb6b5e41eceefdc6f2e5441c74b812e8f0902a9d7f52"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_asset 0.14.2",
- "bevy_color 0.14.3",
- "bevy_core_pipeline 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_gizmos_macros 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_render 0.14.2",
- "bevy_time 0.14.2",
- "bevy_transform 0.14.2",
- "bevy_utils 0.14.2",
- "bytemuck",
 ]
 
 [[package]]
@@ -1093,34 +811,22 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca821905afffe1f3aaf33b496903a24a0c980e4c83fa7523fb41eac16892a57a"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core_pipeline 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_gizmos_macros 0.15.3",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_ecs",
+ "bevy_gizmos_macros",
  "bevy_image",
- "bevy_math 0.15.1",
+ "bevy_math",
  "bevy_pbr",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_sprite 0.15.1",
- "bevy_time 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_sprite",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
  "bytemuck",
-]
-
-[[package]]
-name = "bevy_gizmos_macros"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906b052f8cf3f3983f0f6df625fb10cbd9b27d44e362a327dc1ed51300d362bc"
-dependencies = [
- "bevy_macro_utils 0.14.2",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -1129,7 +835,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0edb9e0dca64e0fc9d6b1d9e6e2178396e339e3e2b9f751e2504e3ea4ddf4508"
 dependencies = [
- "bevy_macro_utils 0.15.3",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1143,22 +849,22 @@ checksum = "c38b79c0e43c6387699d6a332d12f98ed895bcf69dd70c462d5e49ad76d44d1f"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core 0.15.1",
- "bevy_core_pipeline 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core",
+ "bevy_core_pipeline",
+ "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_image",
- "bevy_math 0.15.1",
+ "bevy_math",
  "bevy_pbr",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
+ "bevy_reflect",
+ "bevy_render",
  "bevy_scene",
- "bevy_tasks 0.15.3",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_tasks",
+ "bevy_transform",
+ "bevy_utils",
  "derive_more",
  "gltf",
  "percent-encoding",
@@ -1172,12 +878,12 @@ name = "bevy_gltf_export"
 version = "0.1.0"
 source = "git+https://github.com/xiyuoh/bevy_gltf_export?branch=xiyu%2Fbevy_0.15#1a72af7b946c00315b344c09a153290b65287009"
 dependencies = [
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
+ "bevy_asset",
+ "bevy_color",
  "bevy_image",
  "bevy_pbr",
- "bevy_render 0.15.1",
- "bevy_transform 0.15.1",
+ "bevy_render",
+ "bevy_transform",
  "gltf",
  "gltf-json",
  "image 0.24.9",
@@ -1188,29 +894,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b912b37e1bc4dbb2aa40723199f74c8b06c4fbb6da0bb4585131df28ef66e"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_core 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_utils 0.14.2",
- "smallvec",
-]
-
-[[package]]
-name = "bevy_hierarchy"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd9aab2cd1684d30f2eedf953b6377a6416fd6b482f8145b6c05f4684bd60c3e"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_core 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_core",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_utils",
  "disqualified",
  "smallvec",
 ]
@@ -1221,11 +913,11 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c5942a7d681b81aa9723bb1d918135c2f88e7871331f5676119c86c01984759"
 dependencies = [
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_utils",
  "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
@@ -1234,7 +926,7 @@ dependencies = [
  "ktx2",
  "ruzstd",
  "serde",
- "wgpu 23.0.1",
+ "wgpu",
 ]
 
 [[package]]
@@ -1245,15 +937,15 @@ dependencies = [
  "anyhow",
  "async-task",
  "backtrace",
- "bevy_app 0.15.1",
- "bevy_core 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
+ "bevy_app",
+ "bevy_core",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_impulse_derive",
- "bevy_tasks 0.15.3",
- "bevy_time 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_tasks",
+ "bevy_time",
+ "bevy_utils",
  "futures",
  "itertools 0.13.0",
  "smallvec",
@@ -1275,31 +967,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd3a54e67cc3ba17971de7b1a7e64eda84493c1e7bb6bfa11c6cf8ac124377b"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_utils 0.14.2",
- "smol_str",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "bevy_input"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9bbf39c1d2d33350e03354a67bebee5c21973c5203b1456a9a4b90a5e6f8e75"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_core 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_core",
+ "bevy_ecs",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_utils",
  "derive_more",
  "smol_str",
 ]
@@ -1310,56 +987,41 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd7fc4db9a1793ee71f79abb15e7a8fcfe4e2081e5f18ed91b802bf6cf30e088"
 dependencies = [
- "bevy_a11y 0.15.1",
+ "bevy_a11y",
  "bevy_animation",
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
+ "bevy_app",
+ "bevy_asset",
  "bevy_audio",
- "bevy_color 0.15.2",
- "bevy_core 0.15.1",
- "bevy_core_pipeline 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_diagnostic 0.15.1",
- "bevy_ecs 0.15.1",
+ "bevy_color",
+ "bevy_core",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_ecs",
  "bevy_gilrs",
- "bevy_gizmos 0.15.1",
+ "bevy_gizmos",
  "bevy_gltf",
- "bevy_hierarchy 0.15.1",
+ "bevy_hierarchy",
  "bevy_image",
- "bevy_input 0.15.1",
- "bevy_log 0.15.1",
- "bevy_math 0.15.1",
+ "bevy_input",
+ "bevy_log",
+ "bevy_math",
  "bevy_pbr",
  "bevy_picking",
- "bevy_ptr 0.15.3",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
+ "bevy_ptr",
+ "bevy_reflect",
+ "bevy_render",
  "bevy_scene",
- "bevy_sprite 0.15.1",
+ "bevy_sprite",
  "bevy_state",
- "bevy_tasks 0.15.3",
+ "bevy_tasks",
  "bevy_text",
- "bevy_time 0.15.1",
- "bevy_transform 0.15.1",
+ "bevy_time",
+ "bevy_transform",
  "bevy_ui",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
- "bevy_winit 0.15.1",
-]
-
-[[package]]
-name = "bevy_log"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67240c7596c8f0653e50fce35a60196516817449235193246599facba9002e02"
-dependencies = [
- "android_log-sys",
- "bevy_app 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_utils 0.14.2",
- "tracing-log",
- "tracing-subscriber",
- "tracing-wasm",
+ "bevy_utils",
+ "bevy_window",
+ "bevy_winit",
 ]
 
 [[package]]
@@ -1369,25 +1031,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774238dcf70a0ef4d82aa2860b24b1cffdd4633f3694d3bcbfbb05c4f17ae4fe"
 dependencies = [
  "android_log-sys",
- "bevy_app 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_utils",
  "tracing-log",
  "tracing-oslog",
  "tracing-subscriber",
  "tracing-wasm",
-]
-
-[[package]]
-name = "bevy_macro_utils"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc65e570012e64a21f3546df68591aaede8349e6174fb500071677f54f06630"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -1404,27 +1054,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5421792749dda753ab3718e77d27bfce38443daf1850b836b97530b6245a4581"
-dependencies = [
- "bevy_reflect 0.14.2",
- "glam 0.27.0",
- "rand",
- "serde",
- "smallvec",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "bevy_math"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edec18d90e6bab27b5c6131ee03172ece75b7edd0abe4e482a26d6db906ec357"
 dependencies = [
- "bevy_reflect 0.15.1",
+ "bevy_reflect",
  "derive_more",
- "glam 0.29.3",
+ "glam",
  "itertools 0.13.0",
  "rand",
  "rand_distr",
@@ -1438,30 +1074,21 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183abae7c6695a80d7408c860bd737410cd66d2a9f910dafc914485da06e43dc"
 dependencies = [
- "bevy_asset 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
  "bevy_image",
- "bevy_math 0.15.1",
- "bevy_mikktspace 0.15.3",
- "bevy_reflect 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_math",
+ "bevy_mikktspace",
+ "bevy_reflect",
+ "bevy_transform",
+ "bevy_utils",
  "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
- "hexasphere 15.1.0",
+ "hexasphere",
  "serde",
- "wgpu 23.0.1",
-]
-
-[[package]]
-name = "bevy_mikktspace"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66cf695a264b043f2c4edb92dd5c742e6892180d2b30dac870012d153f8557ea"
-dependencies = [
- "glam 0.27.0",
+ "wgpu",
 ]
 
 [[package]]
@@ -1470,7 +1097,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "226f663401069ded4352ed1472a85bb1f43e2b7305d6a50e53a4f6508168e380"
 dependencies = [
- "glam 0.29.3",
+ "glam",
 ]
 
 [[package]]
@@ -1485,29 +1112,7 @@ dependencies = [
  "interpolation",
  "nonmax",
  "thiserror 1.0.69",
- "wgpu-types 23.0.0",
-]
-
-[[package]]
-name = "bevy_mod_raycast"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e4ff45885c4716771a9f55977d8ce69596502a5241da55bf608d7cd71a9cb3"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_asset 0.14.2",
- "bevy_color 0.14.3",
- "bevy_derive 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_gizmos 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_render 0.14.2",
- "bevy_sprite 0.14.2",
- "bevy_transform 0.14.2",
- "bevy_utils 0.14.2",
- "bevy_window 0.14.2",
- "crossbeam-channel",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -1528,19 +1133,19 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f17067399cf00f4441e93d39fb4c391a16cc223e0d35346ac388e66712c418"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core_pipeline 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
  "bevy_image",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
  "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
@@ -1557,20 +1162,20 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "125e0c7327ec155c566c044c6eefd1a02e904134fa5dc0ba54665e06a35297b0"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
- "bevy_input 0.15.1",
- "bevy_math 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_input",
+ "bevy_math",
  "bevy_mesh",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_time 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
  "crossbeam-channel",
  "uuid",
 ]
@@ -1588,34 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61baa1bdc1f4a7ac2c18217570a7cc04e1cd54d38456e91782f0371c79afe0a8"
-
-[[package]]
-name = "bevy_ptr"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89fe0b0b919146939481a3a7c38864face2c6d0fd2c73ab3d430dc693ecd9b11"
-
-[[package]]
-name = "bevy_reflect"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2508785a4a5809f25a237eec4fee2c91a4dbcf81324b2bbc2d6c52629e603781"
-dependencies = [
- "bevy_ptr 0.14.2",
- "bevy_reflect_derive 0.14.2",
- "bevy_utils 0.14.2",
- "downcast-rs",
- "erased-serde",
- "glam 0.27.0",
- "serde",
- "smallvec",
- "smol_str",
- "thiserror 1.0.69",
- "uuid",
-]
 
 [[package]]
 name = "bevy_reflect"
@@ -1624,14 +1204,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab3264acc3b6f48bc23fbd09fdfea6e5d9b7bfec142e4f3333f532acf195bca"
 dependencies = [
  "assert_type_match",
- "bevy_ptr 0.15.3",
- "bevy_reflect_derive 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_ptr",
+ "bevy_reflect_derive",
+ "bevy_utils",
  "derive_more",
  "disqualified",
  "downcast-rs",
  "erased-serde",
- "glam 0.29.3",
+ "glam",
  "petgraph",
  "serde",
  "smallvec",
@@ -1641,74 +1221,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967d5da1882ec3bb3675353915d3da909cafac033cbf31e58727824a1ad2a288"
-dependencies = [
- "bevy_macro_utils 0.14.2",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "uuid",
-]
-
-[[package]]
-name = "bevy_reflect_derive"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f83876a322130ab38a47d5dcf75258944bf76b3387d1acdb3750920fda63e2"
 dependencies = [
- "bevy_macro_utils 0.15.3",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
  "uuid",
-]
-
-[[package]]
-name = "bevy_render"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836cf8a513db013cbe7d55a331060088efd407e49fd5b05c8404700cd82e7619"
-dependencies = [
- "async-channel",
- "bevy_app 0.14.2",
- "bevy_asset 0.14.2",
- "bevy_color 0.14.3",
- "bevy_core 0.14.2",
- "bevy_derive 0.14.2",
- "bevy_diagnostic 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_encase_derive 0.14.2",
- "bevy_hierarchy 0.14.2",
- "bevy_math 0.14.2",
- "bevy_mikktspace 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_render_macros 0.14.2",
- "bevy_tasks 0.14.2",
- "bevy_time 0.14.2",
- "bevy_transform 0.14.2",
- "bevy_utils 0.14.2",
- "bevy_window 0.14.2",
- "bitflags 2.9.0",
- "bytemuck",
- "codespan-reporting",
- "downcast-rs",
- "encase 0.8.0",
- "futures-lite 2.6.0",
- "hexasphere 12.0.0",
- "image 0.25.6",
- "js-sys",
- "naga 0.20.0",
- "naga_oil 0.14.0",
- "nonmax",
- "send_wrapper",
- "serde",
- "smallvec",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
- "wgpu 0.20.1",
 ]
 
 [[package]]
@@ -1718,36 +1239,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b14d77d8ff589743237c98502c0e47fd31059cf348ab86a265c4f90bb5e2a22"
 dependencies = [
  "async-channel",
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_diagnostic 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_encase_derive 0.15.3",
- "bevy_hierarchy 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_ecs",
+ "bevy_encase_derive",
+ "bevy_hierarchy",
  "bevy_image",
- "bevy_math 0.15.1",
+ "bevy_math",
  "bevy_mesh",
- "bevy_reflect 0.15.1",
- "bevy_render_macros 0.15.3",
- "bevy_tasks 0.15.3",
- "bevy_time 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_reflect",
+ "bevy_render_macros",
+ "bevy_tasks",
+ "bevy_time",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
  "bytemuck",
  "codespan-reporting",
  "derive_more",
  "downcast-rs",
- "encase 0.10.0",
+ "encase",
  "futures-lite 2.6.0",
  "image 0.25.6",
  "js-sys",
  "ktx2",
- "naga 23.1.0",
- "naga_oil 0.16.0",
+ "naga",
+ "naga_oil",
  "nonmax",
  "offset-allocator",
  "send_wrapper",
@@ -1755,19 +1276,7 @@ dependencies = [
  "smallvec",
  "wasm-bindgen",
  "web-sys",
- "wgpu 23.0.1",
-]
-
-[[package]]
-name = "bevy_render_macros"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc24e0e95061a38a7744218b9c7e52e4c08b53f1499f33480e2b749f3864432"
-dependencies = [
- "bevy_macro_utils 0.14.2",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "wgpu",
 ]
 
 [[package]]
@@ -1776,7 +1285,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3469307d1b5ca5c37b7f9269be033845357412ebad33eace46826e59da592f66"
 dependencies = [
- "bevy_macro_utils 0.15.3",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1788,44 +1297,18 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd00a08d01a190a826a5f6ad0fcb3dbf7bd1bd4f64ebe6108c38384691a21111"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_transform",
+ "bevy_utils",
  "derive_more",
  "serde",
  "uuid",
-]
-
-[[package]]
-name = "bevy_sprite"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e045b4d8cc8e7422a4c29b1eadbe224f5cc42f170b88d43e7535892fcede3840"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_asset 0.14.2",
- "bevy_color 0.14.3",
- "bevy_core_pipeline 0.14.2",
- "bevy_derive 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_render 0.14.2",
- "bevy_transform 0.14.2",
- "bevy_utils 0.14.2",
- "bitflags 2.9.0",
- "bytemuck",
- "fixedbitset 0.5.7",
- "guillotiere",
- "radsort",
- "rectangle-pack",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1834,20 +1317,20 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c7d22da88e562fb2ae8fe7f8cc749d3024caa4dcb57a777d070ef9141577aa"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core_pipeline 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
  "bevy_image",
- "bevy_math 0.15.1",
+ "bevy_math",
  "bevy_picking",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
  "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
@@ -1864,12 +1347,12 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd10c8b01a982642596406fc4486fcd52239aa9c4aa47fed27abab93a69fba59"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
- "bevy_reflect 0.15.1",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_reflect",
  "bevy_state_macros",
- "bevy_utils 0.15.3",
+ "bevy_utils",
 ]
 
 [[package]]
@@ -1878,7 +1361,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022eb069dfd64090fd92ba4a7f235383e49aa1c0f4320dab4999b23f67843b36"
 dependencies = [
- "bevy_macro_utils 0.15.3",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1893,17 +1376,6 @@ dependencies = [
  "bevy",
  "stl_io",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "bevy_tasks"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77865f310b1fc48fb05b7c4adbe76607ec01d0c14f8ab4caba4d714c86439946"
-dependencies = [
- "async-executor",
- "futures-lite 2.6.0",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1927,20 +1399,20 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ee0b5f52946d222521f93773a6230f42e868548f881c4c5bddb1393a96298b"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_image",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_sprite 0.15.1",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_sprite",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
  "cosmic-text",
  "derive_more",
  "serde",
@@ -1951,43 +1423,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e4d53ec32a1b16492396951d04de0d2d90e924bf9adcb8d1adacab5ab6c17c"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_utils 0.14.2",
- "crossbeam-channel",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "bevy_time"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3108ed1ef864bc40bc859ba4c9c3844213c7be3674f982203cf5d87c656848"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_utils",
  "crossbeam-channel",
-]
-
-[[package]]
-name = "bevy_transform"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5493dce84427d00a9266e8e4386d738a72ee8640423b62dfcecb6dfccbfe0d2"
-dependencies = [
- "bevy_app 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_hierarchy 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1996,11 +1440,11 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "056fabcedbf0503417af69447d47a983e18c7cfb5e6b6728636be3ec285cbcfa"
 dependencies = [
- "bevy_app 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_math",
+ "bevy_reflect",
  "derive_more",
 ]
 
@@ -2010,26 +1454,26 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4556fc2202c6339f95e0c24ca4c96ee959854b702e23ecf73e05fb20e67d67b0"
 dependencies = [
- "accesskit 0.17.1",
- "bevy_a11y 0.15.1",
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_color 0.15.2",
- "bevy_core_pipeline 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
+ "accesskit",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_color",
+ "bevy_core_pipeline",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_image",
- "bevy_input 0.15.1",
- "bevy_math 0.15.1",
+ "bevy_input",
+ "bevy_math",
  "bevy_picking",
- "bevy_reflect 0.15.1",
- "bevy_render 0.15.1",
- "bevy_sprite 0.15.1",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_sprite",
  "bevy_text",
- "bevy_transform 0.15.1",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_transform",
+ "bevy_utils",
+ "bevy_window",
  "bytemuck",
  "derive_more",
  "nonmax",
@@ -2039,43 +1483,17 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb0ec333b5965771153bd746f92ffd8aeeb9d008a8620ffd9ed474859381a5e"
-dependencies = [
- "ahash",
- "bevy_utils_proc_macros 0.14.2",
- "getrandom 0.2.12",
- "hashbrown 0.14.3",
- "thread_local",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "bevy_utils"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c2174d43a0de99f863c98a472370047a2bfa7d1e5cec8d9d647fb500905d9d"
 dependencies = [
  "ahash",
- "bevy_utils_proc_macros 0.15.3",
+ "bevy_utils_proc_macros",
  "getrandom 0.2.12",
  "hashbrown 0.14.3",
  "thread_local",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "bevy_utils_proc_macros"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f1ab8f2f6f58439d260081d89a42b02690e5fdd64f814edc9417d33fcf2857"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -2091,64 +1509,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e88a20db64ea8204540afb4699295947c454738fd50293f7b32ab8be857a6"
-dependencies = [
- "bevy_a11y 0.14.2",
- "bevy_app 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_utils 0.14.2",
- "raw-window-handle 0.6.2",
- "smol_str",
-]
-
-[[package]]
-name = "bevy_window"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36139955777cc9e7a40a97833ff3a95b7401ce525a3dbac05fc52557968b31a7"
 dependencies = [
  "android-activity",
- "bevy_a11y 0.15.1",
- "bevy_app 0.15.1",
- "bevy_ecs 0.15.1",
- "bevy_input 0.15.1",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_utils 0.15.3",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_utils",
  "raw-window-handle 0.6.2",
  "smol_str",
-]
-
-[[package]]
-name = "bevy_winit"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bef8ec3e4b45db943ad4d1c0bf59b09e382ce0651a706e2f33a70fa955303c"
-dependencies = [
- "accesskit_winit 0.20.4",
- "approx",
- "bevy_a11y 0.14.2",
- "bevy_app 0.14.2",
- "bevy_derive 0.14.2",
- "bevy_ecs 0.14.2",
- "bevy_hierarchy 0.14.2",
- "bevy_input 0.14.2",
- "bevy_log 0.14.2",
- "bevy_math 0.14.2",
- "bevy_reflect 0.14.2",
- "bevy_tasks 0.14.2",
- "bevy_utils 0.14.2",
- "bevy_window 0.14.2",
- "cfg-if",
- "crossbeam-channel",
- "raw-window-handle 0.6.2",
- "wasm-bindgen",
- "web-sys",
- "winit",
 ]
 
 [[package]]
@@ -2157,30 +1531,30 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36e84e7f94583cac93de4ba641029eb0b6551d35e559c829209f2b1b9fe532d8"
 dependencies = [
- "accesskit 0.17.1",
- "accesskit_winit 0.23.1",
+ "accesskit",
+ "accesskit_winit",
  "approx",
- "bevy_a11y 0.15.1",
- "bevy_app 0.15.1",
- "bevy_asset 0.15.1",
- "bevy_derive 0.15.3",
- "bevy_ecs 0.15.1",
- "bevy_hierarchy 0.15.1",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_image",
- "bevy_input 0.15.1",
- "bevy_log 0.15.1",
- "bevy_math 0.15.1",
- "bevy_reflect 0.15.1",
- "bevy_tasks 0.15.3",
- "bevy_utils 0.15.3",
- "bevy_window 0.15.1",
+ "bevy_input",
+ "bevy_log",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "bevy_window",
  "bytemuck",
  "cfg-if",
  "crossbeam-channel",
  "raw-window-handle 0.6.2",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types 23.0.0",
+ "wgpu-types",
  "winit",
 ]
 
@@ -2478,7 +1852,7 @@ checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.3",
+ "libloading",
 ]
 
 [[package]]
@@ -2551,37 +1925,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "combine"
@@ -2862,17 +2205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
-name = "d3d12"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
-dependencies = [
- "bitflags 2.9.0",
- "libloading 0.8.3",
- "winapi",
-]
-
-[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,7 +2286,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.3",
+ "libloading",
 ]
 
 [[package]]
@@ -3044,35 +2376,14 @@ dependencies = [
 
 [[package]]
 name = "encase"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9299a95fa5671ddf29ecc22b00e121843a65cb9ff24911e394b4ae556baf36"
-dependencies = [
- "const_panic",
- "encase_derive 0.8.0",
- "glam 0.27.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "encase"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a05902cf601ed11d564128448097b98ebe3c6574bd7b6a653a3d56d54aa020"
 dependencies = [
  "const_panic",
- "encase_derive 0.10.0",
- "glam 0.29.3",
+ "encase_derive",
+ "glam",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "encase_derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e09decb3beb1fe2db6940f598957b2e1f7df6206a804d438ff6cb2a9cddc10"
-dependencies = [
- "encase_derive_impl 0.8.0",
 ]
 
 [[package]]
@@ -3081,18 +2392,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "181d475b694e2dd56ae919ce7699d344d1fd259292d590c723a50d1189a2ea85"
 dependencies = [
- "encase_derive_impl 0.10.0",
-]
-
-[[package]]
-name = "encase_derive_impl"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd31dbbd9743684d339f907a87fe212cb7b51d75b9e8e74181fe363199ee9b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "encase_derive_impl",
 ]
 
 [[package]]
@@ -3686,17 +2986,6 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
-dependencies = [
- "bytemuck",
- "rand",
- "serde",
-]
-
-[[package]]
-name = "glam"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
@@ -3721,18 +3010,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "glow"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "glow"
@@ -3784,15 +3061,6 @@ dependencies = [
 
 [[package]]
 name = "glutin_wgl_sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
-dependencies = [
- "gl_generator",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
@@ -3828,19 +3096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
  "bitflags 2.9.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "winapi",
- "windows 0.52.0",
 ]
 
 [[package]]
@@ -3969,21 +3224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hassle-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
-dependencies = [
- "bitflags 2.9.0",
- "com",
- "libc",
- "libloading 0.8.3",
- "thiserror 1.0.69",
- "widestring",
- "winapi",
-]
-
-[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,22 +3259,12 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hexasphere"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd6b038160f086b0a7496edae34169ae22f328793cbe2b627a5a3d8373748ec"
-dependencies = [
- "constgebra",
- "glam 0.27.0",
-]
-
-[[package]]
-name = "hexasphere"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c9e718d32b6e6b2b32354e1b0367025efdd0b11d6a740b905ddf5db1074679"
 dependencies = [
  "constgebra",
- "glam 0.29.3",
+ "glam",
  "tinyvec",
 ]
 
@@ -4301,7 +3531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.8.3",
+ "libloading",
  "pkg-config",
 ]
 
@@ -4363,16 +3593,6 @@ checksum = "cf78f52d400cf2d84a3a973a78a592b4adc535739e0a5597a0da6f0c357adc75"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
 ]
 
 [[package]]
@@ -4530,21 +3750,6 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
-dependencies = [
- "bitflags 2.9.0",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
@@ -4576,28 +3781,6 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
-dependencies = [
- "arrayvec",
- "bit-set 0.5.3",
- "bitflags 2.9.0",
- "codespan-reporting",
- "hexf-parse",
- "indexmap 2.2.5",
- "log",
- "num-traits",
- "pp-rs",
- "rustc-hash",
- "spirv",
- "termcolor",
- "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
-name = "naga"
 version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
@@ -4620,26 +3803,6 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275d9720a7338eedac966141089232514c84d76a246a58ef501af88c5edf402f"
-dependencies = [
- "bit-set 0.5.3",
- "codespan-reporting",
- "data-encoding",
- "indexmap 2.2.5",
- "naga 0.20.0",
- "once_cell",
- "regex",
- "regex-syntax 0.8.2",
- "rustc-hash",
- "thiserror 1.0.69",
- "tracing",
- "unicode-ident",
-]
-
-[[package]]
-name = "naga_oil"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31ea1f080bb359927cd5404d0af1e5e6758f4f2d82ecfbebb0a0c434764e40f1"
@@ -4648,7 +3811,7 @@ dependencies = [
  "codespan-reporting",
  "data-encoding",
  "indexmap 2.2.5",
- "naga 23.1.0",
+ "naga",
  "once_cell",
  "regex",
  "regex-syntax 0.8.2",
@@ -5830,7 +4993,6 @@ dependencies = [
  "bevy_gltf_export",
  "bevy_impulse",
  "bevy_mod_outline",
- "bevy_mod_raycast",
  "bevy_obj",
  "bevy_polyline",
  "bevy_stl",
@@ -5877,7 +5039,7 @@ version = "0.0.1"
 dependencies = [
  "bevy",
  "float_eq",
- "glam 0.29.3",
+ "glam",
  "once_cell",
  "pathdiff",
  "ron 0.9.0-alpha.0",
@@ -7203,32 +6365,6 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
-dependencies = [
- "arrayvec",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "document-features",
- "js-sys",
- "log",
- "naga 0.20.0",
- "parking_lot",
- "profiling",
- "raw-window-handle 0.6.2",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core 0.21.1",
- "wgpu-hal 0.21.1",
- "wgpu-types 0.20.0",
-]
-
-[[package]]
-name = "wgpu"
 version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
@@ -7238,7 +6374,7 @@ dependencies = [
  "document-features",
  "js-sys",
  "log",
- "naga 23.1.0",
+ "naga",
  "parking_lot",
  "profiling",
  "raw-window-handle 0.6.2",
@@ -7247,36 +6383,9 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 23.0.1",
- "wgpu-hal 23.0.1",
- "wgpu-types 23.0.0",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
-dependencies = [
- "arrayvec",
- "bit-vec 0.6.3",
- "bitflags 2.9.0",
- "cfg_aliases 0.1.1",
- "codespan-reporting",
- "document-features",
- "indexmap 2.2.5",
- "log",
- "naga 0.20.0",
- "once_cell",
- "parking_lot",
- "profiling",
- "raw-window-handle 0.6.2",
- "rustc-hash",
- "smallvec",
- "thiserror 1.0.69",
- "web-sys",
- "wgpu-hal 0.21.1",
- "wgpu-types 0.20.0",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -7292,7 +6401,7 @@ dependencies = [
  "document-features",
  "indexmap 2.2.5",
  "log",
- "naga 23.1.0",
+ "naga",
  "once_cell",
  "parking_lot",
  "profiling",
@@ -7300,53 +6409,8 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "thiserror 1.0.69",
- "wgpu-hal 23.0.1",
- "wgpu-types 23.0.0",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash 0.37.3+1.3.251",
- "bit-set 0.5.3",
- "bitflags 2.9.0",
- "block",
- "cfg_aliases 0.1.1",
- "core-graphics-types",
- "d3d12",
- "glow 0.13.1",
- "glutin_wgl_sys 0.5.0",
- "gpu-alloc",
- "gpu-allocator 0.25.0",
- "gpu-descriptor",
- "hassle-rs",
- "js-sys",
- "khronos-egl",
- "libc",
- "libloading 0.8.3",
- "log",
- "metal 0.28.0",
- "naga 0.20.0",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc",
- "once_cell",
- "parking_lot",
- "profiling",
- "range-alloc",
- "raw-window-handle 0.6.2",
- "renderdoc-sys",
- "rustc-hash",
- "smallvec",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types 0.20.0",
- "winapi",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -7357,25 +6421,25 @@ checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
 dependencies = [
  "android_system_properties",
  "arrayvec",
- "ash 0.38.0+1.3.281",
+ "ash",
  "bit-set 0.8.0",
  "bitflags 2.9.0",
  "block",
  "bytemuck",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
- "glow 0.14.2",
- "glutin_wgl_sys 0.6.1",
+ "glow",
+ "glutin_wgl_sys",
  "gpu-alloc",
- "gpu-allocator 0.27.0",
+ "gpu-allocator",
  "gpu-descriptor",
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.3",
+ "libloading",
  "log",
- "metal 0.29.0",
- "naga 23.1.0",
+ "metal",
+ "naga",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
@@ -7389,20 +6453,9 @@ dependencies = [
  "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types 23.0.0",
+ "wgpu-types",
  "windows 0.58.0",
  "windows-core 0.58.0",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
-dependencies = [
- "bitflags 2.9.0",
- "js-sys",
- "web-sys",
 ]
 
 [[package]]
@@ -7425,12 +6478,6 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"
@@ -7465,23 +6512,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-implement 0.53.0",
- "windows-interface 0.53.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7492,15 +6527,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -7520,8 +6546,8 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.2.0",
  "windows-strings",
  "windows-targets 0.52.6",
@@ -7529,31 +6555,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7912,7 +6916,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading 0.8.3",
+ "libloading",
  "once_cell",
  "rustix",
  "x11rb-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cf780eb737f2d4a49ffbd512324d53ad089070f813f7be7f99dbd5123a7f448"
 
 [[package]]
+name = "accesskit"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+
+[[package]]
 name = "accesskit_consumer"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bdfa1638ddd6eb9c752def95568df8b3ad832df252e9156d2eb783b201ca8a9"
 dependencies = [
- "accesskit",
+ "accesskit 0.14.0",
+ "immutable-chunkmap",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+dependencies = [
+ "accesskit 0.17.1",
+ "hashbrown 0.15.2",
  "immutable-chunkmap",
 ]
 
@@ -40,12 +57,26 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c236a84ff1111defc280cee755eaa953d0b24398786851b9d28322c6d3bb1ebd"
 dependencies = [
- "accesskit",
- "accesskit_consumer",
+ "accesskit 0.14.0",
+ "accesskit_consumer 0.22.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "once_cell",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+dependencies = [
+ "accesskit 0.17.1",
+ "accesskit_consumer 0.26.0",
+ "hashbrown 0.15.2",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -54,11 +85,26 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7f43d24b16b3e76bef248124fbfd2493c3a9860edb5aae1010c890e826de5e"
 dependencies = [
- "accesskit",
- "accesskit_consumer",
+ "accesskit 0.14.0",
+ "accesskit_consumer 0.22.0",
  "paste",
  "static_assertions",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+dependencies = [
+ "accesskit 0.17.1",
+ "accesskit_consumer 0.26.0",
+ "hashbrown 0.15.2",
+ "paste",
+ "static_assertions",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -67,9 +113,22 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755535e6bf711a42dac28b888b884b10fc00ff4010d9d3bd871c5f5beae5aa78"
 dependencies = [
- "accesskit",
- "accesskit_macos",
- "accesskit_windows",
+ "accesskit 0.14.0",
+ "accesskit_macos 0.15.0",
+ "accesskit_windows 0.20.0",
+ "raw-window-handle 0.6.2",
+ "winit",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+dependencies = [
+ "accesskit 0.17.1",
+ "accesskit_macos 0.18.1",
+ "accesskit_windows 0.24.1",
  "raw-window-handle 0.6.2",
  "winit",
 ]
@@ -96,6 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.2.12",
  "once_cell",
  "version_check",
@@ -262,7 +322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1df21f715862ede32a0c525ce2ca4d52626bb0007f8c18b87a384503ac33e70"
 dependencies = [
  "clipboard-win",
- "image",
+ "image 0.25.6",
  "log",
  "objc2 0.6.1",
  "objc2-app-kit 0.3.1",
@@ -314,6 +374,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.3",
+]
+
+[[package]]
+name = "assert_type_match"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,13 +405,12 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
- "event-listener-strategy 0.5.0",
+ "event-listener-strategy 0.5.4",
  "futures-core",
  "pin-project-lite",
 ]
@@ -345,7 +424,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.2.0",
+ "futures-lite 2.6.0",
  "slab",
 ]
 
@@ -357,7 +436,7 @@ checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
  "async-lock",
  "blocking",
- "futures-lite 2.2.0",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -403,6 +482,16 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomicow"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52e8890bb9844440d0c412fa74b67fd2f14e85248b6e00708059b6da9e5f8bf"
+dependencies = [
+ "portable-atomic",
+ "portable-atomic-util",
+]
 
 [[package]]
 name = "autocfg"
@@ -462,9 +551,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043c9ad4b6fc4ca52d779873a8ca792a4e37842d07fce95363c9e17e36a1d8a0"
+checksum = "bb2a21c9f3306676077a88700bb8f354be779cf9caba9c21e94da9e696751af4"
 dependencies = [
  "bevy_internal",
 ]
@@ -475,38 +564,53 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a976cb539d6a5a3ff579cdb78187a6bcfbffa7e8224ea28f23d8b983d9389"
 dependencies = [
- "accesskit",
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
+ "accesskit 0.14.0",
+ "bevy_app 0.14.2",
+ "bevy_derive 0.14.2",
+ "bevy_ecs 0.14.2",
+]
+
+[[package]]
+name = "bevy_a11y"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f96642402d2cd7c8e58c5994bbd14a2e44ca72dd7e460a2edad82aa3bf0348f9"
+dependencies = [
+ "accesskit 0.17.1",
+ "bevy_app 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_reflect 0.15.1",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aef7d21a0342c24b05059493aa31d58f1798d34a2236569a8789b74df5a475"
+checksum = "03064ab96e15b2fda5bd58eac2055692d731c1fba3e211fd1ba48472cced75c3"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_log",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_log 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_time 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
  "blake3",
- "fixedbitset 0.5.7",
+ "derive_more",
+ "downcast-rs",
+ "either",
  "petgraph",
  "ron 0.8.1",
  "serde",
- "thiserror 1.0.69",
+ "smallvec",
  "thread_local",
  "uuid",
 ]
@@ -517,14 +621,33 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5361d0f8a8677a5d0102cfe7321a7ecd2a8b9a4f887ce0dde1059311cf9cd42"
 dependencies = [
- "bevy_derive",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_derive 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_tasks 0.14.2",
+ "bevy_utils 0.14.2",
  "console_error_panic_hook",
  "downcast-rs",
  "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "bevy_app"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "454a8cfd134864dcdcba6ee56fb958531b981021bba6bb2037c9e3df6046603c"
+dependencies = [
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_tasks 0.15.3",
+ "bevy_utils 0.15.3",
+ "console_error_panic_hook",
+ "ctrlc",
+ "derive_more",
+ "downcast-rs",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -538,18 +661,18 @@ dependencies = [
  "async-broadcast",
  "async-fs",
  "async-lock",
- "bevy_app",
- "bevy_asset_macros",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
- "bevy_winit",
+ "bevy_app 0.14.2",
+ "bevy_asset_macros 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_tasks 0.14.2",
+ "bevy_utils 0.14.2",
+ "bevy_winit 0.14.2",
  "blake3",
  "crossbeam-channel",
  "downcast-rs",
  "futures-io",
- "futures-lite 2.2.0",
+ "futures-lite 2.6.0",
  "js-sys",
  "parking_lot",
  "ron 0.8.1",
@@ -562,12 +685,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_asset"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d762dd4422fb6219fd904e514a4a5d1d451711a0a8e1d6495dea15a545f04f3"
+dependencies = [
+ "async-broadcast",
+ "async-fs",
+ "async-lock",
+ "atomicow",
+ "bevy_app 0.15.1",
+ "bevy_asset_macros 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_tasks 0.15.3",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "bitflags 2.9.0",
+ "blake3",
+ "crossbeam-channel",
+ "derive_more",
+ "disqualified",
+ "downcast-rs",
+ "either",
+ "futures-io",
+ "futures-lite 2.6.0",
+ "js-sys",
+ "parking_lot",
+ "ron 0.8.1",
+ "serde",
+ "stackfuture",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "bevy_asset_macros"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9eb05ce838d282f09d83380b4d6432aec7519d421dee8c75cc20e6148237e6e"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.14.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "bevy_asset_macros"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6725a785789ece8d8c73bba25fdac5e50494d959530e89565bbcea9f808b7181"
+dependencies = [
+ "bevy_macro_utils 0.15.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -575,19 +747,19 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee31312a0e67f288fe12a1d9aa679dd0ba8a49e1e6fe5fcd2ba1aa1ea34e5ed"
+checksum = "13d13715401172d7616b376362a46bba125ec9ccc73ab262153a43a2402537ca"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_math",
- "bevy_reflect",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
  "cpal",
  "rodio",
 ]
@@ -598,13 +770,28 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04842e9d38a93f0c75ab46f7f404ea24ef57ad83dbd159e5b4b35318b02257bb"
 dependencies = [
- "bevy_math",
- "bevy_reflect",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
  "bytemuck",
- "encase",
+ "encase 0.8.0",
  "serde",
  "thiserror 1.0.69",
- "wgpu-types",
+ "wgpu-types 0.20.0",
+]
+
+[[package]]
+name = "bevy_color"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00aa2966c7ca0c7dd39f5ba8f3b1eaa5c2005a93ffdefb7a4090150d8327678"
+dependencies = [
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bytemuck",
+ "derive_more",
+ "encase 0.10.0",
+ "serde",
+ "wgpu-types 23.0.0",
 ]
 
 [[package]]
@@ -613,11 +800,25 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de706862871a1fe99ea619bff2f99d73e43ad82f19ef866a9e19a14c957c8537"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_tasks 0.14.2",
+ "bevy_utils 0.14.2",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_core"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff28118f5ae3193f7f6cab30d4fd4246ba1802776910ab256dc7c20e8696381"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_tasks 0.15.3",
+ "bevy_utils 0.15.3",
  "uuid",
 ]
 
@@ -627,17 +828,17 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f6e1e122ada4cd811442e083fb5ad3e325c59a87271d5ef57193f1c2cad7f8c"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core",
- "bevy_derive",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_asset 0.14.2",
+ "bevy_color 0.14.3",
+ "bevy_core 0.14.2",
+ "bevy_derive 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_render 0.14.2",
+ "bevy_transform 0.14.2",
+ "bevy_utils 0.14.2",
  "bitflags 2.9.0",
  "nonmax",
  "radsort",
@@ -647,12 +848,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_core_pipeline"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0c0eea548a55fd04acf01d351bd16da4d1198037cb9c7b98dea6519f5d7dade"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_image",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "bitflags 2.9.0",
+ "derive_more",
+ "nonmax",
+ "radsort",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "bevy_derive"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbfc33a4c6b80760bb8bf850a2cc65a1e031da62fd3ca8b552189104dc98514"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.14.2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "bevy_derive"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d94761ce947b0a2402fd949fe1e7a5b1535293130ba4cd9893be6295d4680a"
+dependencies = [
+ "bevy_macro_utils 0.15.3",
  "quote",
  "syn 2.0.100",
 ]
@@ -663,12 +902,27 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebb154e0cc78e3bbfbfdb42fb502b14c1cd47e72f16e6d4228dfe6233ba6cbd"
 dependencies = [
- "bevy_app",
- "bevy_core",
- "bevy_ecs",
- "bevy_tasks",
- "bevy_time",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_core 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_tasks 0.14.2",
+ "bevy_time 0.14.2",
+ "bevy_utils 0.14.2",
+ "const-fnv1a-hash",
+]
+
+[[package]]
+name = "bevy_diagnostic"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21fe41b22fdf47bf11f0a3ca3e61975b003e86fa44d87e070f2dc7e752dd99f5"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_core 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_tasks 0.15.3",
+ "bevy_time 0.15.1",
+ "bevy_utils 0.15.3",
  "const-fnv1a-hash",
  "sysinfo",
 ]
@@ -679,12 +933,11 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee4222406637f3c8e3991a99788cfcde76097bf997c311f1b6297364057483f"
 dependencies = [
- "arrayvec",
- "bevy_ecs_macros",
- "bevy_ptr",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
+ "bevy_ecs_macros 0.14.2",
+ "bevy_ptr 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_tasks 0.14.2",
+ "bevy_utils 0.14.2",
  "bitflags 2.9.0",
  "concurrent-queue",
  "fixedbitset 0.5.7",
@@ -695,12 +948,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_ecs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b747210d7db09dfacc237707d4fd31c8b43d7744cd5e5829e2c4ca86b9e47baf"
+dependencies = [
+ "arrayvec",
+ "bevy_ecs_macros 0.15.3",
+ "bevy_ptr 0.15.3",
+ "bevy_reflect 0.15.1",
+ "bevy_tasks 0.15.3",
+ "bevy_utils 0.15.3",
+ "bitflags 2.9.0",
+ "concurrent-queue",
+ "derive_more",
+ "disqualified",
+ "fixedbitset 0.5.7",
+ "nonmax",
+ "petgraph",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "bevy_ecs_macros"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36b573430b67aff7bde8292257494f39343401379bfbda64035ba4918bba7b20"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.14.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "bevy_ecs_macros"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f453adf07712b39826bc5845e5b0887ce03204ee8359bbe6b40a9afda60564a1"
+dependencies = [
+ "bevy_macro_utils 0.15.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -708,23 +996,38 @@ dependencies = [
 
 [[package]]
 name = "bevy_egui"
-version = "0.28.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4a90f30f2849a07d91e393b10c0cc05df09b5773c010ddde57dd8b583be230"
+checksum = "45fa3f22e775175244a36b50615c0c71df9e0847e297283e5ec62ec5f99439a0"
 dependencies = [
  "arboard",
- "bevy",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_image",
+ "bevy_input 0.15.1",
+ "bevy_log 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_picking",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_time 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "bevy_winit 0.15.1",
  "bytemuck",
- "console_log",
  "crossbeam-channel",
  "egui",
+ "encase 0.10.0",
+ "image 0.25.6",
  "js-sys",
- "log",
  "thread_local",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webbrowser",
+ "wgpu-types 23.0.0",
  "winit",
 ]
 
@@ -734,23 +1037,33 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06c9693847a2a6ea61d6b86288dd4d8b6a79f05d4bf6e27b96d4f5c8d552fe4"
 dependencies = [
- "bevy_macro_utils",
- "encase_derive_impl",
+ "bevy_macro_utils 0.14.2",
+ "encase_derive_impl 0.8.0",
+]
+
+[[package]]
+name = "bevy_encase_derive"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37ad69d36bb9e8479a88d481ef9748f5d7ab676040531d751d3a44441dcede7"
+dependencies = [
+ "bevy_macro_utils 0.15.3",
+ "encase_derive_impl 0.10.0",
 ]
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0422ccb3ce0f79b264100cf064fdc5ef65cef5c7d51bf6378058f9b96fea4183"
+checksum = "a20320bd21f379ba4ec885b8217cb7c2c57eb0be014ba29509959e252480c3e9"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_input",
- "bevy_time",
- "bevy_utils",
+ "bevy_app 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_input 0.15.1",
+ "bevy_time 0.15.1",
+ "bevy_utils 0.15.3",
+ "derive_more",
  "gilrs",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -759,20 +1072,42 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfe32af0666d8d8a7fd6eb6b5e41eceefdc6f2e5441c74b812e8f0902a9d7f52"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core_pipeline",
- "bevy_ecs",
- "bevy_gizmos_macros",
- "bevy_math",
+ "bevy_app 0.14.2",
+ "bevy_asset 0.14.2",
+ "bevy_color 0.14.3",
+ "bevy_core_pipeline 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_gizmos_macros 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_render 0.14.2",
+ "bevy_time 0.14.2",
+ "bevy_transform 0.14.2",
+ "bevy_utils 0.14.2",
+ "bytemuck",
+]
+
+[[package]]
+name = "bevy_gizmos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca821905afffe1f3aaf33b496903a24a0c980e4c83fa7523fb41eac16892a57a"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core_pipeline 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_gizmos_macros 0.15.3",
+ "bevy_image",
+ "bevy_math 0.15.1",
  "bevy_pbr",
- "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_sprite 0.15.1",
+ "bevy_time 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
  "bytemuck",
 ]
 
@@ -782,7 +1117,19 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "906b052f8cf3f3983f0f6df625fb10cbd9b27d44e362a327dc1ed51300d362bc"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.14.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "bevy_gizmos_macros"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb9e0dca64e0fc9d6b1d9e6e2178396e339e3e2b9f751e2504e3ea4ddf4508"
+dependencies = [
+ "bevy_macro_utils 0.15.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -790,48 +1137,50 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6adbd325b90e3c700d0966b5404e226c7deec1b8bda8f36832788d7b435b9b8"
+checksum = "c38b79c0e43c6387699d6a332d12f98ed895bcf69dd70c462d5e49ad76d44d1f"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core",
- "bevy_core_pipeline",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_math",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core 0.15.1",
+ "bevy_core_pipeline 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_image",
+ "bevy_math 0.15.1",
  "bevy_pbr",
- "bevy_reflect",
- "bevy_render",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
  "bevy_scene",
- "bevy_tasks",
- "bevy_transform",
- "bevy_utils",
+ "bevy_tasks 0.15.3",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "derive_more",
  "gltf",
  "percent-encoding",
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "bevy_gltf_export"
 version = "0.1.0"
-source = "git+https://github.com/luca-della-vedova/bevy_gltf_export?branch=bevy_0.14#21294b4bbb144fdee13be7daebea787333f8cf7a"
+source = "git+https://github.com/xiyuoh/bevy_gltf_export?branch=xiyu%2Fbevy_0.15#1a72af7b946c00315b344c09a153290b65287009"
 dependencies = [
- "bevy_asset",
- "bevy_color",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_image",
  "bevy_pbr",
- "bevy_render",
- "bevy_transform",
+ "bevy_render 0.15.1",
+ "bevy_transform 0.15.1",
  "gltf",
  "gltf-json",
- "image",
+ "image 0.24.9",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -843,31 +1192,68 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88b912b37e1bc4dbb2aa40723199f74c8b06c4fbb6da0bb4585131df28ef66e"
 dependencies = [
- "bevy_app",
- "bevy_core",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_core 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_utils 0.14.2",
  "smallvec",
 ]
 
 [[package]]
+name = "bevy_hierarchy"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9aab2cd1684d30f2eedf953b6377a6416fd6b482f8145b6c05f4684bd60c3e"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_core 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_utils 0.15.3",
+ "disqualified",
+ "smallvec",
+]
+
+[[package]]
+name = "bevy_image"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5942a7d681b81aa9723bb1d918135c2f88e7871331f5676119c86c01984759"
+dependencies = [
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_utils 0.15.3",
+ "bitflags 2.9.0",
+ "bytemuck",
+ "derive_more",
+ "futures-lite 2.6.0",
+ "image 0.25.6",
+ "ktx2",
+ "ruzstd",
+ "serde",
+ "wgpu 23.0.1",
+]
+
+[[package]]
 name = "bevy_impulse"
-version = "0.2.0"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.2#2e5e7162dad955dd0308e8aabb914650496e9725"
+version = "0.3.0"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#603e60e8c0d2bbb2f2534117676778cbd1f43992"
 dependencies = [
  "anyhow",
  "async-task",
  "backtrace",
- "bevy_app",
- "bevy_core",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
+ "bevy_app 0.15.1",
+ "bevy_core 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
  "bevy_impulse_derive",
- "bevy_tasks",
- "bevy_time",
- "bevy_utils",
+ "bevy_tasks 0.15.3",
+ "bevy_time 0.15.1",
+ "bevy_utils 0.15.3",
  "futures",
  "itertools 0.13.0",
  "smallvec",
@@ -880,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "bevy_impulse_derive"
 version = "0.0.2"
-source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.2#2e5e7162dad955dd0308e8aabb914650496e9725"
+source = "git+https://github.com/open-rmf/bevy_impulse?branch=xiyu%2Frelease-0.3#603e60e8c0d2bbb2f2534117676778cbd1f43992"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -893,54 +1279,72 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd3a54e67cc3ba17971de7b1a7e64eda84493c1e7bb6bfa11c6cf8ac124377b"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_utils 0.14.2",
  "smol_str",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "bevy_internal"
-version = "0.14.2"
+name = "bevy_input"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d435cac77c568f3aef65f786a5fee0e53c81950c5258182dd2c1d6cd6c4fec"
+checksum = "a9bbf39c1d2d33350e03354a67bebee5c21973c5203b1456a9a4b90a5e6f8e75"
 dependencies = [
- "bevy_a11y",
+ "bevy_app 0.15.1",
+ "bevy_core 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_utils 0.15.3",
+ "derive_more",
+ "smol_str",
+]
+
+[[package]]
+name = "bevy_internal"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7fc4db9a1793ee71f79abb15e7a8fcfe4e2081e5f18ed91b802bf6cf30e088"
+dependencies = [
+ "bevy_a11y 0.15.1",
  "bevy_animation",
- "bevy_app",
- "bevy_asset",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
  "bevy_audio",
- "bevy_color",
- "bevy_core",
- "bevy_core_pipeline",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
+ "bevy_color 0.15.2",
+ "bevy_core 0.15.1",
+ "bevy_core_pipeline 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_diagnostic 0.15.1",
+ "bevy_ecs 0.15.1",
  "bevy_gilrs",
- "bevy_gizmos",
+ "bevy_gizmos 0.15.1",
  "bevy_gltf",
- "bevy_hierarchy",
- "bevy_input",
- "bevy_log",
- "bevy_math",
+ "bevy_hierarchy 0.15.1",
+ "bevy_image",
+ "bevy_input 0.15.1",
+ "bevy_log 0.15.1",
+ "bevy_math 0.15.1",
  "bevy_pbr",
- "bevy_ptr",
- "bevy_reflect",
- "bevy_render",
+ "bevy_picking",
+ "bevy_ptr 0.15.3",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
  "bevy_scene",
- "bevy_sprite",
+ "bevy_sprite 0.15.1",
  "bevy_state",
- "bevy_tasks",
+ "bevy_tasks 0.15.3",
  "bevy_text",
- "bevy_time",
- "bevy_transform",
+ "bevy_time 0.15.1",
+ "bevy_transform 0.15.1",
  "bevy_ui",
- "bevy_utils",
- "bevy_window",
- "bevy_winit",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "bevy_winit 0.15.1",
 ]
 
 [[package]]
@@ -950,10 +1354,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67240c7596c8f0653e50fce35a60196516817449235193246599facba9002e02"
 dependencies = [
  "android_log-sys",
- "bevy_app",
- "bevy_ecs",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_utils 0.14.2",
  "tracing-log",
+ "tracing-subscriber",
+ "tracing-wasm",
+]
+
+[[package]]
+name = "bevy_log"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774238dcf70a0ef4d82aa2860b24b1cffdd4633f3694d3bcbfbb05c4f17ae4fe"
+dependencies = [
+ "android_log-sys",
+ "bevy_app 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_utils 0.15.3",
+ "tracing-log",
+ "tracing-oslog",
  "tracing-subscriber",
  "tracing-wasm",
 ]
@@ -971,17 +1391,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_macro_utils"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb6ded1ddc124ea214f6a2140e47a78d1fe79b0638dad39419cdeef2e1133f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "toml_edit 0.22.12",
+]
+
+[[package]]
 name = "bevy_math"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5421792749dda753ab3718e77d27bfce38443daf1850b836b97530b6245a4581"
 dependencies = [
- "bevy_reflect",
- "glam",
+ "bevy_reflect 0.14.2",
+ "glam 0.27.0",
  "rand",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bevy_math"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edec18d90e6bab27b5c6131ee03172ece75b7edd0abe4e482a26d6db906ec357"
+dependencies = [
+ "bevy_reflect 0.15.1",
+ "derive_more",
+ "glam 0.29.3",
+ "itertools 0.13.0",
+ "rand",
+ "rand_distr",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "bevy_mesh"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183abae7c6695a80d7408c860bd737410cd66d2a9f910dafc914485da06e43dc"
+dependencies = [
+ "bevy_asset 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_image",
+ "bevy_math 0.15.1",
+ "bevy_mikktspace 0.15.3",
+ "bevy_reflect 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bitflags 2.9.0",
+ "bytemuck",
+ "derive_more",
+ "hexasphere 15.1.0",
+ "serde",
+ "wgpu 23.0.1",
 ]
 
 [[package]]
@@ -990,21 +1461,31 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66cf695a264b043f2c4edb92dd5c742e6892180d2b30dac870012d153f8557ea"
 dependencies = [
- "glam",
+ "glam 0.27.0",
+]
+
+[[package]]
+name = "bevy_mikktspace"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226f663401069ded4352ed1472a85bb1f43e2b7305d6a50e53a4f6508168e380"
+dependencies = [
+ "glam 0.29.3",
 ]
 
 [[package]]
 name = "bevy_mod_outline"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a262553297f0a22d21b1b01d6b377ef0c904d261fe52d09ec7d2ad967a6a26"
+checksum = "380a62f1c85e631a884b642e380d3ad2dbb15d4fbeb9cb35bcbd97efa8de1136"
 dependencies = [
  "bevy",
+ "bevy_image",
  "bitfield",
  "interpolation",
  "nonmax",
  "thiserror 1.0.69",
- "wgpu-types",
+ "wgpu-types 23.0.0",
 ]
 
 [[package]]
@@ -1013,60 +1494,56 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e4ff45885c4716771a9f55977d8ce69596502a5241da55bf608d7cd71a9cb3"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_derive",
- "bevy_ecs",
- "bevy_gizmos",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
+ "bevy_app 0.14.2",
+ "bevy_asset 0.14.2",
+ "bevy_color 0.14.3",
+ "bevy_derive 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_gizmos 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_render 0.14.2",
+ "bevy_sprite 0.14.2",
+ "bevy_transform 0.14.2",
+ "bevy_utils 0.14.2",
+ "bevy_window 0.14.2",
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "bevy_obj"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891c44dd1ed9aa3fc80d55e9019f61771307c1a6eb4cae3117cef25bd9fcfcee"
+checksum = "e4191729706530ab50a73998fd94b3d80c9de725891959f45f98d29259f51f3c"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_ecs",
- "bevy_pbr",
- "bevy_render",
- "bevy_scene",
- "bevy_utils",
+ "bevy",
+ "serde",
  "thiserror 1.0.69",
  "tobj",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccaa3c945f19834dcf7cd8eb358236dbf0fc4000dacbc7710564e7856714db"
+checksum = "f7f17067399cf00f4441e93d39fb4c391a16cc223e0d35346ac388e66712c418"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core_pipeline",
- "bevy_derive",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core_pipeline 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_image",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
  "bitflags 2.9.0",
  "bytemuck",
+ "derive_more",
  "fixedbitset 0.5.7",
  "nonmax",
  "radsort",
@@ -1075,10 +1552,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_polyline"
-version = "0.10.0"
+name = "bevy_picking"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54091a26c01aa225f771e1a9b12eb2eadabfec359b67aeab75a46f7d3437647"
+checksum = "125e0c7327ec155c566c044c6eefd1a02e904134fa5dc0ba54665e06a35297b0"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_input 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_mesh",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_time 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "crossbeam-channel",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_polyline"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbf333dab4a712f63456aa64b8e06268a44afdcbc9be4780e6260a0e8113072"
 dependencies = [
  "bevy",
  "bitflags 2.9.0",
@@ -1092,22 +1593,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61baa1bdc1f4a7ac2c18217570a7cc04e1cd54d38456e91782f0371c79afe0a8"
 
 [[package]]
+name = "bevy_ptr"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89fe0b0b919146939481a3a7c38864face2c6d0fd2c73ab3d430dc693ecd9b11"
+
+[[package]]
 name = "bevy_reflect"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2508785a4a5809f25a237eec4fee2c91a4dbcf81324b2bbc2d6c52629e603781"
 dependencies = [
- "bevy_ptr",
- "bevy_reflect_derive",
- "bevy_utils",
+ "bevy_ptr 0.14.2",
+ "bevy_reflect_derive 0.14.2",
+ "bevy_utils 0.14.2",
  "downcast-rs",
  "erased-serde",
- "glam",
- "petgraph",
+ "glam 0.27.0",
  "serde",
  "smallvec",
  "smol_str",
  "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_reflect"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab3264acc3b6f48bc23fbd09fdfea6e5d9b7bfec142e4f3333f532acf195bca"
+dependencies = [
+ "assert_type_match",
+ "bevy_ptr 0.15.3",
+ "bevy_reflect_derive 0.15.1",
+ "bevy_utils 0.15.3",
+ "derive_more",
+ "disqualified",
+ "downcast-rs",
+ "erased-serde",
+ "glam 0.29.3",
+ "petgraph",
+ "serde",
+ "smallvec",
+ "smol_str",
  "uuid",
 ]
 
@@ -1117,7 +1645,20 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "967d5da1882ec3bb3675353915d3da909cafac033cbf31e58727824a1ad2a288"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.14.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_reflect_derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f83876a322130ab38a47d5dcf75258944bf76b3387d1acdb3750920fda63e2"
+dependencies = [
+ "bevy_macro_utils 0.15.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1131,45 +1672,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836cf8a513db013cbe7d55a331060088efd407e49fd5b05c8404700cd82e7619"
 dependencies = [
  "async-channel",
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core",
- "bevy_derive",
- "bevy_diagnostic",
- "bevy_ecs",
- "bevy_encase_derive",
- "bevy_hierarchy",
- "bevy_math",
- "bevy_mikktspace",
- "bevy_reflect",
- "bevy_render_macros",
- "bevy_tasks",
- "bevy_time",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
+ "bevy_app 0.14.2",
+ "bevy_asset 0.14.2",
+ "bevy_color 0.14.3",
+ "bevy_core 0.14.2",
+ "bevy_derive 0.14.2",
+ "bevy_diagnostic 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_encase_derive 0.14.2",
+ "bevy_hierarchy 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_mikktspace 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_render_macros 0.14.2",
+ "bevy_tasks 0.14.2",
+ "bevy_time 0.14.2",
+ "bevy_transform 0.14.2",
+ "bevy_utils 0.14.2",
+ "bevy_window 0.14.2",
  "bitflags 2.9.0",
  "bytemuck",
  "codespan-reporting",
  "downcast-rs",
- "encase",
- "futures-lite 2.2.0",
- "hexasphere",
- "image",
+ "encase 0.8.0",
+ "futures-lite 2.6.0",
+ "hexasphere 12.0.0",
+ "image 0.25.6",
  "js-sys",
- "ktx2",
- "naga",
- "naga_oil",
+ "naga 0.20.0",
+ "naga_oil 0.14.0",
  "nonmax",
- "ruzstd",
  "send_wrapper",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
- "wgpu",
+ "wgpu 0.20.1",
+]
+
+[[package]]
+name = "bevy_render"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b14d77d8ff589743237c98502c0e47fd31059cf348ab86a265c4f90bb5e2a22"
+dependencies = [
+ "async-channel",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_diagnostic 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_encase_derive 0.15.3",
+ "bevy_hierarchy 0.15.1",
+ "bevy_image",
+ "bevy_math 0.15.1",
+ "bevy_mesh",
+ "bevy_reflect 0.15.1",
+ "bevy_render_macros 0.15.3",
+ "bevy_tasks 0.15.3",
+ "bevy_time 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "bytemuck",
+ "codespan-reporting",
+ "derive_more",
+ "downcast-rs",
+ "encase 0.10.0",
+ "futures-lite 2.6.0",
+ "image 0.25.6",
+ "js-sys",
+ "ktx2",
+ "naga 23.1.0",
+ "naga_oil 0.16.0",
+ "nonmax",
+ "offset-allocator",
+ "send_wrapper",
+ "serde",
+ "smallvec",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu 23.0.1",
 ]
 
 [[package]]
@@ -1178,7 +1764,19 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc24e0e95061a38a7744218b9c7e52e4c08b53f1499f33480e2b749f3864432"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.14.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "bevy_render_macros"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3469307d1b5ca5c37b7f9269be033845357412ebad33eace46826e59da592f66"
+dependencies = [
+ "bevy_macro_utils 0.15.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1186,21 +1784,21 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec57a72d75273bdbb6154390688fd07ba79ae9f6f99476d1937f799c736c2da"
+checksum = "cd00a08d01a190a826a5f6ad0fcb3dbf7bd1bd4f64ebe6108c38384691a21111"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_reflect",
- "bevy_render",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "derive_more",
  "serde",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -1210,17 +1808,17 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e045b4d8cc8e7422a4c29b1eadbe224f5cc42f170b88d43e7535892fcede3840"
 dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core_pipeline",
- "bevy_derive",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_transform",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_asset 0.14.2",
+ "bevy_color 0.14.3",
+ "bevy_core_pipeline 0.14.2",
+ "bevy_derive 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_render 0.14.2",
+ "bevy_transform 0.14.2",
+ "bevy_utils 0.14.2",
  "bitflags 2.9.0",
  "bytemuck",
  "fixedbitset 0.5.7",
@@ -1231,26 +1829,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_state"
-version = "0.14.2"
+name = "bevy_sprite"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25335bfa58cc22371182335c3b133017293bc9b6d3308402fd4d1f978b83f937"
+checksum = "84c7d22da88e562fb2ae8fe7f8cc749d3024caa4dcb57a777d070ef9141577aa"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_reflect",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core_pipeline 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_image",
+ "bevy_math 0.15.1",
+ "bevy_picking",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "bitflags 2.9.0",
+ "bytemuck",
+ "derive_more",
+ "fixedbitset 0.5.7",
+ "guillotiere",
+ "nonmax",
+ "radsort",
+ "rectangle-pack",
+]
+
+[[package]]
+name = "bevy_state"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd10c8b01a982642596406fc4486fcd52239aa9c4aa47fed27abab93a69fba59"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_reflect 0.15.1",
  "bevy_state_macros",
- "bevy_utils",
+ "bevy_utils 0.15.3",
 ]
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.14.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee600b659c739f1911f997a81611fec0a1832cf731727956e5fa4e7532b4dd5"
+checksum = "022eb069dfd64090fd92ba4a7f235383e49aa1c0f4320dab4999b23f67843b36"
 dependencies = [
- "bevy_macro_utils",
+ "bevy_macro_utils 0.15.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -1258,13 +1886,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_stl"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ca2d994225ab4429b450eb32dc1b49bf795b3b1bf88d4ddee39012195f201c"
+checksum = "5bdd359a6cdf7f26593ba9b5709db011eb88980c94ff95465bae0dd715117a55"
 dependencies = [
  "bevy",
  "stl_io",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1273,34 +1901,52 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77865f310b1fc48fb05b7c4adbe76607ec01d0c14f8ab4caba4d714c86439946"
 dependencies = [
+ "async-executor",
+ "futures-lite 2.6.0",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028630ddc355563bd567df1076db3515858aa26715ddf7467d2086f9b40e5ab1"
+dependencies = [
  "async-channel",
  "async-executor",
  "concurrent-queue",
- "futures-lite 2.2.0",
+ "futures-channel",
+ "futures-lite 2.6.0",
+ "pin-project",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b661db828fd423fc41a4ccf43aa4d1b8e50e75057ec40453317d0d761e8ad62d"
+checksum = "17ee0b5f52946d222521f93773a6230f42e868548f881c4c5bddb1393a96298b"
 dependencies = [
- "ab_glyph",
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
- "glyph_brush_layout",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_image",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_sprite 0.15.1",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "cosmic-text",
+ "derive_more",
  "serde",
- "thiserror 1.0.69",
+ "smallvec",
+ "sys-locale",
+ "unicode-bidi",
 ]
 
 [[package]]
@@ -1309,12 +1955,25 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e4d53ec32a1b16492396951d04de0d2d90e924bf9adcb8d1adacab5ab6c17c"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_app 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_utils 0.14.2",
  "crossbeam-channel",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bevy_time"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3108ed1ef864bc40bc859ba4c9c3844213c7be3674f982203cf5d87c656848"
+dependencies = [
+ "bevy_app 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_utils 0.15.3",
+ "crossbeam-channel",
 ]
 
 [[package]]
@@ -1323,42 +1982,59 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5493dce84427d00a9266e8e4386d738a72ee8640423b62dfcecb6dfccbfe0d2"
 dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_math",
- "bevy_reflect",
+ "bevy_app 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_hierarchy 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "bevy_ui"
-version = "0.14.2"
+name = "bevy_transform"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d2cba6603b39a3765f043212ae530e25550af168a7eec6b23b9b93c19bc5f7"
+checksum = "056fabcedbf0503417af69447d47a983e18c7cfb5e6b6728636be3ec285cbcfa"
 dependencies = [
- "bevy_a11y",
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_core_pipeline",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_input",
- "bevy_math",
- "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
+ "bevy_app 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "derive_more",
+]
+
+[[package]]
+name = "bevy_ui"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4556fc2202c6339f95e0c24ca4c96ee959854b702e23ecf73e05fb20e67d67b0"
+dependencies = [
+ "accesskit 0.17.1",
+ "bevy_a11y 0.15.1",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_color 0.15.2",
+ "bevy_core_pipeline 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_image",
+ "bevy_input 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_picking",
+ "bevy_reflect 0.15.1",
+ "bevy_render 0.15.1",
+ "bevy_sprite 0.15.1",
  "bevy_text",
- "bevy_transform",
- "bevy_utils",
- "bevy_window",
+ "bevy_transform 0.15.1",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
  "bytemuck",
+ "derive_more",
  "nonmax",
  "smallvec",
  "taffy",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1368,7 +2044,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb0ec333b5965771153bd746f92ffd8aeeb9d008a8620ffd9ed474859381a5e"
 dependencies = [
  "ahash",
- "bevy_utils_proc_macros",
+ "bevy_utils_proc_macros 0.14.2",
+ "getrandom 0.2.12",
+ "hashbrown 0.14.3",
+ "thread_local",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "bevy_utils"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c2174d43a0de99f863c98a472370047a2bfa7d1e5cec8d9d647fb500905d9d"
+dependencies = [
+ "ahash",
+ "bevy_utils_proc_macros 0.15.3",
  "getrandom 0.2.12",
  "hashbrown 0.14.3",
  "thread_local",
@@ -1388,17 +2079,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_utils_proc_macros"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94847541f6dd2e28f54a9c2b0e857da5f2631e2201ebc25ce68781cdcb721391"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "bevy_window"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e88a20db64ea8204540afb4699295947c454738fd50293f7b32ab8be857a6"
 dependencies = [
- "bevy_a11y",
- "bevy_app",
- "bevy_ecs",
- "bevy_math",
- "bevy_reflect",
- "bevy_utils",
+ "bevy_a11y 0.14.2",
+ "bevy_app 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_utils 0.14.2",
+ "raw-window-handle 0.6.2",
+ "smol_str",
+]
+
+[[package]]
+name = "bevy_window"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36139955777cc9e7a40a97833ff3a95b7401ce525a3dbac05fc52557968b31a7"
+dependencies = [
+ "android-activity",
+ "bevy_a11y 0.15.1",
+ "bevy_app 0.15.1",
+ "bevy_ecs 0.15.1",
+ "bevy_input 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_utils 0.15.3",
  "raw-window-handle 0.6.2",
  "smol_str",
 ]
@@ -1409,25 +2129,58 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0bef8ec3e4b45db943ad4d1c0bf59b09e382ce0651a706e2f33a70fa955303c"
 dependencies = [
- "accesskit_winit",
+ "accesskit_winit 0.20.4",
  "approx",
- "bevy_a11y",
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_hierarchy",
- "bevy_input",
- "bevy_log",
- "bevy_math",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
- "bevy_window",
+ "bevy_a11y 0.14.2",
+ "bevy_app 0.14.2",
+ "bevy_derive 0.14.2",
+ "bevy_ecs 0.14.2",
+ "bevy_hierarchy 0.14.2",
+ "bevy_input 0.14.2",
+ "bevy_log 0.14.2",
+ "bevy_math 0.14.2",
+ "bevy_reflect 0.14.2",
+ "bevy_tasks 0.14.2",
+ "bevy_utils 0.14.2",
+ "bevy_window 0.14.2",
  "cfg-if",
  "crossbeam-channel",
  "raw-window-handle 0.6.2",
  "wasm-bindgen",
  "web-sys",
+ "winit",
+]
+
+[[package]]
+name = "bevy_winit"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e84e7f94583cac93de4ba641029eb0b6551d35e559c829209f2b1b9fe532d8"
+dependencies = [
+ "accesskit 0.17.1",
+ "accesskit_winit 0.23.1",
+ "approx",
+ "bevy_a11y 0.15.1",
+ "bevy_app 0.15.1",
+ "bevy_asset 0.15.1",
+ "bevy_derive 0.15.3",
+ "bevy_ecs 0.15.1",
+ "bevy_hierarchy 0.15.1",
+ "bevy_image",
+ "bevy_input 0.15.1",
+ "bevy_log 0.15.1",
+ "bevy_math 0.15.1",
+ "bevy_reflect 0.15.1",
+ "bevy_tasks 0.15.3",
+ "bevy_utils 0.15.3",
+ "bevy_window 0.15.1",
+ "bytemuck",
+ "cfg-if",
+ "crossbeam-channel",
+ "raw-window-handle 0.6.2",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types 23.0.0",
  "winit",
 ]
 
@@ -1452,12 +2205,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1465,6 +2247,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -1538,7 +2326,7 @@ dependencies = [
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.2.0",
+ "futures-lite 2.6.0",
  "piper",
  "tracing",
 ]
@@ -1807,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1825,20 +2613,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
 name = "const-fnv1a-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.12",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_panic"
@@ -1887,10 +2685,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
@@ -1899,7 +2707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1912,7 +2720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1933,7 +2741,30 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f01585027057ff5f0a5bf276174ae4c1594a2c5bde93d5f46a016d76270f5a9"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
+dependencies = [
+ "bitflags 2.9.0",
+ "fontdb",
+ "log",
+ "rangemap",
+ "rayon",
+ "rustc-hash",
+ "rustybuzz",
+ "self_cell",
+ "swash",
+ "sys-locale",
+ "ttf-parser 0.21.1",
+ "unicode-bidi",
+ "unicode-linebreak",
+ "unicode-script",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2015,6 +2846,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "ctrlc"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2883,27 @@ name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "unicode-xid",
+]
 
 [[package]]
 name = "dirs"
@@ -2081,6 +2943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "disqualified"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c272297e804878a2a4b707cfcfc6d2328b5bb936944613b4fdf2b9269afdfd"
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -2122,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
@@ -2132,14 +3000,16 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
 dependencies = [
  "ahash",
+ "bitflags 2.9.0",
  "emath",
  "epaint",
  "nohash-hasher",
+ "profiling",
 ]
 
 [[package]]
@@ -2159,15 +3029,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
 ]
@@ -2179,8 +3049,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9299a95fa5671ddf29ecc22b00e121843a65cb9ff24911e394b4ae556baf36"
 dependencies = [
  "const_panic",
- "encase_derive",
- "glam",
+ "encase_derive 0.8.0",
+ "glam 0.27.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "encase"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a05902cf601ed11d564128448097b98ebe3c6574bd7b6a653a3d56d54aa020"
+dependencies = [
+ "const_panic",
+ "encase_derive 0.10.0",
+ "glam 0.29.3",
  "thiserror 1.0.69",
 ]
 
@@ -2190,7 +3072,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e09decb3beb1fe2db6940f598957b2e1f7df6206a804d438ff6cb2a9cddc10"
 dependencies = [
- "encase_derive_impl",
+ "encase_derive_impl 0.8.0",
+]
+
+[[package]]
+name = "encase_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "181d475b694e2dd56ae919ce7699d344d1fd259292d590c723a50d1189a2ea85"
+dependencies = [
+ "encase_derive_impl 0.10.0",
 ]
 
 [[package]]
@@ -2205,19 +3096,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "epaint"
-version = "0.28.1"
+name = "encase_derive_impl"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
+checksum = "f97b51c5cc57ef7c5f7a0c57c250251c49ee4c28f819f87ac32f4aceabc36792"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "epaint"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
 dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
+ "epaint_default_fonts",
  "nohash-hasher",
  "parking_lot",
+ "profiling",
 ]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "equivalent"
@@ -2300,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.2.0",
  "pin-project-lite",
@@ -2413,6 +3323,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "font-types"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3971f9a5ca983419cdc386941ba3b9e1feba01a0ab888adf78739feb2798492"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.20.0",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.2.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
@@ -2680,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b2e57a9cb946b5d04ae8638c5f554abb5a9f82c4c950fd5b1fee6d119592fb"
+checksum = "bbb2c998745a3c1ac90f64f4f7b3a54219fd3612d7705e7798212935641ed18f"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -2693,11 +3635,11 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af1827b7dd2f36d740ae804c1b3ea0d64c12533fb61ff91883005143a0e8c5a"
+checksum = "a6d95ae10ce5aa99543a28cf74e41c11f3b9e3c14f0452bbde46024753cd683e"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.0",
  "inotify",
  "io-kit-sys",
  "js-sys",
@@ -2709,7 +3651,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.52.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -2754,6 +3696,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+dependencies = [
+ "bytemuck",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "glib-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +3727,18 @@ name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2827,14 +3792,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "glyph_brush_layout"
-version = "0.2.3"
+name = "glutin_wgl_sys"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
- "ab_glyph",
- "approx",
- "xi-unicode",
+ "gl_generator",
 ]
 
 [[package]]
@@ -2878,6 +3841,18 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
  "windows 0.52.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -2942,7 +3917,7 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "ehttp",
- "futures-lite 2.2.0",
+ "futures-lite 1.13.0",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -3049,7 +4024,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd6b038160f086b0a7496edae34169ae22f328793cbe2b627a5a3d8373748ec"
 dependencies = [
  "constgebra",
- "glam",
+ "glam 0.27.0",
+]
+
+[[package]]
+name = "hexasphere"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c9e718d32b6e6b2b32354e1b0367025efdd0b11d6a740b905ddf5db1074679"
+dependencies = [
+ "constgebra",
+ "glam 0.29.3",
+ "tinyvec",
 ]
 
 [[package]]
@@ -3075,6 +4061,24 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
+ "qoi",
+ "tiff",
 ]
 
 [[package]]
@@ -3153,11 +4157,11 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.0",
  "inotify-sys",
  "libc",
 ]
@@ -3199,9 +4203,9 @@ checksum = "e9c13ae9d91148fcb4aab6654c4c2a7d02a15395ea9e23f65170f175f8b269ce"
 
 [[package]]
 name = "io-kit-sys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
  "mach2",
@@ -3276,13 +4280,17 @@ name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3374,7 +4382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3536,6 +4544,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.9.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,7 +4581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.5.3",
  "bitflags 2.9.0",
  "codespan-reporting",
  "hexf-parse",
@@ -3574,16 +4597,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "naga"
+version = "23.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.8.0",
+ "bitflags 2.9.0",
+ "cfg_aliases 0.1.1",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap 2.2.5",
+ "log",
+ "pp-rs",
+ "rustc-hash",
+ "spirv",
+ "termcolor",
+ "thiserror 1.0.69",
+ "unicode-xid",
+]
+
+[[package]]
 name = "naga_oil"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "275d9720a7338eedac966141089232514c84d76a246a58ef501af88c5edf402f"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "codespan-reporting",
  "data-encoding",
  "indexmap 2.2.5",
- "naga",
+ "naga 0.20.0",
+ "once_cell",
+ "regex",
+ "regex-syntax 0.8.2",
+ "rustc-hash",
+ "thiserror 1.0.69",
+ "tracing",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga_oil"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ea1f080bb359927cd5404d0af1e5e6758f4f2d82ecfbebb0a0c434764e40f1"
+dependencies = [
+ "bit-set 0.5.3",
+ "codespan-reporting",
+ "data-encoding",
+ "indexmap 2.2.5",
+ "naga 23.1.0",
  "once_cell",
  "regex",
  "regex-syntax 0.8.2",
@@ -3681,12 +4746,13 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -4151,6 +5217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "offset-allocator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234d535da3521eb95106f40f0b73483d80bfb3aacf27c40d7e2b72f1a3e00a2"
+dependencies = [
+ "log",
+ "nonmax",
+]
+
+[[package]]
 name = "ogg"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,9 +5237,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "option-ext"
@@ -4192,7 +5268,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -4344,6 +5420,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "pp-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,6 +5459,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4387,9 +5488,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 dependencies = [
  "profiling-procmacros",
 ]
@@ -4480,10 +5581,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
+
+[[package]]
+name = "rangemap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "rav1e"
@@ -4571,6 +5688,16 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69aacb76b5c29acfb7f90155d39759a29496aebb49395830e928a9703d2eec2f"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -4750,7 +5877,7 @@ version = "0.0.1"
 dependencies = [
  "bevy",
  "float_eq",
- "glam",
+ "glam 0.27.0",
  "once_cell",
  "pathdiff",
  "ron 0.9.0-alpha.0",
@@ -4772,9 +5899,9 @@ checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
 name = "rodio"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fceb9d127d515af1586d8d0cc601e1245bdb0af38e75c865a156290184f5b3"
+checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
 dependencies = [
  "cpal",
  "lewton",
@@ -4804,6 +5931,12 @@ dependencies = [
  "serde_derive",
  "unicode-ident",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rstar"
@@ -4882,6 +6015,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags 2.9.0",
+ "bytemuck",
+ "libm",
+ "smallvec",
+ "ttf-parser 0.21.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ruzstd"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,6 +6106,12 @@ dependencies = [
  "yaserde",
  "yaserde_derive",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "semver"
@@ -5059,6 +6221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "skrifa"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1c44ad1f6c5bdd4eefed8326711b7dbda9ea45dfd36068c427d332aa382cbe"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,6 +6325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stackfuture"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eae92052b72ef70dafa16eddbabffc77e5ca3574be2f7bc1127b36f0a7ad7f2"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5160,9 +6338,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stl_io"
-version = "0.7.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d520eb03e632e666ac32f3c0cf018ac6dcd535ab0be1420937e2d896f44f7cf7"
+checksum = "cff2e145168af9fef3b518ac0c6f9849c407b3df8a28582ced9f1fda510aa34c"
 dependencies = [
  "byteorder",
  "float-cmp",
@@ -5193,6 +6371,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
+name = "swash"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd59f3f359ddd2c95af4758c18270eddd9c730dde98598023cdabff472c2ca2"
+dependencies = [
+ "skrifa",
+ "yazi",
+ "zeno",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,17 +6404,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.30.13"
+name = "sys-locale"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
- "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "windows 0.52.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -5331,6 +6528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5357,9 +6563,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5372,12 +6578,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tobj"
-version = "4.0.1"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7ca3ec0405b0f2f95e0dbcced28882190dc79b0dac63ff82533d256d770223"
+checksum = "04aca6092e5978e708ee784e8ab9b5cf3cdb598b28f99a2f257446e7081a7025"
 dependencies = [
  "ahash",
- "log",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -5479,6 +6685,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
+dependencies = [
+ "bindgen 0.70.1",
+ "cc",
+ "cfg-if",
+ "once_cell",
+ "parking_lot",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5514,6 +6735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5542,10 +6769,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -5555,6 +6800,18 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5570,9 +6827,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -5713,24 +6970,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -5739,21 +6996,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5761,9 +7019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5774,9 +7032,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wayland-backend"
@@ -5889,9 +7150,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5914,7 +7175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
 dependencies = [
  "block2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "home",
  "jni",
  "log",
@@ -5952,7 +7213,7 @@ dependencies = [
  "document-features",
  "js-sys",
  "log",
- "naga",
+ "naga 0.20.0",
  "parking_lot",
  "profiling",
  "raw-window-handle 0.6.2",
@@ -5961,9 +7222,34 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 0.21.1",
+ "wgpu-hal 0.21.1",
+ "wgpu-types 0.20.0",
+]
+
+[[package]]
+name = "wgpu"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
+dependencies = [
+ "arrayvec",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga 23.1.0",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 23.0.1",
+ "wgpu-hal 23.0.1",
+ "wgpu-types 23.0.0",
 ]
 
 [[package]]
@@ -5973,14 +7259,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.6.3",
  "bitflags 2.9.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "document-features",
  "indexmap 2.2.5",
  "log",
- "naga",
+ "naga 0.20.0",
  "once_cell",
  "parking_lot",
  "profiling",
@@ -5989,8 +7275,33 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "web-sys",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-hal 0.21.1",
+ "wgpu-types 0.20.0",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
+dependencies = [
+ "arrayvec",
+ "bit-vec 0.8.0",
+ "bitflags 2.9.0",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "indexmap 2.2.5",
+ "log",
+ "naga 23.1.0",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 1.0.69",
+ "wgpu-hal 23.0.1",
+ "wgpu-types 23.0.0",
 ]
 
 [[package]]
@@ -6001,17 +7312,17 @@ checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",
- "ash",
- "bit-set",
+ "ash 0.37.3+1.3.251",
+ "bit-set 0.5.3",
  "bitflags 2.9.0",
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
  "d3d12",
- "glow",
- "glutin_wgl_sys",
+ "glow 0.13.1",
+ "glutin_wgl_sys 0.5.0",
  "gpu-alloc",
- "gpu-allocator",
+ "gpu-allocator 0.25.0",
  "gpu-descriptor",
  "hassle-rs",
  "js-sys",
@@ -6019,8 +7330,8 @@ dependencies = [
  "libc",
  "libloading 0.8.3",
  "log",
- "metal",
- "naga",
+ "metal 0.28.0",
+ "naga 0.20.0",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
@@ -6034,8 +7345,53 @@ dependencies = [
  "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
+ "wgpu-types 0.20.0",
  "winapi",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash 0.38.0+1.3.281",
+ "bit-set 0.8.0",
+ "bitflags 2.9.0",
+ "block",
+ "bytemuck",
+ "cfg_aliases 0.1.1",
+ "core-graphics-types",
+ "glow 0.14.2",
+ "glutin_wgl_sys 0.6.1",
+ "gpu-alloc",
+ "gpu-allocator 0.27.0",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.3",
+ "log",
+ "metal 0.29.0",
+ "naga 23.1.0",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle 0.6.2",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types 23.0.0",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6043,6 +7399,17 @@ name = "wgpu-types"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
+dependencies = [
+ "bitflags 2.9.0",
+ "js-sys",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610f6ff27778148c31093f3b03abc4840f9636d58d597ca2f5977433acfe0068"
 dependencies = [
  "bitflags 2.9.0",
  "js-sys",
@@ -6103,7 +7470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6113,9 +7480,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-implement",
- "windows-interface",
- "windows-targets 0.52.4",
+ "windows-implement 0.53.0",
+ "windows-interface 0.53.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6124,7 +7501,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6133,8 +7510,21 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.4",
+ "windows-result 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6142,6 +7532,17 @@ name = "windows-implement"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6160,12 +7561,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6192,7 +7623,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6227,17 +7667,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6254,9 +7695,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6272,9 +7713,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6290,9 +7731,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6308,9 +7755,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6326,9 +7773,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6344,9 +7791,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6362,9 +7809,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
@@ -6381,7 +7828,7 @@ dependencies = [
  "calloop",
  "cfg_aliases 0.2.1",
  "concurrent-queue",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -6484,12 +7931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
-name = "xi-unicode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
-
-[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6555,6 +7996,18 @@ dependencies = [
  "syn 1.0.109",
  "xml-rs",
 ]
+
+[[package]]
+name = "yazi"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+
+[[package]]
+name = "zeno"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5334,12 +5334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
 name = "rustybuzz"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6307,24 +6301,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -6333,9 +6327,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6346,9 +6340,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6356,9 +6350,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6369,12 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wayland-backend"
@@ -6487,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you install rust from the main rust website. Cargo should take care of
 These are only needed if you're going to build a WebAssembly binary:
 ```bash
 $ sudo apt install binaryen
-$ cargo install -f wasm-bindgen-cli --version 0.2.93
+$ cargo install -f wasm-bindgen-cli --version 0.2.100
 $ cargo install basic-http-server
 $ rustup target add wasm32-unknown-unknown
 ```

--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ Make sure you install rust from the main rust website. Cargo should take care of
 
 These are only needed if you're going to build a WebAssembly binary:
 ```bash
-$ sudo apt install binaryen
-$ cargo install -f wasm-bindgen-cli --version 0.2.100
+$ cargo install -f wasm-bindgen-cli --version 0.2.97
 $ cargo install basic-http-server
 $ rustup target add wasm32-unknown-unknown
+
+# binaryen version >= 110 required for a bug fix for wasm-opt
+# Refer to https://github.com/emilk/egui/pull/6848
+$ wget -P ~/ https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz
+$ tar xf ~/binaryen-version_123-x86_64-linux.tar.gz -C ~/
+$ export PATH=$PATH:~/binaryen-version_123/bin
 ```
 
 # Build and Run (Desktop)

--- a/assets/demo_maps/office.building.yaml
+++ b/assets/demo_maps/office.building.yaml
@@ -137,7 +137,7 @@ levels:
     lights:
       - {pose: {trans: [1672, 783, 2.6], rot: {euler_xyz: [{deg: 30}, {deg: 0}, {deg: 0}]}}, kind: {type: spot}}
       - {pose: {trans: [1273, 783, 2.6]}, kind: {type: point, enable_shadows: false}}
-      - {pose: {trans: [1973, 633, 2.6]}, kind: {type: point, color: [0.5, 0.5, 1.0, 1.0]}}
+      - {pose: {trans: [1973, 633, 2.6]}, kind: {type: point, color: [0.5, 0.5, 1.0]}}
     vertices:
       - [80.27, 1024.974, 0, ""]
       - [580.795, 43.396, 0, ""]

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -16,7 +16,6 @@ name = "extending_site_editor"
 path = "examples/extending_menu.rs"
 
 [dependencies]
-bevy_mod_raycast = "0.18"
 bevy_mod_outline = "0.9"
 bevy_gltf_export = { git = "https://github.com/xiyuoh/bevy_gltf_export", branch = "xiyu/bevy_0.15"}
 bevy_polyline = "0.11"

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -47,7 +47,7 @@ pathdiff = "*"
 ehttp = { version = "0.4", features = ["native-async"] }
 nalgebra = "0.32.5"
 anyhow = "*"
-uuid = { version = "1.7", features = ["v4"] }
+uuid = { version = "1.13", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -16,7 +16,7 @@ name = "extending_site_editor"
 path = "examples/extending_menu.rs"
 
 [dependencies]
-bevy_mod_outline = "0.9"
+bevy_mod_outline = "0.9.1"
 bevy_gltf_export = { git = "https://github.com/xiyuoh/bevy_gltf_export", branch = "xiyu/bevy_0.15"}
 bevy_polyline = "0.11"
 bevy_stl = "0.15"
@@ -47,7 +47,7 @@ pathdiff = "*"
 ehttp = { version = "0.4", features = ["native-async"] }
 nalgebra = "0.32.5"
 anyhow = "*"
-uuid = { version = "1.13", features = ["v4"] }
+uuid = { version = "1.12", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -17,17 +17,17 @@ path = "examples/extending_menu.rs"
 
 [dependencies]
 bevy_mod_raycast = "0.18"
-bevy_mod_outline = "0.8"
-bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export", branch = "bevy_0.14"}
-bevy_polyline = "0.10"
-bevy_stl = "0.14"
-bevy_obj = { version = "0.14", features = ["scene"] }
+bevy_mod_outline = "0.9"
+bevy_gltf_export = { git = "https://github.com/xiyuoh/bevy_gltf_export", branch = "xiyu/bevy_0.15"}
+bevy_polyline = "0.11"
+bevy_stl = "0.15"
+bevy_obj = { version = "0.15", features = ["scene"] }
 smallvec = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.23"
 serde_json = "1.0"
 futures-lite = "1.12.0"
-bevy = { version = "0.14", features = ["pnm", "jpeg", "tga"] }
+bevy = { version = "0.15", features = ["pnm", "jpeg", "tga"] }
 dirs = "5.0"
 thread_local = "*"
 geo = "0.27"
@@ -52,9 +52,9 @@ uuid = { version = "1.7", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }
-bevy_egui = "0.28"
-bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.2" }
+bevy_egui = "0.33"
+bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.3" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy_egui = { version = "0.28", default-features = false, features = ["open_url", "default_fonts", "render"] }
-bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.2", features = ["single_threaded_async"]}
+bevy_egui = { version = "0.33", default-features = false, features = ["open_url", "default_fonts", "render"] }
+bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.3", features = ["single_threaded_async"]}

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -16,7 +16,6 @@ name = "extending_site_editor"
 path = "examples/extending_menu.rs"
 
 [dependencies]
-bevy_egui = "0.28"
 bevy_mod_raycast = "0.18"
 bevy_mod_outline = "0.8"
 bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export", branch = "bevy_0.14"}
@@ -53,7 +52,9 @@ uuid = { version = "1.7", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }
+bevy_egui = "0.28"
 bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.2" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+bevy_egui = { version = "0.28", default-features = false, features = ["open_url", "default_fonts", "render"] }
 bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.2", features = ["single_threaded_async"]}

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -16,19 +16,19 @@ name = "extending_site_editor"
 path = "examples/extending_menu.rs"
 
 [dependencies]
-bevy_egui = "0.23"
-bevy_mod_raycast = "0.16"
-bevy_mod_outline = "0.6"
-bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export", branch = "luca/transform_api"}
-bevy_polyline = "0.8.1"
-bevy_stl = "0.12"
-bevy_obj = { version = "0.12.1", features = ["scene"] }
+bevy_egui = "0.28"
+bevy_mod_raycast = "0.18"
+bevy_mod_outline = "0.8"
+bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export", branch = "bevy_0.14"}
+bevy_polyline = "0.10"
+bevy_stl = "0.14"
+bevy_obj = { version = "0.14", features = ["scene"] }
 smallvec = "*"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.23"
 serde_json = "1.0"
 futures-lite = "1.12.0"
-bevy = { version = "0.12", features = ["pnm", "jpeg", "tga"] }
+bevy = { version = "0.14", features = ["pnm", "jpeg", "tga"] }
 dirs = "5.0"
 thread_local = "*"
 geo = "0.27"
@@ -37,7 +37,7 @@ rmf_site_format = { path = "../rmf_site_format", features = ["bevy"] }
 itertools = "*"
 bitfield = "*"
 crossbeam-channel = "0.5"
-tracing = "0.1.37"
+tracing = "0.1.41"
 tracing-subscriber = "0.3.1"
 rfd = "0.12"
 urdf-rs = "0.7"
@@ -49,10 +49,11 @@ pathdiff = "*"
 ehttp = { version = "0.4", features = ["native-async"] }
 nalgebra = "0.32.5"
 anyhow = "*"
+uuid = { version = "1.7", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.0.10", features = ["color", "derive", "help", "usage", "suggestions"] }
-bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "main" }
+bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.2" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "main", features = ["single_threaded_async"]}
+bevy_impulse = { git = "https://github.com/open-rmf/bevy_impulse", branch = "xiyu/release-0.2", features = ["single_threaded_async"]}

--- a/rmf_site_editor/examples/extending_menu.rs
+++ b/rmf_site_editor/examples/extending_menu.rs
@@ -19,9 +19,7 @@ impl FromWorld for MyMenuHandler {
 
         // Make it a child of the "File Menu"
         let file_header = world.resource::<FileMenu>().get();
-        world
-            .entity_mut(file_header)
-            .push_children(&[unique_export]);
+        world.entity_mut(file_header).add_children(&[unique_export]);
 
         // For top level menus simply spawn a menu with no parent
         let menu = world
@@ -32,13 +30,13 @@ impl FromWorld for MyMenuHandler {
         let sub_menu = world
             .spawn(Menu::from_title("My Awesome sub menu".to_string()))
             .id();
-        world.entity_mut(menu).push_children(&[sub_menu]);
+        world.entity_mut(menu).add_children(&[sub_menu]);
 
         // Finally we can create a custom action
         let custom_nested_menu = world.spawn(MenuItem::Text("My Awesome Action".into())).id();
         world
             .entity_mut(sub_menu)
-            .push_children(&[custom_nested_menu]);
+            .add_children(&[custom_nested_menu]);
 
         // Track the entity so that we know when to handle events from it in
         Self {

--- a/rmf_site_editor/src/animate.rs
+++ b/rmf_site_editor/src/animate.rs
@@ -86,7 +86,7 @@ pub fn update_spinning_animations(
 ) {
     for (mut tf, spin, visibility) in &mut spinners {
         if **visibility {
-            let angle = 2. * std::f32::consts::PI * now.elapsed_seconds() / spin.period;
+            let angle = 2. * std::f32::consts::PI * now.elapsed_secs() / spin.period;
             tf.as_mut().rotation = Quat::from_rotation_z(angle);
         }
     }
@@ -98,7 +98,7 @@ pub fn update_bobbing_animations(
 ) {
     for (mut tf, bob, visibility) in &mut bobbers {
         if **visibility {
-            let theta = 2. * std::f32::consts::PI * now.elapsed_seconds() / bob.period;
+            let theta = 2. * std::f32::consts::PI * now.elapsed_secs() / bob.period;
             let dh = bob.heights.1 - bob.heights.0;
             tf.as_mut().translation[2] = dh * (1. - theta.cos()) / 2.0 + bob.heights.0;
         }

--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -53,11 +53,12 @@ pub fn add_anchor_visual_cues(
         };
 
         let body = commands
-            .spawn(PbrBundle {
-                mesh: body_mesh,
-                material: site_assets.passive_anchor_material.clone(),
-                ..default()
-            })
+            .spawn((
+                Mesh3d(body_mesh),
+                MeshMaterial3d(site_assets.passive_anchor_material.clone()),
+                Transform::default(),
+                Visibility::default(),
+            ))
             .insert(Selectable::new(e))
             .id();
         if subordinate.is_none() {

--- a/rmf_site_editor/src/interaction/anchor.rs
+++ b/rmf_site_editor/src/interaction/anchor.rs
@@ -198,7 +198,7 @@ pub fn update_anchor_visual_cues(
         Or<(Changed<Hovered>, Changed<Selected>, Changed<Dependents>)>,
     >,
     mut visibility: Query<&mut Visibility>,
-    mut materials: Query<&mut Handle<StandardMaterial>>,
+    mut materials: Query<&mut MeshMaterial3d<StandardMaterial>>,
     deps: Query<&Dependents>,
     mut cursor: ResMut<Cursor>,
     site_assets: Res<SiteAssets>,

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -18,6 +18,7 @@
 use crate::{interaction::*, shapes::*};
 use bevy::color::palettes::css as Colors;
 use bevy::{math::primitives, math::Affine3A, prelude::*};
+use bevy_polyline::prelude::PolylineMaterialHandle;
 use bevy_polyline::{
     material::PolylineMaterial,
     polyline::{Polyline, PolylineBundle},
@@ -206,7 +207,7 @@ impl InteractionAssets {
                 parent.spawn((
                     PolylineBundle {
                         polyline: polyline.clone(),
-                        material: material.clone(),
+                        material: PolylineMaterialHandle(material.clone()),
                         ..default()
                     },
                     DisableXray,

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -78,14 +78,14 @@ impl InteractionAssets {
         scale: f32,
     ) -> Entity {
         let child_entity = commands
-            .spawn(PbrBundle {
-                transform: Transform::from_rotation(rotation)
+            .spawn((
+                Transform::from_rotation(rotation)
                     .with_translation(offset)
                     .with_scale(Vec3::splat(scale)),
-                mesh: self.arrow_mesh.clone(),
-                material: material_set.passive.clone(),
-                ..default()
-            })
+                Mesh3d(self.arrow_mesh.clone()),
+                MeshMaterial3d(material_set.passive.clone()),
+                Visibility::default(),
+            ))
             .set_parent(parent)
             .id();
 
@@ -128,7 +128,7 @@ impl InteractionAssets {
         cue: &mut AnchorVisualization,
     ) {
         let drag_parent = commands
-            .spawn(SpatialBundle::default())
+            .spawn((Transform::default(), Visibility::default()))
             .insert(VisualCue::no_outline().irregular().always_xray())
             .set_parent(anchor)
             .id();
@@ -173,7 +173,7 @@ impl InteractionAssets {
         draggable: bool,
     ) {
         let drag_parent = commands
-            .spawn(SpatialBundle::default())
+            .spawn((Transform::default(), Visibility::default()))
             .insert(VisualCue::no_outline().irregular().always_xray())
             .id();
         commands.entity(anchor).add_child(drag_parent);

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -16,12 +16,12 @@
 */
 
 use crate::{interaction::*, shapes::*};
-use bevy::{math::Affine3A, prelude::*};
+use bevy::color::palettes::css as Colors;
+use bevy::{math::primitives, math::Affine3A, prelude::*};
 use bevy_polyline::{
     material::PolylineMaterial,
     polyline::{Polyline, PolylineBundle},
 };
-use shape::UVSphere;
 
 #[derive(Clone, Debug, Resource)]
 pub struct InteractionAssets {
@@ -231,47 +231,36 @@ impl FromWorld for InteractionAssets {
         let mut meshes = world.get_resource_mut::<Assets<Mesh>>().unwrap();
         let dagger_mesh = meshes.add(make_dagger_mesh());
         let halo_mesh = meshes.add(make_halo_mesh());
-        let camera_control_mesh = meshes.add(Mesh::from(UVSphere {
-            radius: 0.02,
-            ..Default::default()
-        }));
+        let camera_control_mesh = meshes.add(Mesh::from(primitives::Sphere::new(0.02)));
         let arrow_mesh = meshes.add(make_cylinder_arrow_mesh());
         let point_light_socket_mesh = meshes.add(
-            make_cylinder(0.06, 0.02)
-                .transform_by(Affine3A::from_translation(0.04 * Vec3::Z))
-                .into(),
+            make_cylinder(0.06, 0.02).transform_by(Affine3A::from_translation(0.04 * Vec3::Z)),
         );
-        let point_light_shine_mesh = meshes.add(Mesh::from(shape::UVSphere {
-            radius: 0.05,
-            ..Default::default()
-        }));
-        let spot_light_cover_mesh = meshes.add(
-            make_smooth_wrap(
-                [
-                    Circle {
-                        radius: 0.05,
-                        height: 0.0,
-                    },
-                    Circle {
-                        radius: 0.01,
-                        height: 0.04,
-                    },
-                ],
-                32,
-            )
-            .into(),
-        );
+        let point_light_shine_mesh = meshes.add(Mesh::from(primitives::Sphere::new(0.05)));
+        let spot_light_cover_mesh = meshes.add(make_smooth_wrap(
+            [
+                OffsetCircle {
+                    radius: 0.05,
+                    height: 0.0,
+                },
+                OffsetCircle {
+                    radius: 0.01,
+                    height: 0.04,
+                },
+            ],
+            32,
+        ));
         let spot_light_shine_mesh = meshes.add(
             Mesh::from(
                 make_bottom_circle(
-                    Circle {
+                    OffsetCircle {
                         radius: 0.05,
                         height: 0.0,
                     },
                     32,
                 )
                 .merge_with(make_top_circle(
-                    Circle {
+                    OffsetCircle {
                         radius: 0.01,
                         height: 0.04,
                     },
@@ -300,7 +289,7 @@ impl FromWorld for InteractionAssets {
             .get_resource_mut::<Assets<StandardMaterial>>()
             .unwrap();
         let halo_material = materials.add(StandardMaterial {
-            base_color: Color::WHITE,
+            base_color: Colors::WHITE.into(),
             alpha_mode: AlphaMode::Blend,
             unlit: true,
             perceptual_roughness: 0.089,
@@ -308,26 +297,26 @@ impl FromWorld for InteractionAssets {
             ..default()
         });
         let dagger_material = materials.add(StandardMaterial {
-            base_color: Color::WHITE,
-            emissive: Color::WHITE,
+            base_color: Colors::WHITE.into(),
+            emissive: Colors::WHITE.into(),
             perceptual_roughness: 0.089,
             metallic: 0.01,
             ..default()
         });
         let camera_control_orbit_material = materials.add(StandardMaterial {
-            base_color: Color::GREEN,
-            emissive: Color::GREEN,
+            base_color: Colors::GREEN.into(),
+            emissive: Colors::LIME.into(),
             depth_bias: f32::MAX,
             unlit: true,
             ..default()
         });
         let camera_control_pan_material = materials.add(StandardMaterial {
-            base_color: Color::WHITE,
-            emissive: Color::WHITE,
+            base_color: Colors::WHITE.into(),
+            emissive: Colors::WHITE.into(),
             unlit: true,
             ..default()
         });
-        let light_cover_color = Color::rgb(0.6, 0.7, 0.8);
+        let light_cover_color = Color::srgb(0.6, 0.7, 0.8);
         let physical_light_cover_material = materials.add(StandardMaterial {
             base_color: light_cover_color,
             perceptual_roughness: 0.089,
@@ -347,7 +336,7 @@ impl FromWorld for InteractionAssets {
         let z_plane_materials = GizmoMaterialSet::make_z_plane(&mut materials);
         let lift_doormat_available_materials = GizmoMaterialSet {
             passive: materials.add(StandardMaterial {
-                base_color: Color::rgba(0.1, 0.9, 0.1, 0.1),
+                base_color: Color::srgba(0.1, 0.9, 0.1, 0.1),
                 alpha_mode: AlphaMode::Blend,
                 unlit: true,
                 perceptual_roughness: 0.089,
@@ -355,7 +344,7 @@ impl FromWorld for InteractionAssets {
                 ..default()
             }),
             hover: materials.add(StandardMaterial {
-                base_color: Color::rgba(0.1, 0.9, 0.1, 0.9),
+                base_color: Color::srgba(0.1, 0.9, 0.1, 0.9),
                 alpha_mode: AlphaMode::Blend,
                 unlit: true,
                 perceptual_roughness: 0.089,
@@ -363,7 +352,7 @@ impl FromWorld for InteractionAssets {
                 ..default()
             }),
             drag: materials.add(StandardMaterial {
-                base_color: Color::rgba(0.1, 0.9, 0.1, 0.9),
+                base_color: Color::srgba(0.1, 0.9, 0.1, 0.9),
                 alpha_mode: AlphaMode::Blend,
                 unlit: true,
                 perceptual_roughness: 0.089,
@@ -373,7 +362,7 @@ impl FromWorld for InteractionAssets {
         };
         let lift_doormat_unavailable_materials = GizmoMaterialSet {
             passive: materials.add(StandardMaterial {
-                base_color: Color::rgba(0.9, 0.1, 0.1, 0.1),
+                base_color: Color::srgba(0.9, 0.1, 0.1, 0.1),
                 alpha_mode: AlphaMode::Blend,
                 unlit: true,
                 perceptual_roughness: 0.089,
@@ -381,7 +370,7 @@ impl FromWorld for InteractionAssets {
                 ..default()
             }),
             hover: materials.add(StandardMaterial {
-                base_color: Color::rgba(0.9, 0.1, 0.1, 0.9),
+                base_color: Color::srgba(0.9, 0.1, 0.1, 0.9),
                 alpha_mode: AlphaMode::Blend,
                 unlit: true,
                 perceptual_roughness: 0.089,
@@ -389,7 +378,7 @@ impl FromWorld for InteractionAssets {
                 ..default()
             }),
             drag: materials.add(StandardMaterial {
-                base_color: Color::rgba(0.9, 0.1, 0.1, 0.9),
+                base_color: Color::srgba(0.9, 0.1, 0.1, 0.9),
                 alpha_mode: AlphaMode::Blend,
                 unlit: true,
                 perceptual_roughness: 0.089,
@@ -400,7 +389,7 @@ impl FromWorld for InteractionAssets {
 
         let centimeter_finite_grid = {
             let (polylines, polyline_mats): (Vec<_>, Vec<_>) =
-                make_metric_finite_grid(0.01, 100, Color::WHITE)
+                make_metric_finite_grid(0.01, 100, Colors::WHITE.into())
                     .into_iter()
                     .unzip();
             let mut polyline_assets = world.get_resource_mut::<Assets<Polyline>>().unwrap();

--- a/rmf_site_editor/src/interaction/assets.rs
+++ b/rmf_site_editor/src/interaction/assets.rs
@@ -18,7 +18,7 @@
 use crate::{interaction::*, shapes::*};
 use bevy::color::palettes::css as Colors;
 use bevy::{math::primitives, math::Affine3A, prelude::*};
-use bevy_polyline::prelude::PolylineMaterialHandle;
+use bevy_polyline::prelude::{PolylineHandle, PolylineMaterialHandle};
 use bevy_polyline::{
     material::PolylineMaterial,
     polyline::{Polyline, PolylineBundle},
@@ -206,7 +206,7 @@ impl InteractionAssets {
             for (polyline, material) in &self.centimeter_finite_grid {
                 parent.spawn((
                     PolylineBundle {
-                        polyline: polyline.clone(),
+                        polyline: PolylineHandle(polyline.clone()),
                         material: PolylineMaterialHandle(material.clone()),
                         ..default()
                     },

--- a/rmf_site_editor/src/interaction/camera_controls/cursor.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/cursor.rs
@@ -132,7 +132,7 @@ pub fn update_cursor_command(
             Some(selection) => selection,
             None => cursor_selection_new,
         };
-        let cursor_direction = cursor_ray.direction.clone().normalize();
+        let cursor_direction = cursor_ray.direction.normalize();
         let cursor_direction_camera_frame = camera_transform.rotation.inverse() * cursor_direction;
         let cursor_direction_camera_frame_prev = cursor_command
             .cursor_direction_camera_frame
@@ -375,9 +375,9 @@ fn get_cursor_selected_point(
     match cursor_raycast_source.get_nearest_intersection() {
         Some((_, intersection)) => intersection.position(),
         None => get_groundplane_else_default_selection(
-            cursor_ray.origin.clone(),
-            cursor_ray.direction.as_vec3(),
-            camera_transform.forward().as_vec3(),
+            cursor_ray.origin,
+            *cursor_ray.direction,
+            *camera_transform.forward(),
         ),
     }
 }

--- a/rmf_site_editor/src/interaction/camera_controls/cursor.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/cursor.rs
@@ -77,8 +77,8 @@ pub fn update_cursor_command(
     mut camera_controls: ResMut<CameraControls>,
     mut cursor_command: ResMut<CursorCommand>,
     mut mouse_wheel: EventReader<MouseWheel>,
-    mouse_input: Res<Input<MouseButton>>,
-    keyboard_input: Res<Input<KeyCode>>,
+    mouse_input: Res<ButtonInput<MouseButton>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
     raycast_sources: Query<&RaycastSource<SiteRaycastSet>>,
     cameras: Query<(&Projection, &Transform, &GlobalTransform)>,
     primary_windows: Query<&Window, With<PrimaryWindow>>,
@@ -132,7 +132,7 @@ pub fn update_cursor_command(
             Some(selection) => selection,
             None => cursor_selection_new,
         };
-        let cursor_direction = cursor_ray.direction().normalize();
+        let cursor_direction = cursor_ray.direction.clone().normalize();
         let cursor_direction_camera_frame = camera_transform.rotation.inverse() * cursor_direction;
         let cursor_direction_camera_frame_prev = cursor_command
             .cursor_direction_camera_frame
@@ -375,16 +375,16 @@ fn get_cursor_selected_point(
     match cursor_raycast_source.get_nearest_intersection() {
         Some((_, intersection)) => intersection.position(),
         None => get_groundplane_else_default_selection(
-            cursor_ray.origin(),
-            cursor_ray.direction(),
-            camera_transform.forward(),
+            cursor_ray.origin.clone(),
+            cursor_ray.direction.as_vec3(),
+            camera_transform.forward().as_vec3(),
         ),
     }
 }
 
 fn get_command_type(
-    keyboard_input: &Res<Input<KeyCode>>,
-    mouse_input: &Res<Input<MouseButton>>,
+    keyboard_input: &Res<ButtonInput<KeyCode>>,
+    mouse_input: &Res<ButtonInput<MouseButton>>,
     scroll_motion: &f32,
     projection_mode: ProjectionMode,
 ) -> CameraCommandType {

--- a/rmf_site_editor/src/interaction/camera_controls/cursor.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/cursor.rs
@@ -124,20 +124,15 @@ pub fn update_cursor_command(
         // Get selection under cursor, cursor direction
         let Some((_, cursor_ray)) = ray_map
             .iter()
-            .find(|(id, ray)| id.camera == active_camera_entity && id.pointer.is_mouse())
+            .find(|(id, _)| id.camera == active_camera_entity)
         else {
             return;
         };
-        let Some((_, hit_data)) = pointers
-            .get_single()
-            .ok()
-            .filter(|(id, _)| id.is_mouse())
-            .and_then(|(_, interactions)| {
-                interactions
-                    .iter()
-                    .find(|(_, hit)| hit.camera == active_camera_entity)
-            })
-        else {
+        let Some((_, hit_data)) = pointers.get_single().ok().and_then(|(_, interactions)| {
+            interactions
+                .iter()
+                .find(|(_, hit)| hit.camera == active_camera_entity)
+        }) else {
             return;
         };
         let cursor_selection_new =

--- a/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
@@ -80,7 +80,7 @@ impl KeyboardCommand {
 pub fn update_keyboard_command(
     mut camera_controls: ResMut<CameraControls>,
     mut keyboard_command: ResMut<KeyboardCommand>,
-    keyboard_input: Res<Input<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
     cameras: Query<(&Camera, &Projection, &Transform, &GlobalTransform)>,
     immediate_raycast: Raycast,
     time: Res<Time>,
@@ -92,16 +92,16 @@ pub fn update_keyboard_command(
         let is_shifting = keyboard_input.pressed(KeyCode::ShiftLeft)
             || keyboard_input.pressed(KeyCode::ShiftRight);
         let mut target_keyboard_motion = Vec2::ZERO;
-        if keyboard_input.pressed(KeyCode::Up) {
+        if keyboard_input.pressed(KeyCode::ArrowUp) {
             target_keyboard_motion.y += 1.0;
         }
-        if keyboard_input.pressed(KeyCode::Left) {
+        if keyboard_input.pressed(KeyCode::ArrowLeft) {
             target_keyboard_motion.x += -1.0;
         }
-        if keyboard_input.pressed(KeyCode::Down) {
+        if keyboard_input.pressed(KeyCode::ArrowDown) {
             target_keyboard_motion.y += -1.0;
         }
-        if keyboard_input.pressed(KeyCode::Right) {
+        if keyboard_input.pressed(KeyCode::ArrowRight) {
             target_keyboard_motion.x += 1.0;
         }
         if target_keyboard_motion.length() > 0.0 {

--- a/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/keyboard.rs
@@ -20,8 +20,7 @@ use super::{
     MIN_SCALE,
 };
 use crate::widgets::UserCameraDisplay;
-use bevy::{prelude::*, window::PrimaryWindow};
-use bevy_mod_raycast::immediate::Raycast;
+use bevy::{picking::mesh_picking::ray_cast::MeshRayCast, prelude::*, window::PrimaryWindow};
 
 // Keyboard control limits
 pub const MIN_RESPONSE_TIME: f32 = 0.25; // [s] time taken to reach minimum input, or to reset
@@ -82,7 +81,7 @@ pub fn update_keyboard_command(
     mut keyboard_command: ResMut<KeyboardCommand>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
     cameras: Query<(&Camera, &Projection, &Transform, &GlobalTransform)>,
-    immediate_raycast: Raycast,
+    mesh_ray_cast: MeshRayCast,
     time: Res<Time>,
     primary_windows: Query<&Window, With<PrimaryWindow>>,
     uncovered_window_area: Option<Res<UserCameraDisplay>>,
@@ -117,7 +116,7 @@ pub fn update_keyboard_command(
         }
 
         // Smooth and normalize keyboard
-        let delta_seconds = time.delta_seconds();
+        let delta_seconds = time.delta_secs();
         let prev_keyboard_motion = keyboard_command.keyboard_motion;
         let keyboard_motion_delta =
             (target_keyboard_motion - prev_keyboard_motion).normalize_or_zero();
@@ -192,7 +191,7 @@ pub fn update_keyboard_command(
                 &camera,
                 &camera_global_transform,
                 uncovered_window_area,
-                immediate_raycast,
+                mesh_ray_cast,
             ),
         };
 

--- a/rmf_site_editor/src/interaction/camera_controls/mod.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/mod.rs
@@ -16,12 +16,11 @@
 */
 use crate::interaction::{InteractionAssets, PickingBlockers};
 use bevy::{
-    core_pipeline::{
-        clear_color::ClearColorConfig, core_3d::Camera3dBundle, tonemapping::Tonemapping,
-    },
+    color::palettes::css as Colors,
+    core_pipeline::{core_3d::Camera3dBundle, tonemapping::Tonemapping},
     prelude::*,
     render::{
-        camera::{Camera, Projection, ScalingMode},
+        camera::{Camera, ClearColorConfig, Projection, ScalingMode},
         view::RenderLayers,
     },
 };
@@ -285,7 +284,7 @@ impl FromWorld for CameraControls {
                     visibility: Visibility::Inherited,
                     ..default()
                 })
-                .insert(RenderLayers::layer(layer))
+                .insert(RenderLayers::layer(layer.into()))
                 .id()
         });
 
@@ -301,8 +300,8 @@ impl FromWorld for CameraControls {
                 ..default()
             })
             .insert(RenderLayers::from_layers(&[
-                GENERAL_RENDER_LAYER,
-                VISUAL_CUE_RENDER_LAYER,
+                GENERAL_RENDER_LAYER.into(),
+                VISUAL_CUE_RENDER_LAYER.into(),
             ]))
             .push_children(&[perspective_headlight])
             .push_children(&perspective_child_cameras)
@@ -355,7 +354,7 @@ impl FromWorld for CameraControls {
                     visibility: Visibility::Inherited,
                     ..default()
                 })
-                .insert(RenderLayers::layer(layer))
+                .insert(RenderLayers::layer(layer.into()))
                 .id()
         });
 
@@ -375,8 +374,8 @@ impl FromWorld for CameraControls {
                 ..default()
             })
             .insert(RenderLayers::from_layers(&[
-                GENERAL_RENDER_LAYER,
-                VISUAL_CUE_RENDER_LAYER,
+                GENERAL_RENDER_LAYER.into(),
+                VISUAL_CUE_RENDER_LAYER.into(),
             ]))
             .push_children(&[orthographic_headlight])
             .push_children(&orthographic_child_cameras)
@@ -522,7 +521,7 @@ fn update_orbit_center_marker(
                 *marker_visibility = Visibility::Visible;
                 *marker_material = interaction_assets.camera_control_orbit_material.clone();
                 marker_transform.translation = orbit_center;
-                gizmo.sphere(orbit_center, Quat::IDENTITY, 0.1, Color::GREEN);
+                gizmo.sphere(orbit_center, Quat::IDENTITY, 0.1, Colors::LIME);
             }
         // Panning
         } else if cursor_command.command_type == CameraCommandType::Pan {
@@ -530,7 +529,7 @@ fn update_orbit_center_marker(
                 *marker_visibility = Visibility::Visible;
                 *marker_material = interaction_assets.camera_control_pan_material.clone();
                 marker_transform.translation = cursor_selection;
-                gizmo.sphere(cursor_selection, Quat::IDENTITY, 0.1, Color::WHITE);
+                gizmo.sphere(cursor_selection, Quat::IDENTITY, 0.1, Colors::WHITE);
             }
         } else {
             *marker_visibility = Visibility::Hidden;

--- a/rmf_site_editor/src/interaction/camera_controls/mod.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/mod.rs
@@ -17,7 +17,7 @@
 use crate::interaction::{InteractionAssets, PickingBlockers};
 use bevy::{
     color::palettes::css as Colors,
-    core_pipeline::{core_3d::Camera3dBundle, tonemapping::Tonemapping},
+    core_pipeline::tonemapping::Tonemapping,
     prelude::*,
     render::{
         camera::{Camera, ClearColorConfig, Exposure, Projection, ScalingMode},
@@ -261,20 +261,18 @@ impl FromWorld for CameraControls {
         );
         let selection_mesh = interaction_assets.camera_control_mesh.clone();
         let selection_marker = world
-            .spawn(PbrBundle {
-                mesh: selection_mesh,
-                visibility: Visibility::Visible,
-                ..default()
-            })
+            .spawn((
+                Mesh3d(selection_mesh),
+                Visibility::Visible,
+                Transform::default(),
+                MeshMaterial3d::default(),
+            ))
             .id();
 
         let perspective_headlight = world
-            .spawn(DirectionalLightBundle {
-                directional_light: DirectionalLight {
-                    shadows_enabled: false,
-                    illuminance: 50.,
-                    ..default()
-                },
+            .spawn(DirectionalLight {
+                shadows_enabled: false,
+                illuminance: 20000.,
                 ..default()
             })
             .insert(main_view_render_layers())
@@ -287,41 +285,35 @@ impl FromWorld for CameraControls {
         ]
         .map(|(order, layer)| {
             world
-                .spawn(Camera3dBundle {
-                    projection: Projection::Perspective(Default::default()),
-                    camera: Camera {
+                .spawn(Camera3d::default())
+                .insert((
+                    Projection::Perspective(Default::default()),
+                    Camera {
                         order,
                         clear_color: ClearColorConfig::None,
                         ..default()
                     },
-                    tonemapping: Tonemapping::ReinhardLuminance,
-                    exposure: Exposure {
+                    Tonemapping::ReinhardLuminance,
+                    Exposure {
                         ev100: DEFAULT_CAMERA_EV100,
                     },
-                    ..default()
-                })
-                .insert(VisibilityBundle {
-                    visibility: Visibility::Inherited,
-                    ..default()
-                })
+                ))
+                .insert(Visibility::Inherited)
                 .insert(RenderLayers::layer(layer.into()))
                 .id()
         });
 
         let perspective_base_camera = world
-            .spawn(Camera3dBundle {
-                transform: Transform::from_xyz(-10., -10., 10.).looking_at(Vec3::ZERO, Vec3::Z),
-                projection: Projection::Perspective(Default::default()),
-                exposure: Exposure {
+            .spawn(Camera3d::default())
+            .insert((
+                Transform::from_xyz(-10., -10., 10.).looking_at(Vec3::ZERO, Vec3::Z),
+                Projection::Perspective(Default::default()),
+                Exposure {
                     ev100: DEFAULT_CAMERA_EV100,
                 },
-                tonemapping: Tonemapping::ReinhardLuminance,
-                ..default()
-            })
-            .insert(VisibilityBundle {
-                visibility: Visibility::Inherited,
-                ..default()
-            })
+                Tonemapping::ReinhardLuminance,
+            ))
+            .insert(Visibility::Inherited)
             .insert(RenderLayers::from_layers(&[
                 GENERAL_RENDER_LAYER.into(),
                 VISUAL_CUE_RENDER_LAYER.into(),
@@ -331,18 +323,17 @@ impl FromWorld for CameraControls {
             .id();
 
         let orthographic_headlight = world
-            .spawn(DirectionalLightBundle {
-                transform: Transform::from_rotation(Quat::from_axis_angle(
+            .spawn((
+                DirectionalLight {
+                    shadows_enabled: false,
+                    illuminance: 20000.,
+                    ..default()
+                },
+                Transform::from_rotation(Quat::from_axis_angle(
                     Vec3::new(1., 1., 0.).normalize(),
                     35_f32.to_radians(),
                 )),
-                directional_light: DirectionalLight {
-                    shadows_enabled: false,
-                    illuminance: 50.,
-                    ..default()
-                },
-                ..default()
-            })
+            ))
             .insert(main_view_render_layers())
             .id();
 
@@ -360,46 +351,40 @@ impl FromWorld for CameraControls {
         ]
         .map(|(order, layer)| {
             world
-                .spawn(Camera3dBundle {
-                    camera: Camera {
+                .spawn(Camera3d::default())
+                .insert((
+                    Camera {
                         is_active: false,
                         order,
                         clear_color: ClearColorConfig::None,
                         ..default()
                     },
-                    projection: Projection::Orthographic(ortho_projection.clone()),
-                    exposure: Exposure {
+                    Projection::Orthographic(ortho_projection.clone()),
+                    Exposure {
                         ev100: DEFAULT_CAMERA_EV100,
                     },
-                    tonemapping: Tonemapping::ReinhardLuminance,
-                    ..default()
-                })
-                .insert(VisibilityBundle {
-                    visibility: Visibility::Inherited,
-                    ..default()
-                })
+                    Tonemapping::ReinhardLuminance,
+                ))
+                .insert(Visibility::Inherited)
                 .insert(RenderLayers::layer(layer.into()))
                 .id()
         });
 
         let orthographic_camera_entity = world
-            .spawn(Camera3dBundle {
-                camera: Camera {
+            .spawn(Camera3d::default())
+            .insert((
+                Camera {
                     is_active: false,
                     ..default()
                 },
-                transform: Transform::from_xyz(0., 0., 20.).looking_at(Vec3::ZERO, Vec3::Y),
-                projection: Projection::Orthographic(ortho_projection),
-                exposure: Exposure {
+                Transform::from_xyz(0., 0., 20.).looking_at(Vec3::ZERO, Vec3::Y),
+                Projection::Orthographic(ortho_projection),
+                Exposure {
                     ev100: DEFAULT_CAMERA_EV100,
                 },
-                tonemapping: Tonemapping::ReinhardLuminance,
-                ..default()
-            })
-            .insert(VisibilityBundle {
-                visibility: Visibility::Inherited,
-                ..default()
-            })
+                Tonemapping::ReinhardLuminance,
+            ))
+            .insert(Visibility::Inherited)
             .insert(RenderLayers::from_layers(&[
                 GENERAL_RENDER_LAYER.into(),
                 VISUAL_CUE_RENDER_LAYER.into(),

--- a/rmf_site_editor/src/interaction/camera_controls/mod.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/mod.rs
@@ -265,7 +265,7 @@ impl FromWorld for CameraControls {
                 Mesh3d(selection_mesh),
                 Visibility::Visible,
                 Transform::default(),
-                MeshMaterial3d::default(),
+                MeshMaterial3d::<StandardMaterial>::default(),
             ))
             .id();
 
@@ -522,7 +522,7 @@ fn update_orbit_center_marker(
         (
             &mut Transform,
             &mut Visibility,
-            &mut Handle<StandardMaterial>,
+            &mut MeshMaterial3d<StandardMaterial>,
         ),
         Without<Projection>,
     >,
@@ -537,7 +537,8 @@ fn update_orbit_center_marker(
         {
             if let Some(orbit_center) = controls.orbit_center {
                 *marker_visibility = Visibility::Visible;
-                *marker_material = interaction_assets.camera_control_orbit_material.clone();
+                *marker_material =
+                    MeshMaterial3d(interaction_assets.camera_control_orbit_material.clone());
                 marker_transform.translation = orbit_center;
                 gizmo.sphere(orbit_center, Quat::IDENTITY, 0.1, Colors::LIME);
             }
@@ -545,7 +546,8 @@ fn update_orbit_center_marker(
         } else if cursor_command.command_type == CameraCommandType::Pan {
             if let Some(cursor_selection) = cursor_command.cursor_selection {
                 *marker_visibility = Visibility::Visible;
-                *marker_material = interaction_assets.camera_control_pan_material.clone();
+                *marker_material =
+                    MeshMaterial3d(interaction_assets.camera_control_pan_material.clone());
                 marker_transform.translation = cursor_selection;
                 gizmo.sphere(cursor_selection, Quat::IDENTITY, 0.1, Colors::WHITE);
             }

--- a/rmf_site_editor/src/interaction/camera_controls/mod.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/mod.rs
@@ -294,7 +294,6 @@ impl FromWorld for CameraControls {
                         clear_color: ClearColorConfig::None,
                         ..default()
                     },
-                    camera_3d: Camera3d::default(),
                     tonemapping: Tonemapping::ReinhardLuminance,
                     exposure: Exposure {
                         ev100: DEFAULT_CAMERA_EV100,
@@ -368,7 +367,6 @@ impl FromWorld for CameraControls {
                         clear_color: ClearColorConfig::None,
                         ..default()
                     },
-                    camera_3d: Camera3d::default(),
                     projection: Projection::Orthographic(ortho_projection.clone()),
                     exposure: Exposure {
                         ev100: DEFAULT_CAMERA_EV100,
@@ -497,7 +495,7 @@ fn camera_controls(
 
             // Ensure upright
             let forward = persp_transform.forward();
-            persp_transform.look_to(forward, Vec3::Z);
+            persp_transform.look_to(*forward, Vec3::Z);
         }
 
         let proj = persp_proj.clone();

--- a/rmf_site_editor/src/interaction/camera_controls/mod.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/mod.rs
@@ -62,7 +62,7 @@ pub const MODEL_PREVIEW_LAYER: u8 = 6;
 
 // Creates all the layers visible in the main camera view (excluding, for example
 // the model preview which is on a separate view). The main lights will affect these.
-fn main_view_render_layers() -> RenderLayers {
+pub fn main_view_render_layers() -> RenderLayers {
     RenderLayers::from_layers(&[
         GENERAL_RENDER_LAYER.into(),
         PHYSICAL_RENDER_LAYER.into(),

--- a/rmf_site_editor/src/interaction/camera_controls/mod.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/mod.rs
@@ -272,11 +272,12 @@ impl FromWorld for CameraControls {
             world
                 .spawn(Camera3dBundle {
                     projection: Projection::Perspective(Default::default()),
-                    camera: Camera { order, ..default() },
-                    camera_3d: Camera3d {
+                    camera: Camera {
+                        order,
                         clear_color: ClearColorConfig::None,
                         ..default()
                     },
+                    camera_3d: Camera3d::default(),
                     tonemapping: Tonemapping::ReinhardLuminance,
                     ..default()
                 })
@@ -340,12 +341,10 @@ impl FromWorld for CameraControls {
                     camera: Camera {
                         is_active: false,
                         order,
-                        ..default()
-                    },
-                    camera_3d: Camera3d {
                         clear_color: ClearColorConfig::None,
                         ..default()
                     },
+                    camera_3d: Camera3d::default(),
                     projection: Projection::Orthographic(ortho_projection.clone()),
                     tonemapping: Tonemapping::ReinhardLuminance,
                     ..default()

--- a/rmf_site_editor/src/interaction/camera_controls/utils.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/utils.rs
@@ -94,9 +94,9 @@ pub fn get_camera_selected_point(
         return Some(intersection_data.position());
     } else {
         return Some(get_groundplane_else_default_selection(
-            camera_ray.origin.clone(),
-            camera_ray.direction.as_vec3(),
-            camera_ray.direction.as_vec3(),
+            camera_ray.origin,
+            *camera_ray.direction,
+            *camera_ray.direction,
         ));
     }
 }

--- a/rmf_site_editor/src/interaction/camera_controls/utils.rs
+++ b/rmf_site_editor/src/interaction/camera_controls/utils.rs
@@ -15,11 +15,9 @@
  *
 */
 
+use bevy::math::Ray3d;
 use bevy::prelude::*;
-use bevy_mod_raycast::{
-    immediate::{Raycast, RaycastSettings, RaycastVisibility},
-    primitives::Ray3d,
-};
+use bevy_mod_raycast::immediate::{Raycast, RaycastSettings, RaycastVisibility};
 
 use super::{MAX_PITCH, MAX_SELECTION_DIST, MIN_SELECTION_DIST};
 use crate::UserCameraDisplay;
@@ -84,7 +82,7 @@ pub fn get_camera_selected_point(
 
     let camera_ray =
         camera.viewport_to_world(camera_global_transform, available_viewport_center)?;
-    let camera_ray = Ray3d::new(camera_ray.origin, camera_ray.direction);
+    let camera_ray = Ray3d::new(camera_ray.origin, camera_ray.direction.as_vec3());
     let raycast_setting = RaycastSettings::default()
         .always_early_exit()
         .with_visibility(RaycastVisibility::MustBeVisible);
@@ -96,9 +94,9 @@ pub fn get_camera_selected_point(
         return Some(intersection_data.position());
     } else {
         return Some(get_groundplane_else_default_selection(
-            camera_ray.origin(),
-            camera_ray.direction(),
-            camera_ray.direction(),
+            camera_ray.origin.clone(),
+            camera_ray.direction.as_vec3(),
+            camera_ray.direction.as_vec3(),
         ));
     }
 }

--- a/rmf_site_editor/src/interaction/category_visibility.rs
+++ b/rmf_site_editor/src/interaction/category_visibility.rs
@@ -104,10 +104,7 @@ fn set_category_visibility_for_new_entity<T: Component + Clone + Debug>(
         if let Some(mut vis) = vis {
             *vis = visibility;
         } else {
-            commands.entity(e).insert(VisibilityBundle {
-                visibility,
-                ..default()
-            });
+            commands.entity(e).insert(visibility);
         }
     }
 }

--- a/rmf_site_editor/src/interaction/cursor.rs
+++ b/rmf_site_editor/src/interaction/cursor.rs
@@ -162,24 +162,23 @@ impl FromWorld for Cursor {
         let preview_frame_material = site_assets.preview_anchor_material.clone();
 
         let halo = world
-            .spawn(PbrBundle {
-                transform: Transform::from_scale([0.2, 0.2, 1.].into()),
-                mesh: halo_mesh,
-                material: halo_material,
-                visibility: Visibility::Inherited,
-                ..default()
-            })
+            .spawn((
+                Transform::from_scale([0.2, 0.2, 1.].into()),
+                Mesh3d(halo_mesh),
+                MeshMaterial3d(halo_material),
+                Visibility::Inherited,
+            ))
             .insert(Spinning::default())
             .insert(VisualCue::no_outline())
             .id();
 
         let dagger = world
-            .spawn(PbrBundle {
-                mesh: dagger_mesh,
-                material: dagger_material,
-                visibility: Visibility::Inherited,
-                ..default()
-            })
+            .spawn((
+                Mesh3d(dagger_mesh),
+                MeshMaterial3d(dagger_material),
+                Transform::default(),
+                Visibility::Inherited,
+            ))
             .insert(Spinning::default())
             .insert(Bobbing::default())
             .insert(VisualCue::no_outline())
@@ -191,11 +190,12 @@ impl FromWorld for Cursor {
             .insert(Preview)
             .insert(VisualCue::no_outline())
             .with_children(|parent| {
-                parent.spawn(PbrBundle {
-                    mesh: level_anchor_mesh,
-                    material: preview_anchor_material.clone(),
-                    ..default()
-                });
+                parent.spawn((
+                    Mesh3d(level_anchor_mesh),
+                    MeshMaterial3d(preview_anchor_material.clone()),
+                    Transform::default(),
+                    Visibility::default(),
+                ));
             })
             .id();
 
@@ -205,11 +205,12 @@ impl FromWorld for Cursor {
             .insert(Preview)
             .insert(VisualCue::no_outline())
             .with_children(|parent| {
-                parent.spawn(PbrBundle {
-                    mesh: site_anchor_mesh,
-                    material: preview_anchor_material,
-                    ..default()
-                });
+                parent.spawn((
+                    Mesh3d(site_anchor_mesh),
+                    MeshMaterial3d(preview_anchor_material),
+                    Transform::default(),
+                    Visibility::default(),
+                ));
             })
             .id();
 
@@ -219,12 +220,12 @@ impl FromWorld for Cursor {
             .insert(Preview)
             .insert(VisualCue::no_outline())
             .with_children(|parent| {
-                parent.spawn(PbrBundle {
-                    mesh: frame_mesh,
-                    material: preview_frame_material,
-                    transform: Transform::from_scale(Vec3::new(0.2, 0.2, 0.2)),
-                    ..default()
-                });
+                parent.spawn((
+                    Mesh3d(frame_mesh),
+                    MeshMaterial3d(preview_frame_material),
+                    Transform::from_scale(Vec3::new(0.2, 0.2, 0.2)),
+                    Visibility::default(),
+                ));
             })
             .id();
 
@@ -237,10 +238,7 @@ impl FromWorld for Cursor {
                 site_anchor_placement,
                 frame_placement,
             ])
-            .insert(SpatialBundle {
-                visibility: Visibility::Hidden,
-                ..default()
-            })
+            .insert((Transform::default(), Visibility::Hidden))
             .id();
 
         Self {

--- a/rmf_site_editor/src/interaction/cursor.rs
+++ b/rmf_site_editor/src/interaction/cursor.rs
@@ -20,9 +20,7 @@ use crate::{
     interaction::*,
     site::{AnchorBundle, ModelLoader, Pending, SiteAssets},
 };
-use bevy::{
-    ecs::system::SystemParam, picking::backend::ray::RayMap, prelude::*, window::PrimaryWindow,
-};
+use bevy::{ecs::system::SystemParam, picking::backend::ray::RayMap, prelude::*};
 
 use rmf_site_format::{FloorMarker, ModelInstance, WallMarker};
 use std::collections::HashSet;
@@ -265,11 +263,8 @@ pub struct Preview;
 
 #[derive(SystemParam)]
 pub struct IntersectGroundPlaneParams<'w, 's> {
-    primary_windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     camera_controls: Res<'w, CameraControls>,
-    cameras: Query<'w, 's, &'static Camera>,
     global_transforms: Query<'w, 's, &'static GlobalTransform>,
-    primary_window: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     ray_map: Res<'w, RayMap>,
 }
 
@@ -291,12 +286,7 @@ impl<'w, 's> IntersectGroundPlaneParams<'w, 's> {
         plane_origin: Vec3,
         plane: InfinitePlane3d,
     ) -> Option<Transform> {
-        let window = self.primary_windows.get_single().ok()?;
-        let cursor_position = window.cursor_position()?;
         let e_active_camera = self.camera_controls.active_camera();
-        let active_camera = self.cameras.get(e_active_camera).ok()?;
-        let camera_tf = self.global_transforms.get(e_active_camera).ok()?;
-        let primary_window = self.primary_window.get_single().ok()?;
 
         let (_, ray) = self
             .ray_map

--- a/rmf_site_editor/src/interaction/cursor.rs
+++ b/rmf_site_editor/src/interaction/cursor.rs
@@ -21,7 +21,7 @@ use crate::{
     site::{AnchorBundle, ModelLoader, Pending, SiteAssets},
 };
 use bevy::{ecs::system::SystemParam, prelude::*, window::PrimaryWindow};
-use bevy_mod_raycast::primitives::{rays::Ray3d, Primitive3d};
+use bevy_mod_raycast::primitives::rays;
 
 use rmf_site_format::{FloorMarker, ModelInstance, WallMarker};
 use std::collections::HashSet;
@@ -275,22 +275,22 @@ pub struct IntersectGroundPlaneParams<'w, 's> {
 
 impl<'w, 's> IntersectGroundPlaneParams<'w, 's> {
     pub fn ground_plane_intersection(&self) -> Option<Transform> {
-        let ground_plane = Primitive3d::Plane {
-            point: Vec3::ZERO,
-            normal: Vec3::Z,
-        };
-        self.primitive_intersection(ground_plane)
+        self.plane_intersection(Vec3::ZERO, InfinitePlane3d { normal: Dir3::Z })
     }
 
     pub fn frame_plane_intersection(&self, frame: Entity) -> Option<Transform> {
         let tf = self.global_transforms.get(frame).ok()?;
         let affine = tf.affine();
         let point = affine.translation.into();
-        let normal = affine.matrix3.col(2).into();
-        self.primitive_intersection(Primitive3d::Plane { point, normal })
+        let normal = Dir3::new(affine.matrix3.col(2).into()).ok()?;
+        self.plane_intersection(point, InfinitePlane3d { normal })
     }
 
-    pub fn primitive_intersection(&self, primitive: Primitive3d) -> Option<Transform> {
+    pub fn plane_intersection(
+        &self,
+        plane_origin: Vec3,
+        plane: InfinitePlane3d,
+    ) -> Option<Transform> {
         let window = self.primary_windows.get_single().ok()?;
         let cursor_position = window.cursor_position()?;
         let e_active_camera = self.camera_controls.active_camera();
@@ -298,20 +298,13 @@ impl<'w, 's> IntersectGroundPlaneParams<'w, 's> {
         let camera_tf = self.global_transforms.get(e_active_camera).ok()?;
         let primary_window = self.primary_window.get_single().ok()?;
         let ray =
-            Ray3d::from_screenspace(cursor_position, active_camera, camera_tf, primary_window)?;
+            rays::ray_from_screenspace(cursor_position, active_camera, camera_tf, primary_window)?;
 
-        let n = *match &primitive {
-            Primitive3d::Plane { normal, .. } => normal,
-            _ => {
-                warn!("Unsupported primitive type found");
-                return None;
-            }
-        };
         let p = ray
-            .intersects_primitive(primitive)
-            .map(|intersection| intersection.position())?;
+            .intersect_plane(plane_origin, plane)
+            .map(|distance| ray.get_point(distance))?;
 
-        Some(Transform::from_translation(p).with_rotation(aligned_z_axis(n)))
+        Some(Transform::from_translation(p).with_rotation(aligned_z_axis(*plane.normal)))
     }
 }
 

--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -479,7 +479,7 @@ pub fn update_drag_motions(
                     plane.in_plane.normalize_or_zero()
                 };
 
-                let n_r = ray.direction.clone();
+                let n_r = ray.direction.as_vec3();
                 let denom = n_p.dot(n_r);
                 if denom.abs() < 1e-3 {
                     // The rays are nearly parallel so we should not attempt

--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -264,7 +264,7 @@ pub fn update_gizmo_click_start(
     mut gizmos: Query<(
         &Gizmo,
         Option<&mut Draggable>,
-        &mut Handle<StandardMaterial>,
+        &mut MeshMaterial3d<StandardMaterial>,
     )>,
     mut selection_blocker: ResMut<SelectionBlockers>,
     gizmo_blocker: Res<GizmoBlockers>,
@@ -298,7 +298,7 @@ pub fn update_gizmo_click_start(
             if *gizmo_state == GizmoState::Hovering(previous_pick) {
                 if let Ok((gizmo, _, mut material)) = gizmos.get_mut(previous_pick) {
                     if let Some(gizmo_materials) = &gizmo.materials {
-                        *material = gizmo_materials.passive.clone();
+                        *material = MeshMaterial3d(gizmo_materials.passive.clone());
                     }
                 }
 
@@ -311,7 +311,7 @@ pub fn update_gizmo_click_start(
                 if let Ok((gizmo, _, mut material)) = gizmos.get_mut(new_pick) {
                     cursor.add_blocker(new_pick, &mut visibility);
                     if let Some(gizmo_materials) = &gizmo.materials {
-                        *material = gizmo_materials.hover.clone();
+                        *material = MeshMaterial3d(gizmo_materials.hover.clone());
                     }
 
                     *gizmo_state = GizmoState::Hovering(new_pick);
@@ -344,7 +344,7 @@ pub fn update_gizmo_click_start(
                             tf_for_entity_parent_inv,
                         });
                         if let Some(drag_materials) = &gizmo.materials {
-                            *material = drag_materials.drag.clone();
+                            *material = MeshMaterial3d(drag_materials.drag.clone());
                         }
                         *gizmo_state = GizmoState::Dragging(e);
                     } else {
@@ -361,7 +361,11 @@ pub fn update_gizmo_click_start(
 }
 
 pub fn update_gizmo_release(
-    mut draggables: Query<(&Gizmo, &mut Draggable, &mut Handle<StandardMaterial>)>,
+    mut draggables: Query<(
+        &Gizmo,
+        &mut Draggable,
+        &mut MeshMaterial3d<StandardMaterial>,
+    )>,
     mut selection_blockers: ResMut<SelectionBlockers>,
     gizmo_blockers: Res<GizmoBlockers>,
     mut gizmo_state: ResMut<GizmoState>,
@@ -375,7 +379,7 @@ pub fn update_gizmo_release(
             if let Ok((gizmo, mut draggable, mut material)) = draggables.get_mut(e) {
                 draggable.drag = None;
                 if let Some(gizmo_materials) = &gizmo.materials {
-                    *material = gizmo_materials.passive.clone();
+                    *material = MeshMaterial3d(gizmo_materials.passive.clone());
                 }
             }
 

--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -442,9 +442,9 @@ pub fn update_drag_motions(
                 } else {
                     axis.along.normalize_or_zero()
                 };
-                let dp = ray.origin.clone() - initial.click_point;
-                let a = ray.direction.clone().dot(n);
-                let b = ray.direction.clone().dot(dp);
+                let dp = ray.origin - initial.click_point;
+                let a = ray.direction.dot(n);
+                let b = ray.direction.dot(dp);
                 let c = n.dot(dp);
 
                 let denom = a.powi(2) - 1.;
@@ -479,15 +479,15 @@ pub fn update_drag_motions(
                     plane.in_plane.normalize_or_zero()
                 };
 
-                let n_r = ray.direction.as_vec3();
-                let denom = n_p.dot(n_r);
+                let n_r = ray.direction;
+                let denom = n_p.dot(*n_r);
                 if denom.abs() < 1e-3 {
                     // The rays are nearly parallel so we should not attempt
                     // moving because the motion will be too extreme
                     return;
                 }
 
-                let t = (initial.click_point - ray.origin.clone()).dot(n_p) / denom;
+                let t = (initial.click_point - ray.origin).dot(n_p) / denom;
                 let delta = ray.get_point(t) - initial.click_point;
                 let tf_goal = initial
                     .tf_for_entity_global

--- a/rmf_site_editor/src/interaction/gizmo.rs
+++ b/rmf_site_editor/src/interaction/gizmo.rs
@@ -258,13 +258,6 @@ pub struct MoveTo {
     pub transform: Transform,
 }
 
-pub fn make_gizmos_pickable(mut commands: Commands, new_gizmos: Query<Entity, Added<Gizmo>>) {
-    for e in &new_gizmos {
-        commands.entity(e).insert(RayCastPickable);
-        // TODO(@xiyuuoh) Maybe set MeshPickingSettings::require_markers to true, then insert RayCastPickable to these entities.
-    }
-}
-
 pub fn update_gizmo_click_start(
     mut gizmos: Query<(
         &Gizmo,

--- a/rmf_site_editor/src/interaction/highlight.rs
+++ b/rmf_site_editor/src/interaction/highlight.rs
@@ -53,7 +53,7 @@ pub fn update_highlight_visualization(
         (
             &Hovered,
             &Selected,
-            &Handle<StandardMaterial>,
+            &MeshMaterial3d<StandardMaterial>,
             &Highlight,
             Option<&SuppressHighlight>,
         ),
@@ -61,7 +61,7 @@ pub fn update_highlight_visualization(
             Changed<Hovered>,
             Changed<Selected>,
             Changed<SuppressHighlight>,
-            Changed<Handle<StandardMaterial>>,
+            Changed<MeshMaterial3d<StandardMaterial>>,
         )>,
     >,
     mut materials: ResMut<Assets<StandardMaterial>>,

--- a/rmf_site_editor/src/interaction/highlight.rs
+++ b/rmf_site_editor/src/interaction/highlight.rs
@@ -16,6 +16,7 @@
 */
 
 use crate::{interaction::*, site::DrawingMarker};
+use bevy::color::palettes::css as Colors;
 use bevy::prelude::*;
 
 #[derive(Component)]
@@ -31,9 +32,9 @@ pub struct SuppressHighlight;
 impl Highlight {
     pub fn for_drawing() -> Self {
         Self {
-            select: Color::rgb(1., 0.7, 1.),
-            hover: Color::rgb(0.7, 1., 1.),
-            hover_select: Color::rgb(1.0, 0.5, 0.7),
+            select: Color::srgb(1., 0.7, 1.),
+            hover: Color::srgb(0.7, 1., 1.),
+            hover_select: Color::srgb(1.0, 0.5, 0.7),
         }
     }
 }
@@ -68,7 +69,7 @@ pub fn update_highlight_visualization(
     for (hovered, selected, m, highlight, suppress) in &highlightable {
         if let Some(material) = materials.get_mut(m) {
             let mut color = if suppress.is_some() {
-                Color::WHITE
+                Colors::WHITE.into()
             } else if hovered.cue() && selected.cue() {
                 highlight.hover_select
             } else if hovered.cue() {
@@ -76,9 +77,9 @@ pub fn update_highlight_visualization(
             } else if selected.cue() {
                 highlight.select
             } else {
-                Color::WHITE
+                Colors::WHITE.into()
             };
-            color.set_a(material.base_color.a());
+            color.set_alpha(material.base_color.alpha());
 
             material.base_color = color;
         }

--- a/rmf_site_editor/src/interaction/lane.rs
+++ b/rmf_site_editor/src/interaction/lane.rs
@@ -38,7 +38,7 @@ pub fn update_lane_visual_cues(
             Or<(Changed<Hovered>, Changed<Selected>, Changed<Edge<Entity>>)>,
         ),
     >,
-    mut materials: Query<&mut Handle<StandardMaterial>>,
+    mut materials: Query<&mut MeshMaterial3d<StandardMaterial>>,
     mut visibility: Query<&mut Visibility>,
     site_assets: Res<SiteAssets>,
     cursor: Res<Cursor>,

--- a/rmf_site_editor/src/interaction/lift.rs
+++ b/rmf_site_editor/src/interaction/lift.rs
@@ -28,7 +28,7 @@ pub fn make_lift_doormat_gizmo(
             Entity,
             &LiftDoormat,
             &mut Visibility,
-            &mut Handle<StandardMaterial>,
+            &mut MeshMaterial3d<StandardMaterial>,
         ),
         Added<LiftDoormat>,
     >,
@@ -37,7 +37,7 @@ pub fn make_lift_doormat_gizmo(
 ) {
     for (e, doormat, mut visible, mut material) in &mut new_doormats {
         let materials = assets.lift_doormat_materials(doormat.door_available);
-        *material = materials.passive.clone();
+        *material = MeshMaterial3d(materials.passive.clone());
         commands
             .entity(e)
             .insert(Gizmo::new().with_materials(materials));

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -78,82 +78,82 @@ pub fn add_physical_light_visual_cues(
             headlight_toggle.0 = false;
         }
 
+        let point_visibility = if kind.is_point() {
+            Visibility::Inherited
+        } else {
+            Visibility::Hidden
+        };
         let point = commands
-            .spawn(SpatialBundle {
-                visibility: if kind.is_point() {
-                    Visibility::Inherited
-                } else {
-                    Visibility::Hidden
-                },
-                ..default()
-            })
+            .spawn((Transform::default(), point_visibility))
             .with_children(|point| {
                 point
-                    .spawn(PbrBundle {
-                        mesh: assets.point_light_socket_mesh.clone(),
-                        material: assets.physical_light_cover_material.clone(),
-                        ..default()
-                    })
+                    .spawn((
+                        Mesh3d(assets.point_light_socket_mesh.clone()),
+                        MeshMaterial3d(assets.physical_light_cover_material.clone()),
+                        Transform::default(),
+                        Visibility::default(),
+                    ))
                     .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
 
                 point
-                    .spawn(PbrBundle {
-                        mesh: assets.point_light_shine_mesh.clone(),
-                        material: light_material.clone(),
-                        ..default()
-                    })
+                    .spawn((
+                        Mesh3d(assets.point_light_shine_mesh.clone()),
+                        MeshMaterial3d(light_material.clone()),
+                        Transform::default(),
+                        Visibility::default(),
+                    ))
                     .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
             })
             .id();
 
+        let spot_visibility = if kind.is_point() {
+            Visibility::Inherited
+        } else {
+            Visibility::Hidden
+        };
         let spot = commands
-            .spawn(SpatialBundle {
-                visibility: if kind.is_spot() {
-                    Visibility::Inherited
-                } else {
-                    Visibility::Hidden
-                },
-                ..default()
-            })
+            .spawn((Transform::default(), spot_visibility))
             .with_children(|spot| {
-                spot.spawn(PbrBundle {
-                    mesh: assets.spot_light_cover_mesh.clone(),
-                    material: assets.physical_light_cover_material.clone(),
-                    ..default()
-                })
+                spot.spawn((
+                    Mesh3d(assets.spot_light_cover_mesh.clone()),
+                    MeshMaterial3d(assets.physical_light_cover_material.clone()),
+                    Transform::default(),
+                    Visibility::default(),
+                ))
                 .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
 
-                spot.spawn(PbrBundle {
-                    mesh: assets.spot_light_shine_mesh.clone(),
-                    material: light_material.clone(),
-                    ..default()
-                })
+                spot.spawn((
+                    Mesh3d(assets.spot_light_shine_mesh.clone()),
+                    MeshMaterial3d(light_material.clone()),
+                    Transform::default(),
+                    Visibility::default(),
+                ))
                 .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
             })
             .id();
 
+        let directional_visibility = if kind.is_point() {
+            Visibility::Inherited
+        } else {
+            Visibility::Hidden
+        };
         let directional = commands
-            .spawn(SpatialBundle {
-                visibility: if kind.is_directional() {
-                    Visibility::Inherited
-                } else {
-                    Visibility::Hidden
-                },
-                ..default()
-            })
+            .spawn((Transform::default(), directional_visibility))
             .with_children(|dir| {
-                dir.spawn(PbrBundle {
-                    mesh: assets.directional_light_cover_mesh.clone(),
-                    material: assets.direction_light_cover_material.clone(),
-                    ..default()
-                })
+                dir.spawn((
+                    Mesh3d(assets.directional_light_cover_mesh.clone()),
+                    MeshMaterial3d(assets.direction_light_cover_material.clone()),
+                    Transform::default(),
+                    Visibility::default(),
+                ))
                 .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
 
-                dir.spawn(PbrBundle {
-                    mesh: assets.directional_light_shine_mesh.clone(),
-                    material: light_material.clone(),
-                    ..default()
-                })
+                dir.spawn((
+                    Mesh3d(assets.directional_light_shine_mesh.clone()),
+                    MeshMaterial3d(light_material.clone()),
+                    Transform::default(),
+                    Visibility::default(),
+                ))
                 .insert(DragPlaneBundle::new(e, Vec3::Z).globally());
             })
             .id();

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -67,8 +67,9 @@ pub fn add_physical_light_visual_cues(
     mut headlight_toggle: ResMut<HeadlightToggle>,
 ) {
     for (e, kind) in &new_lights {
+        let color = kind.color();
         let light_material = materials.add(StandardMaterial {
-            base_color: kind.color().into(),
+            base_color: Color::srgba(color[0], color[1], color[2], color[3]),
             unlit: true,
             perceptual_roughness: 0.089,
             ..default()
@@ -179,7 +180,8 @@ pub fn update_physical_light_visual_cues(
     for (kind, bodies, material) in &changed {
         bodies.switch(kind, &mut visibilities);
         if let Some(m) = material_assets.get_mut(material) {
-            m.base_color = kind.color().into();
+            let color = kind.color();
+            m.base_color = Color::srgba(color[0], color[1], color[2], color[3]);
         } else {
             error!("Unable to get material asset for light");
         }

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -160,7 +160,7 @@ pub fn add_physical_light_visual_cues(
 
         commands
             .entity(e)
-            .insert(light_material.clone())
+            .insert(MeshMaterial3d(light_material.clone()))
             .insert(LightBodies {
                 point,
                 spot,
@@ -171,7 +171,10 @@ pub fn add_physical_light_visual_cues(
 }
 
 pub fn update_physical_light_visual_cues(
-    changed: Query<(&LightKind, &LightBodies, &Handle<StandardMaterial>), Changed<LightKind>>,
+    changed: Query<
+        (&LightKind, &LightBodies, &MeshMaterial3d<StandardMaterial>),
+        Changed<LightKind>,
+    >,
     mut material_assets: ResMut<Assets<StandardMaterial>>,
     mut visibilities: Query<&mut Visibility>,
     mut headlight_toggle: ResMut<HeadlightToggle>,

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -166,7 +166,7 @@ pub fn add_physical_light_visual_cues(
                 spot,
                 directional,
             })
-            .push_children(&[point, spot, directional]);
+            .add_children(&[point, spot, directional]);
     }
 }
 

--- a/rmf_site_editor/src/interaction/light.rs
+++ b/rmf_site_editor/src/interaction/light.rs
@@ -67,9 +67,8 @@ pub fn add_physical_light_visual_cues(
     mut headlight_toggle: ResMut<HeadlightToggle>,
 ) {
     for (e, kind) in &new_lights {
-        let color = kind.color();
         let light_material = materials.add(StandardMaterial {
-            base_color: Color::srgba(color[0], color[1], color[2], color[3]),
+            base_color: Color::srgb_from_array(kind.color()),
             unlit: true,
             perceptual_roughness: 0.089,
             ..default()
@@ -180,8 +179,7 @@ pub fn update_physical_light_visual_cues(
     for (kind, bodies, material) in &changed {
         bodies.switch(kind, &mut visibilities);
         if let Some(m) = material_assets.get_mut(material) {
-            let color = kind.color();
-            m.base_color = Color::srgba(color[0], color[1], color[2], color[3]);
+            m.base_color = Color::srgb_from_array(kind.color());
         } else {
             error!("Unable to get material asset for light");
         }

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -278,9 +278,9 @@ pub fn set_visibility(entity: Entity, q_visibility: &mut Query<&mut Visibility>,
 fn set_material(
     entity: Entity,
     to_material: &Handle<StandardMaterial>,
-    q_materials: &mut Query<&mut Handle<StandardMaterial>>,
+    q_materials: &mut Query<&mut MeshMaterial3d<StandardMaterial>>,
 ) {
     if let Some(mut m) = q_materials.get_mut(entity).ok() {
-        *m = to_material.clone();
+        *m = MeshMaterial3d(to_material.clone());
     }
 }

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -129,7 +129,7 @@ pub enum InteractionUpdateSet {
 
 impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
-        app.add_state::<InteractionState>()
+        app.init_state::<InteractionState>()
             .init_resource::<GizmoBlockers>()
             .configure_sets(
                 PostUpdate,

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -86,11 +86,7 @@ pub use visual_cue::*;
 
 use bevy::prelude::*;
 use bevy_mod_outline::OutlinePlugin;
-use bevy_mod_raycast::deferred::DeferredRaycastingPlugin;
 use bevy_polyline::PolylinePlugin;
-
-#[derive(Reflect)]
-pub struct SiteRaycastSet;
 
 #[derive(Default)]
 pub struct InteractionPlugin {
@@ -146,7 +142,8 @@ impl Plugin for InteractionPlugin {
                 apply_deferred.in_set(InteractionUpdateSet::CommandFlush),
             )
             .add_plugins(PolylinePlugin)
-            .add_plugins(DeferredRaycastingPlugin::<SiteRaycastSet>::default())
+            // .add_plugins(DeferredRaycastingPlugin::<SiteRaycastSet>::default())
+            .add_plugins(MeshPickingPlugin)
             .init_resource::<InteractionAssets>()
             .init_resource::<Cursor>()
             .init_resource::<CameraControls>()
@@ -184,7 +181,6 @@ impl Plugin for InteractionPlugin {
                     (
                         make_lift_doormat_gizmo,
                         update_doormats_for_level_change,
-                        update_picking_cam,
                         update_physical_light_visual_cues,
                         make_selectable_entities_pickable,
                         update_anchor_visual_cues.after(SelectionServiceStages::Select),

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -142,7 +142,6 @@ impl Plugin for InteractionPlugin {
                 apply_deferred.in_set(InteractionUpdateSet::CommandFlush),
             )
             .add_plugins(PolylinePlugin)
-            // .add_plugins(DeferredRaycastingPlugin::<SiteRaycastSet>::default())
             .add_plugins(MeshPickingPlugin)
             .init_resource::<InteractionAssets>()
             .init_resource::<Cursor>()

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -243,11 +243,7 @@ impl Plugin for InteractionPlugin {
                 .add_systems(OnExit(InteractionState::Enable), hide_cursor)
                 .add_systems(
                     PostUpdate,
-                    (
-                        move_anchor.before(update_anchor_transforms),
-                        move_pose,
-                        make_gizmos_pickable,
-                    )
+                    (move_anchor.before(update_anchor_transforms), move_pose)
                         .run_if(in_state(InteractionState::Enable)),
                 )
                 .add_systems(First, update_picked);

--- a/rmf_site_editor/src/interaction/model_preview.rs
+++ b/rmf_site_editor/src/interaction/model_preview.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use crate::interaction::{Preview, MODEL_PREVIEW_LAYER};
+use crate::interaction::{Preview, DEFAULT_CAMERA_EV100, MODEL_PREVIEW_LAYER};
 use bevy::render::render_resource::{
     Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
@@ -23,7 +23,10 @@ use bevy::{
     core_pipeline::tonemapping::Tonemapping,
     ecs::system::SystemState,
     prelude::*,
-    render::{camera::RenderTarget, view::RenderLayers},
+    render::{
+        camera::{Exposure, RenderTarget},
+        view::RenderLayers,
+    },
 };
 use bevy_egui::{egui::TextureId, EguiContexts};
 use rmf_site_format::Model;
@@ -33,6 +36,7 @@ pub struct ModelPreviewCamera {
     pub camera_entity: Entity,
     pub egui_handle: TextureId,
     pub model_entity: Entity,
+    pub light_entity: Entity,
 }
 
 pub struct ModelPreviewPlugin;
@@ -75,6 +79,9 @@ impl FromWorld for ModelPreviewCamera {
                     ..default()
                 },
                 tonemapping: Tonemapping::ReinhardLuminance,
+                exposure: Exposure {
+                    ev100: DEFAULT_CAMERA_EV100,
+                },
                 ..default()
             })
             .insert(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]))
@@ -86,11 +93,23 @@ impl FromWorld for ModelPreviewCamera {
                 Model::default(),
             ))
             .id();
+        let light_entity = world
+            .spawn(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]))
+            .insert(DirectionalLightBundle {
+                directional_light: DirectionalLight {
+                    illuminance: 50.0,
+                    ..default()
+                },
+                transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Z),
+                ..default()
+            })
+            .id();
 
         Self {
             camera_entity,
             egui_handle,
             model_entity,
+            light_entity,
         }
     }
 }

--- a/rmf_site_editor/src/interaction/model_preview.rs
+++ b/rmf_site_editor/src/interaction/model_preview.rs
@@ -72,18 +72,18 @@ impl FromWorld for ModelPreviewCamera {
         // Attach the bevy image to the egui image
         let egui_handle = egui_context.add_image(preview_image.clone());
         let camera_entity = world
-            .spawn(Camera3dBundle {
-                transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Z),
-                camera: Camera {
+            .spawn(Camera3d::default())
+            .insert((
+                Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Z),
+                Camera {
                     target: RenderTarget::Image(preview_image),
                     ..default()
                 },
-                tonemapping: Tonemapping::ReinhardLuminance,
-                exposure: Exposure {
+                Tonemapping::ReinhardLuminance,
+                Exposure {
                     ev100: DEFAULT_CAMERA_EV100,
                 },
-                ..default()
-            })
+            ))
             .insert(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]))
             .id();
         let model_entity = world
@@ -95,14 +95,13 @@ impl FromWorld for ModelPreviewCamera {
             .id();
         let light_entity = world
             .spawn(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]))
-            .insert(DirectionalLightBundle {
-                directional_light: DirectionalLight {
+            .insert((
+                DirectionalLight {
                     illuminance: 50.0,
                     ..default()
                 },
-                transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Z),
-                ..default()
-            })
+                Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Z),
+            ))
             .id();
 
         Self {

--- a/rmf_site_editor/src/interaction/model_preview.rs
+++ b/rmf_site_editor/src/interaction/model_preview.rs
@@ -84,17 +84,17 @@ impl FromWorld for ModelPreviewCamera {
                     ev100: DEFAULT_CAMERA_EV100,
                 },
             ))
-            .insert(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]))
+            .insert(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER]))
             .id();
         let model_entity = world
             .spawn((
-                RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]),
+                RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER]),
                 Preview,
                 Model::default(),
             ))
             .id();
         let light_entity = world
-            .spawn(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]))
+            .spawn(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER]))
             .insert((
                 DirectionalLight {
                     illuminance: 50.0,

--- a/rmf_site_editor/src/interaction/model_preview.rs
+++ b/rmf_site_editor/src/interaction/model_preview.rs
@@ -77,11 +77,11 @@ impl FromWorld for ModelPreviewCamera {
                 tonemapping: Tonemapping::ReinhardLuminance,
                 ..default()
             })
-            .insert(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER]))
+            .insert(RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]))
             .id();
         let model_entity = world
             .spawn((
-                RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER]),
+                RenderLayers::from_layers(&[MODEL_PREVIEW_LAYER.into()]),
                 Preview,
                 Model::default(),
             ))

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -71,23 +71,21 @@ impl OutlineVisualization {
         match self {
             OutlineVisualization::Ordinary => {
                 if hovered.cue() {
-                    OutlineRenderLayers(RenderLayers::layer(HOVERED_OUTLINE_LAYER.into()))
+                    OutlineRenderLayers(RenderLayers::layer(HOVERED_OUTLINE_LAYER))
                 } else if selected.cue() {
-                    OutlineRenderLayers(RenderLayers::layer(SELECTED_OUTLINE_LAYER.into()))
+                    OutlineRenderLayers(RenderLayers::layer(SELECTED_OUTLINE_LAYER))
                 } else {
                     OutlineRenderLayers(RenderLayers::none())
                 }
             }
             OutlineVisualization::Anchor { .. } => {
-                OutlineRenderLayers(RenderLayers::layer(XRAY_RENDER_LAYER.into()))
+                OutlineRenderLayers(RenderLayers::layer(XRAY_RENDER_LAYER))
             }
         }
     }
 
     pub fn depth(&self) -> OutlineMode {
-        OutlineMode::FlatVertex {
-            model_origin: Vec3::ZERO,
-        }
+        OutlineMode::ExtrudeFlat
     }
 
     /// If this element should use a different entity as its root for

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -16,6 +16,7 @@
 */
 
 use crate::{interaction::*, site::DrawingMarker};
+use bevy::color::palettes::css as Colors;
 use bevy::render::view::RenderLayers;
 use bevy_mod_outline::{OutlineBundle, OutlineMode, OutlineRenderLayers, OutlineVolume};
 use rmf_site_format::{
@@ -45,20 +46,20 @@ impl OutlineVisualization {
                 if !hovered.cue() && !selected.cue() {
                     None
                 } else if hovered.cue() && selected.cue() {
-                    Some(Color::rgb(1.0, 0.0, 0.3))
+                    Some(Color::srgb(1.0, 0.0, 0.3))
                 } else if selected.cue() {
-                    Some(Color::rgb(1.0, 0.3, 1.0))
+                    Some(Color::srgb(1.0, 0.3, 1.0))
                 } else
                 /* only hovered */
                 {
-                    Some(Color::WHITE)
+                    Some(Colors::WHITE.into())
                 }
             }
             OutlineVisualization::Anchor { .. } => {
                 if hovered.is_hovered {
-                    Some(Color::WHITE)
+                    Some(Colors::WHITE.into())
                 } else {
-                    Some(Color::BLACK)
+                    Some(Colors::BLACK.into())
                 }
             }
         }
@@ -68,15 +69,15 @@ impl OutlineVisualization {
         match self {
             OutlineVisualization::Ordinary => {
                 if hovered.cue() {
-                    OutlineRenderLayers(RenderLayers::layer(HOVERED_OUTLINE_LAYER))
+                    OutlineRenderLayers(RenderLayers::layer(HOVERED_OUTLINE_LAYER.into()))
                 } else if selected.cue() {
-                    OutlineRenderLayers(RenderLayers::layer(SELECTED_OUTLINE_LAYER))
+                    OutlineRenderLayers(RenderLayers::layer(SELECTED_OUTLINE_LAYER.into()))
                 } else {
                     OutlineRenderLayers(RenderLayers::none())
                 }
             }
             OutlineVisualization::Anchor { .. } => {
-                OutlineRenderLayers(RenderLayers::layer(XRAY_RENDER_LAYER))
+                OutlineRenderLayers(RenderLayers::layer(XRAY_RENDER_LAYER.into()))
             }
         }
     }
@@ -181,7 +182,7 @@ pub fn update_outline_visualization(
                             ..default()
                         })
                         .insert(depth.clone())
-                        .insert(layers);
+                        .insert(layers.clone());
                 } else {
                     commands
                         .entity(top)

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -79,7 +79,11 @@ impl OutlineVisualization {
                 }
             }
             OutlineVisualization::Anchor { .. } => {
-                OutlineRenderLayers(RenderLayers::layer(XRAY_RENDER_LAYER))
+                if hovered.cue() || selected.cue() {
+                    OutlineRenderLayers(RenderLayers::layer(XRAY_RENDER_LAYER))
+                } else {
+                    OutlineRenderLayers(RenderLayers::none())
+                }
             }
         }
     }

--- a/rmf_site_editor/src/interaction/outline.rs
+++ b/rmf_site_editor/src/interaction/outline.rs
@@ -18,7 +18,9 @@
 use crate::{interaction::*, site::DrawingMarker};
 use bevy::color::palettes::css as Colors;
 use bevy::render::view::RenderLayers;
-use bevy_mod_outline::{OutlineBundle, OutlineMode, OutlineRenderLayers, OutlineVolume};
+use bevy_mod_outline::{
+    ComputedOutline, OutlineMode, OutlineRenderLayers, OutlineStencil, OutlineVolume,
+};
 use rmf_site_format::{
     DoorType, FiducialMarker, FloorMarker, LiftCabin, LightKind, LocationTags, MeasurementMarker,
     ModelMarker, PhysicalCameraProperties, PrimitiveShape, WallMarker,
@@ -173,20 +175,23 @@ pub fn update_outline_visualization(
                 if let Some(color) = color {
                     commands
                         .entity(top)
-                        .insert(OutlineBundle {
-                            outline: OutlineVolume {
+                        .insert((
+                            OutlineVolume {
                                 visible: true,
                                 width: 3.0,
                                 colour: color,
                             },
-                            ..default()
-                        })
+                            OutlineStencil::default(),
+                            ComputedOutline::default(),
+                        ))
                         .insert(depth.clone())
                         .insert(layers.clone());
                 } else {
                     commands
                         .entity(top)
-                        .remove::<OutlineBundle>()
+                        .remove::<OutlineVolume>()
+                        .remove::<OutlineStencil>()
+                        .remove::<ComputedOutline>()
                         .remove::<OutlineMode>();
                 }
 

--- a/rmf_site_editor/src/interaction/picking.rs
+++ b/rmf_site_editor/src/interaction/picking.rs
@@ -82,7 +82,6 @@ fn pick_topmost(
 pub fn update_picked(
     selectable: Query<&Selectable>,
     blockers: Option<Res<PickingBlockers>>,
-    camera_controls: Res<CameraControls>,
     pointers: Query<&PointerInteraction>,
     visual_cues: Query<&ComputedVisualCue>,
     mut picked: ResMut<Picked>,
@@ -103,14 +102,12 @@ pub fn update_picked(
         }
     }
 
-    let active_camera = camera_controls.active_camera();
     let current_picked = 'current_picked: {
         for interactions in &pointers {
             // First only look at the visual cues that are being xrayed
             if let Some(topmost) = pick_topmost(
                 interactions
                     .iter()
-                    .filter(|(_, hit_data)| hit_data.camera == active_camera)
                     .filter(|(e, _)| {
                         visual_cues
                             .get(*e)
@@ -125,13 +122,7 @@ pub fn update_picked(
             }
 
             // Now look at all possible pickables
-            if let Some(topmost) = pick_topmost(
-                interactions
-                    .iter()
-                    .filter(|(_, hit_data)| hit_data.camera == active_camera)
-                    .map(|(e, _)| *e),
-                &selectable,
-            ) {
+            if let Some(topmost) = pick_topmost(interactions.iter().map(|(e, _)| *e), &selectable) {
                 break 'current_picked Some(topmost);
             }
         }

--- a/rmf_site_editor/src/interaction/preview.rs
+++ b/rmf_site_editor/src/interaction/preview.rs
@@ -18,11 +18,13 @@
 use bevy::{
     prelude::*,
     render::{
-        camera::{Projection, RenderTarget},
+        camera::{Exposure, Projection, RenderTarget},
         view::RenderLayers,
     },
     window::{PresentMode, WindowClosed, WindowRef},
 };
+
+use crate::interaction::DEFAULT_CAMERA_EV100;
 
 use rmf_site_format::{NameInSite, PhysicalCameraProperties, PreviewableMarker};
 
@@ -68,6 +70,9 @@ fn create_camera_window(
             target: RenderTarget::Window(WindowRef::Entity(window_id)),
             is_active: true,
             ..default()
+        })
+        .insert(Exposure {
+            ev100: DEFAULT_CAMERA_EV100,
         })
         .insert(RenderLayers::layer(0));
     window_id

--- a/rmf_site_editor/src/interaction/select.rs
+++ b/rmf_site_editor/src/interaction/select.rs
@@ -907,7 +907,7 @@ pub fn inspector_cursor_transform(
         return;
     }
 
-    let Some((_, interactions)) = pointers.get_single().ok().filter(|(id, _)| id.is_mouse()) else {
+    let Some((_, interactions)) = pointers.get_single().ok() else {
         return;
     };
     let active_camera = camera_controls.active_camera();

--- a/rmf_site_editor/src/interaction/select.rs
+++ b/rmf_site_editor/src/interaction/select.rs
@@ -25,10 +25,7 @@ use anyhow::{anyhow, Error as Anyhow};
 use bevy::{
     ecs::system::{StaticSystemParam, SystemParam},
     math::Ray3d,
-    picking::{
-        mesh_picking::RayCastPickable,
-        pointer::{PointerId, PointerInteraction},
-    },
+    picking::pointer::{PointerId, PointerInteraction},
     prelude::*,
 };
 use bevy_impulse::*;
@@ -389,8 +386,6 @@ pub fn make_selectable_entities_pickable(
     targets: Query<(Option<&Hovered>, Option<&Selected>)>,
 ) {
     for (entity, selectable) in &new_selectables {
-        commands.entity(entity).insert(RayCastPickable);
-
         if let Ok((hovered, selected)) = targets.get(selectable.element) {
             if hovered.is_none() {
                 commands

--- a/rmf_site_editor/src/interaction/select/create_edges.rs
+++ b/rmf_site_editor/src/interaction/select/create_edges.rs
@@ -88,7 +88,7 @@ impl CreateEdges {
             provisional_start: false,
         });
 
-        commands.add(ChangeDependent::add(anchor, edge));
+        commands.queue(ChangeDependent::add(anchor, edge));
     }
 }
 
@@ -134,7 +134,7 @@ impl PreviewEdge {
     ) -> SelectionNodeResult {
         let edge = edges.get(self.edge).or_broken_query()?;
         for anchor in edge.array() {
-            commands.add(ChangeDependent::remove(anchor, self.edge));
+            commands.queue(ChangeDependent::remove(anchor, self.edge));
         }
 
         if self.provisional_start {
@@ -214,11 +214,11 @@ pub fn on_hover_for_create_edges(
         if old_anchor != anchor {
             let opposite_anchor = edge.array()[preview.side.opposite().index()];
             if opposite_anchor != old_anchor {
-                commands.add(ChangeDependent::remove(old_anchor, preview.edge));
+                commands.queue(ChangeDependent::remove(old_anchor, preview.edge));
             }
 
             edge.array_mut()[index] = anchor;
-            commands.add(ChangeDependent::add(anchor, preview.edge));
+            commands.queue(ChangeDependent::add(anchor, preview.edge));
         }
     } else {
         // There is currently no active preview, so we need to create one.
@@ -229,7 +229,7 @@ pub fn on_hover_for_create_edges(
             side: Side::start(),
             provisional_start: false,
         });
-        commands.add(ChangeDependent::add(anchor, edge));
+        commands.queue(ChangeDependent::add(anchor, edge));
     }
 
     Ok(())
@@ -251,16 +251,16 @@ pub fn on_select_for_create_edges(
             Side::Left => {
                 // We are pinning down the first anchor of the edge
                 let mut edge = edges.get_mut(preview.edge).or_broken_query()?;
-                commands.add(ChangeDependent::remove(edge.left(), preview.edge));
+                commands.queue(ChangeDependent::remove(edge.left(), preview.edge));
                 *edge.left_mut() = anchor;
-                commands.add(ChangeDependent::add(anchor, preview.edge));
+                commands.queue(ChangeDependent::add(anchor, preview.edge));
 
                 if edge.right() != anchor {
-                    commands.add(ChangeDependent::remove(edge.right(), preview.edge));
+                    commands.queue(ChangeDependent::remove(edge.right(), preview.edge));
                 }
 
                 *edge.right_mut() = cursor.level_anchor_placement;
-                commands.add(ChangeDependent::add(
+                commands.queue(ChangeDependent::add(
                     cursor.level_anchor_placement,
                     preview.edge,
                 ));
@@ -282,7 +282,7 @@ pub fn on_select_for_create_edges(
                     return Ok(());
                 }
                 *edge.right_mut() = anchor;
-                commands.add(ChangeDependent::add(anchor, preview.edge));
+                commands.queue(ChangeDependent::add(anchor, preview.edge));
                 commands
                     .get_entity(preview.edge)
                     .or_broken_query()?
@@ -310,8 +310,8 @@ pub fn on_select_for_create_edges(
                             side: Side::end(),
                             provisional_start: false,
                         });
-                        commands.add(ChangeDependent::add(anchor, edge));
-                        commands.add(ChangeDependent::add(cursor.level_anchor_placement, edge));
+                        commands.queue(ChangeDependent::add(anchor, edge));
+                        commands.queue(ChangeDependent::add(cursor.level_anchor_placement, edge));
                     }
                 }
             }
@@ -355,7 +355,7 @@ pub fn on_keyboard_for_create_edges(
             // user can choose a different start point.
             let mut edge = edges.get_mut(preview.edge).or_broken_query()?;
             for anchor in edge.array() {
-                commands.add(ChangeDependent::remove(anchor, preview.edge));
+                commands.queue(ChangeDependent::remove(anchor, preview.edge));
             }
             if preview.provisional_start {
                 commands
@@ -368,7 +368,7 @@ pub fn on_keyboard_for_create_edges(
             *edge.right_mut() = cursor.level_anchor_placement;
             preview.side = Side::start();
             preview.provisional_start = false;
-            commands.add(ChangeDependent::add(
+            commands.queue(ChangeDependent::add(
                 cursor.level_anchor_placement,
                 preview.edge,
             ));

--- a/rmf_site_editor/src/interaction/select/create_edges.rs
+++ b/rmf_site_editor/src/interaction/select/create_edges.rs
@@ -43,7 +43,7 @@ pub fn spawn_create_edges_service(
         update_current,
         handle_key_code,
         cleanup_state,
-        &mut app.world,
+        app.world_mut(),
     )
 }
 

--- a/rmf_site_editor/src/interaction/select/create_path.rs
+++ b/rmf_site_editor/src/interaction/select/create_path.rs
@@ -113,10 +113,10 @@ impl CreatePath {
         let previous = *last;
         *last = chosen;
         if !path_mut.0.contains(&previous) {
-            commands.add(ChangeDependent::remove(previous, path));
+            commands.queue(ChangeDependent::remove(previous, path));
         }
 
-        commands.add(ChangeDependent::add(chosen, path));
+        commands.queue(ChangeDependent::add(chosen, path));
         Ok(())
     }
 }
@@ -149,7 +149,7 @@ pub fn create_path_setup(
     if state.path.is_none() {
         let path = Path(vec![cursor.level_anchor_placement]);
         let path = (state.spawn_path)(path, &mut commands);
-        commands.add(ChangeDependent::add(cursor.level_anchor_placement, path));
+        commands.queue(ChangeDependent::add(cursor.level_anchor_placement, path));
         state.path = Some(path);
     }
 
@@ -237,7 +237,7 @@ pub fn on_select_for_create_path(
     }
 
     path_mut.0.push(cursor.level_anchor_placement);
-    commands.add(ChangeDependent::add(cursor.level_anchor_placement, path));
+    commands.queue(ChangeDependent::add(cursor.level_anchor_placement, path));
 
     Ok(())
 }
@@ -268,7 +268,7 @@ pub fn cleanup_create_path(
         // We did not collect enough points for the path so we should despawn it
         // as well as any provisional points it contains.
         for a in &path_mut.0 {
-            commands.add(ChangeDependent::remove(*a, path));
+            commands.queue(ChangeDependent::remove(*a, path));
         }
 
         for a in state.provisional_anchors {
@@ -290,7 +290,7 @@ pub fn cleanup_create_path(
             if !path_mut.contains(&a) {
                 // Remove the dependency on the last point since it no longer
                 // exists in the path
-                commands.add(ChangeDependent::remove(a, path));
+                commands.queue(ChangeDependent::remove(a, path));
             }
         }
 

--- a/rmf_site_editor/src/interaction/select/create_path.rs
+++ b/rmf_site_editor/src/interaction/select/create_path.rs
@@ -45,7 +45,7 @@ pub fn spawn_create_path_service(
         update_current,
         handle_key_code,
         cleanup_state,
-        &mut app.world,
+        app.world_mut(),
     )
 }
 

--- a/rmf_site_editor/src/interaction/select/create_point.rs
+++ b/rmf_site_editor/src/interaction/select/create_point.rs
@@ -43,7 +43,7 @@ pub fn spawn_create_point_service(
         update_current,
         handle_key_code,
         cleanup_state,
-        &mut app.world,
+        app.world_mut(),
     )
 }
 

--- a/rmf_site_editor/src/interaction/select/create_point.rs
+++ b/rmf_site_editor/src/interaction/select/create_point.rs
@@ -74,7 +74,7 @@ impl CreatePoint {
     pub fn create_new_point(&mut self, anchor: Entity, commands: &mut Commands) {
         let point = Point(anchor);
         let point = (self.spawn_point)(point, commands);
-        commands.add(ChangeDependent::add(anchor, point));
+        commands.queue(ChangeDependent::add(anchor, point));
         self.point = Some(point);
     }
 }
@@ -120,8 +120,8 @@ fn change_point(
         return Ok(());
     }
 
-    commands.add(ChangeDependent::remove(point_mut.0, point));
-    commands.add(ChangeDependent::add(chosen, point));
+    commands.queue(ChangeDependent::remove(point_mut.0, point));
+    commands.queue(ChangeDependent::add(chosen, point));
     point_mut.0 = chosen;
     Ok(())
 }
@@ -191,7 +191,7 @@ pub fn cleanup_create_point(
     };
 
     let point_ref = points.get(point).or_broken_query()?;
-    commands.add(ChangeDependent::remove(point_ref.0, point));
+    commands.queue(ChangeDependent::remove(point_ref.0, point));
     commands
         .get_entity(point)
         .or_broken_query()?

--- a/rmf_site_editor/src/interaction/select/place_object.rs
+++ b/rmf_site_editor/src/interaction/select/place_object.rs
@@ -70,7 +70,7 @@ impl<'w, 's> ObjectPlacement<'w, 's> {
     }
 
     fn send(&mut self, run: RunSelector) {
-        self.commands.add(move |world: &mut World| {
+        self.commands.queue(move |world: &mut World| {
             world.send_event(run);
         });
     }
@@ -83,7 +83,7 @@ pub trait ObjectPlacementExt<'w, 's> {
 
 impl<'w, 's> ObjectPlacementExt<'w, 's> for Commands<'w, 's> {
     fn place_object_2d(&mut self, object: ModelInstance<Entity>) {
-        self.add(ObjectPlaceCommand(object));
+        self.queue(ObjectPlaceCommand(object));
     }
 }
 

--- a/rmf_site_editor/src/interaction/select/place_object.rs
+++ b/rmf_site_editor/src/interaction/select/place_object.rs
@@ -19,7 +19,10 @@ use crate::{
     interaction::select::*,
     site::{CurrentLevel, ModelInstance},
 };
-use bevy::ecs::system::{Command, SystemParam, SystemState};
+use bevy::ecs::{
+    system::{SystemParam, SystemState},
+    world::Command,
+};
 
 #[derive(Default)]
 pub struct ObjectPlacementPlugin {}

--- a/rmf_site_editor/src/interaction/select/place_object_2d.rs
+++ b/rmf_site_editor/src/interaction/select/place_object_2d.rs
@@ -19,7 +19,7 @@ use crate::{
     interaction::select::*,
     site::{ModelInstance, ModelLoader},
 };
-use bevy::prelude::Input as UserInput;
+use bevy::prelude::ButtonInput;
 
 pub const PLACE_OBJECT_2D_MODE_LABEL: &'static str = "place_object_2d";
 
@@ -32,18 +32,19 @@ pub fn spawn_place_object_2d_workflow(app: &mut App) -> Service<Option<Entity>, 
     let cleanup = app.spawn_service(place_object_2d_cleanup.into_blocking_service());
 
     let keyboard_just_pressed = app
-        .world
+        .world()
         .resource::<KeyboardServices>()
         .keyboard_just_pressed;
 
-    app.world.spawn_io_workflow(build_place_object_2d_workflow(
-        setup,
-        find_position,
-        placement_chosen,
-        handle_key_code,
-        cleanup,
-        keyboard_just_pressed,
-    ))
+    app.world_mut()
+        .spawn_io_workflow(build_place_object_2d_workflow(
+            setup,
+            find_position,
+            placement_chosen,
+            handle_key_code,
+            cleanup,
+            keyboard_just_pressed,
+        ))
 }
 
 pub fn build_place_object_2d_workflow(
@@ -151,7 +152,7 @@ pub fn place_object_2d_find_placement(
     cursor: Res<Cursor>,
     mut transforms: Query<&mut Transform>,
     intersect_ground_params: IntersectGroundPlaneParams,
-    mouse_button_input: Res<UserInput<MouseButton>>,
+    mouse_button_input: Res<ButtonInput<MouseButton>>,
     blockers: Option<Res<PickingBlockers>>,
 ) {
     let Some(mut orders) = orders.get_mut(&key) else {

--- a/rmf_site_editor/src/interaction/select/replace_point.rs
+++ b/rmf_site_editor/src/interaction/select/replace_point.rs
@@ -43,7 +43,7 @@ pub fn spawn_replace_point_service(
         update_current,
         handle_key_code,
         cleanup_state,
-        &mut app.world,
+        app.world_mut(),
     )
 }
 

--- a/rmf_site_editor/src/interaction/select/replace_point.rs
+++ b/rmf_site_editor/src/interaction/select/replace_point.rs
@@ -78,9 +78,9 @@ impl ReplacePoint {
         commands: &mut Commands,
     ) -> SelectionNodeResult {
         let mut point_mut = points.get_mut(self.point).or_broken_query()?;
-        commands.add(ChangeDependent::remove(point_mut.0, self.point));
+        commands.queue(ChangeDependent::remove(point_mut.0, self.point));
         point_mut.0 = chosen;
-        commands.add(ChangeDependent::add(chosen, self.point));
+        commands.queue(ChangeDependent::add(chosen, self.point));
         Ok(())
     }
 }

--- a/rmf_site_editor/src/interaction/select/replace_side.rs
+++ b/rmf_site_editor/src/interaction/select/replace_side.rs
@@ -87,7 +87,7 @@ impl ReplaceSide {
             // Remove both current dependencies in case both of them change.
             // If either dependency doesn't change then they'll be added back
             // later anyway.
-            commands.add(ChangeDependent::remove(a, self.edge));
+            commands.queue(ChangeDependent::remove(a, self.edge));
         }
 
         if chosen == original.array()[self.side.opposite().index()] {
@@ -103,7 +103,7 @@ impl ReplaceSide {
         }
 
         for a in edge_mut.array() {
-            commands.add(ChangeDependent::add(a, self.edge));
+            commands.queue(ChangeDependent::add(a, self.edge));
         }
 
         Ok(())

--- a/rmf_site_editor/src/interaction/select/replace_side.rs
+++ b/rmf_site_editor/src/interaction/select/replace_side.rs
@@ -43,7 +43,7 @@ pub fn spawn_replace_side_service(
         update_current,
         handle_key_code,
         cleanup_state,
-        &mut app.world,
+        app.world_mut(),
     )
 }
 

--- a/rmf_site_editor/src/interaction/select/select_anchor.rs
+++ b/rmf_site_editor/src/interaction/select/select_anchor.rs
@@ -295,7 +295,7 @@ impl<'w, 's> AnchorSelection<'w, 's> {
     }
 
     fn send(&mut self, run: RunSelector) {
-        self.commands.add(move |world: &mut World| {
+        self.commands.queue(move |world: &mut World| {
             world.send_event(run);
         });
     }
@@ -539,7 +539,7 @@ pub fn extract_selector_input<T: 'static + Send + Sync>(
         return Ok(None);
     };
 
-    let Some(mut e_mut) = world.get_entity_mut(e) else {
+    let Ok(mut e_mut) = world.get_entity_mut(e) else {
         error!(
             "Could not begin selector service because the input entity {e:?} \
             does not exist.",

--- a/rmf_site_editor/src/interaction/select/select_anchor.rs
+++ b/rmf_site_editor/src/interaction/select/select_anchor.rs
@@ -68,11 +68,11 @@ impl AnchorSelectionHelpers {
                 .configure(|config: SystemConfigs| config.in_set(SelectionServiceStages::Pick)),
         );
         let cleanup_anchor_selection = app
-            .world
+            .world_mut()
             .spawn_service(cleanup_anchor_selection.into_blocking_service());
 
         let keyboard_just_pressed = app
-            .world
+            .world()
             .resource::<KeyboardServices>()
             .keyboard_just_pressed;
 

--- a/rmf_site_editor/src/interaction/visual_cue.rs
+++ b/rmf_site_editor/src/interaction/visual_cue.rs
@@ -125,10 +125,10 @@ impl VisualCue {
     pub fn layers(&self) -> RenderLayers {
         let mut layers = RenderLayers::none();
         if self.regular.any() {
-            layers = layers.with(VISUAL_CUE_RENDER_LAYER.into());
+            layers = layers.with(VISUAL_CUE_RENDER_LAYER);
         }
         if self.xray.any() {
-            layers = layers.with(XRAY_RENDER_LAYER.into());
+            layers = layers.with(XRAY_RENDER_LAYER);
         }
         layers
     }

--- a/rmf_site_editor/src/interaction/visual_cue.rs
+++ b/rmf_site_editor/src/interaction/visual_cue.rs
@@ -15,7 +15,9 @@
  *
 */
 
-use crate::interaction::{VISUAL_CUE_RENDER_LAYER, XRAY_RENDER_LAYER};
+use crate::interaction::{
+    HOVERED_OUTLINE_LAYER, SELECTED_OUTLINE_LAYER, VISUAL_CUE_RENDER_LAYER, XRAY_RENDER_LAYER,
+};
 use bevy::{prelude::*, render::view::visibility::RenderLayers};
 use bitfield::bitfield;
 use smallvec::SmallVec;
@@ -128,7 +130,10 @@ impl VisualCue {
             layers = layers.with(VISUAL_CUE_RENDER_LAYER);
         }
         if self.xray.any() {
-            layers = layers.with(XRAY_RENDER_LAYER);
+            layers = layers
+                .with(XRAY_RENDER_LAYER)
+                .with(HOVERED_OUTLINE_LAYER)
+                .with(SELECTED_OUTLINE_LAYER);
         }
         layers
     }

--- a/rmf_site_editor/src/interaction/visual_cue.rs
+++ b/rmf_site_editor/src/interaction/visual_cue.rs
@@ -125,10 +125,10 @@ impl VisualCue {
     pub fn layers(&self) -> RenderLayers {
         let mut layers = RenderLayers::none();
         if self.regular.any() {
-            layers = layers.with(VISUAL_CUE_RENDER_LAYER);
+            layers = layers.with(VISUAL_CUE_RENDER_LAYER.into());
         }
         if self.xray.any() {
-            layers = layers.with(XRAY_RENDER_LAYER);
+            layers = layers.with(XRAY_RENDER_LAYER.into());
         }
         layers
     }

--- a/rmf_site_editor/src/issue.rs
+++ b/rmf_site_editor/src/issue.rs
@@ -16,11 +16,9 @@
 */
 
 use crate::site::ChangePlugin;
-use bevy::{
-    prelude::*,
-    utils::{HashMap, Uuid},
-};
+use bevy::{prelude::*, utils::HashMap};
 use rmf_site_format::{FilteredIssueKinds, FilteredIssues, IssueKey};
+use uuid::Uuid;
 
 #[derive(Component, Debug, Clone)]
 pub struct Issue {
@@ -38,7 +36,7 @@ pub trait RegisterIssueType {
 impl RegisterIssueType for App {
     fn add_issue_type(&mut self, type_uuid: &Uuid, name: &str) -> &mut Self {
         let mut issue_dictionary = self
-            .world
+            .world_mut()
             .get_resource_or_insert_with::<IssueDictionary>(Default::default);
         issue_dictionary.insert(type_uuid.clone(), name.into());
         self

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -20,10 +20,7 @@ use crate::{
     site::{AlignSiteDrawings, Delete},
     CreateNewWorkspace, CurrentWorkspace, WorkspaceLoader, WorkspaceSaver,
 };
-use bevy::{
-    prelude::{Input as UserInput, *},
-    window::PrimaryWindow,
-};
+use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_egui::EguiContexts;
 use bevy_impulse::*;
 
@@ -53,7 +50,7 @@ impl Plugin for KeyboardInputPlugin {
 }
 
 fn handle_keyboard_input(
-    keyboard_input: Res<UserInput<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
     selection: Res<Selection>,
     mut egui_context: EguiContexts,
     mut delete: EventWriter<Delete>,
@@ -89,7 +86,9 @@ fn handle_keyboard_input(
         change_camera_mode.send(ChangeProjectionMode::to_perspective());
     }
 
-    if keyboard_input.just_pressed(KeyCode::Delete) || keyboard_input.just_pressed(KeyCode::Back) {
+    if keyboard_input.just_pressed(KeyCode::Delete)
+        || keyboard_input.just_pressed(KeyCode::Backspace)
+    {
         if let Some(selection) = selection.0 {
             delete.send(Delete::new(selection));
         } else {
@@ -97,14 +96,14 @@ fn handle_keyboard_input(
         }
     }
 
-    if keyboard_input.just_pressed(KeyCode::D) {
+    if keyboard_input.just_pressed(KeyCode::KeyD) {
         debug_mode.0 = !debug_mode.0;
         info!("Toggling debug mode: {debug_mode:?}");
     }
 
     // Ctrl keybindings
     if keyboard_input.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]) {
-        if keyboard_input.just_pressed(KeyCode::S) {
+        if keyboard_input.just_pressed(KeyCode::KeyS) {
             if keyboard_input.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]) {
                 workspace_saver.save_to_dialog();
             } else {
@@ -112,23 +111,23 @@ fn handle_keyboard_input(
             }
         }
 
-        if keyboard_input.just_pressed(KeyCode::T) {
+        if keyboard_input.just_pressed(KeyCode::KeyT) {
             if let Some(site) = current_workspace.root {
                 align_site.send(AlignSiteDrawings(site));
             }
         }
 
-        if keyboard_input.just_pressed(KeyCode::E) {
+        if keyboard_input.just_pressed(KeyCode::KeyE) {
             workspace_saver.export_sdf_to_dialog();
         }
 
         // TODO(luca) pop up a confirmation prompt if the current file is not saved, or create a
         // gui to switch between open workspaces
-        if keyboard_input.just_pressed(KeyCode::N) {
+        if keyboard_input.just_pressed(KeyCode::KeyN) {
             new_workspace.send(CreateNewWorkspace);
         }
 
-        if keyboard_input.just_pressed(KeyCode::O) {
+        if keyboard_input.just_pressed(KeyCode::KeyO) {
             workspace_loader.load_from_dialog();
         }
     }
@@ -137,7 +136,7 @@ fn handle_keyboard_input(
 pub fn keyboard_just_pressed_stream(
     In(ContinuousService { key }): ContinuousServiceInput<(), (), StreamOf<KeyCode>>,
     mut orders: ContinuousQuery<(), (), StreamOf<KeyCode>>,
-    keyboard_input: Res<UserInput<KeyCode>>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
     let Some(mut orders) = orders.get_mut(&key) else {
         return;

--- a/rmf_site_editor/src/keyboard.rs
+++ b/rmf_site_editor/src/keyboard.rs
@@ -66,7 +66,7 @@ fn handle_keyboard_input(
     let Some(egui_context) = primary_windows
         .get_single()
         .ok()
-        .and_then(|w| egui_context.try_ctx_for_window_mut(w))
+        .and_then(|w| egui_context.try_ctx_for_entity_mut(w))
     else {
         return;
     };

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -191,7 +191,7 @@ impl Plugin for SiteEditor {
         ));
 
         app.insert_resource(DirectionalLightShadowMap { size: 2048 })
-            .add_state::<AppState>()
+            .init_state::<AppState>()
             .add_plugins((
                 AssetLoadersPlugin,
                 LogHistoryPlugin,

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -213,11 +213,6 @@ impl Plugin for SiteEditor {
                 .add_plugins((site::ViewMenuPlugin, OSMViewPlugin, SiteWireframePlugin));
         }
 
-        // Ref https://github.com/bevyengine/bevy/issues/10877. The default behavior causes issues
-        // with events being accumulated when not read (i.e. scrolling mouse wheel on a UI widget).
-        app.world
-            .remove_resource::<bevy::ecs::event::EventUpdateSignal>();
-
         if let Some(path) = &self.headless_export {
             // We really don't need a high update rate here since we are IO bound, set a low rate
             // to save CPU.

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -14,7 +14,6 @@ use asset_loaders::*;
 
 // Bevy plugins that are public dependencies, mixing versions won't work for downstream users
 pub use bevy_egui;
-pub use bevy_mod_raycast;
 
 pub mod keyboard;
 use keyboard::*;

--- a/rmf_site_editor/src/log.rs
+++ b/rmf_site_editor/src/log.rs
@@ -43,7 +43,7 @@ impl fmt::Display for LogCategory {
     }
 }
 
-#[derive(Debug, Clone, Component, PartialEq, Eq, Event)]
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
 pub struct Log {
     pub category: LogCategory,
     pub message: String,

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -75,7 +75,7 @@ fn egui_ui(
                 ui.horizontal(|ui| {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         if ui.button("Exit").clicked() {
-                            _exit.send(AppExit);
+                            _exit.send(AppExit::Success);
                         }
                     });
                 });

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -41,7 +41,7 @@ fn egui_ui(
     let Some(ctx) = primary_windows
         .get_single()
         .ok()
-        .and_then(|w| egui_context.try_ctx_for_window_mut(w))
+        .and_then(|w| egui_context.try_ctx_for_entity_mut(w))
     else {
         return;
     };

--- a/rmf_site_editor/src/occupancy.rs
+++ b/rmf_site_editor/src/occupancy.rs
@@ -153,7 +153,7 @@ enum Group {
 fn calculate_grid(
     mut commands: Commands,
     mut request: EventReader<CalculateGrid>,
-    bodies: Query<(Entity, &Handle<Mesh>, &Aabb, &GlobalTransform)>,
+    bodies: Query<(Entity, &Mesh3d, &Aabb, &GlobalTransform)>,
     meta: Query<(
         Option<&Parent>,
         Option<&Category>,
@@ -289,7 +289,7 @@ fn calculate_grid(
             commands.entity(level).with_children(|level| {
                 level
                     .spawn((
-                        Mesh3d(meshes.add(mesh.into())),
+                        Mesh3d(meshes.add(mesh)),
                         MeshMaterial3d(assets.occupied_material.clone()),
                         Transform::default(),
                         Visibility::default(),
@@ -345,7 +345,7 @@ fn get_group(
 }
 
 fn collect_physical_entities(
-    meshes: &Query<(Entity, &Handle<Mesh>, &Aabb, &GlobalTransform)>,
+    meshes: &Query<(Entity, &Mesh3d, &Aabb, &GlobalTransform)>,
     meta: &Query<(
         Option<&Parent>,
         Option<&Category>,

--- a/rmf_site_editor/src/occupancy.rs
+++ b/rmf_site_editor/src/occupancy.rs
@@ -289,7 +289,7 @@ fn calculate_grid(
             commands.entity(level).with_children(|level| {
                 level
                     .spawn(PbrBundle {
-                        mesh: meshes.add(mesh.into()),
+                        mesh: meshes.add(mesh),
                         material: assets.occupied_material.clone(),
                         ..default()
                     })

--- a/rmf_site_editor/src/occupancy.rs
+++ b/rmf_site_editor/src/occupancy.rs
@@ -288,11 +288,12 @@ fn calculate_grid(
 
             commands.entity(level).with_children(|level| {
                 level
-                    .spawn(PbrBundle {
-                        mesh: meshes.add(mesh),
-                        material: assets.occupied_material.clone(),
-                        ..default()
-                    })
+                    .spawn((
+                        Mesh3d(meshes.add(mesh.into())),
+                        MeshMaterial3d(assets.occupied_material.clone()),
+                        Transform::default(),
+                        Visibility::default(),
+                    ))
                     .insert(Grid {
                         occupied: level_occupied,
                         cell_size,

--- a/rmf_site_editor/src/osm_slippy_map.rs
+++ b/rmf_site_editor/src/osm_slippy_map.rs
@@ -146,7 +146,7 @@ impl OSMTile {
         let uvs: Vec<_> = vertices.iter().map(|(_, _, uv)| *uv).collect();
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-        mesh.set_indices(Some(indices));
+        mesh.insert_indices(indices);
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
         mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);

--- a/rmf_site_editor/src/osm_slippy_map.rs
+++ b/rmf_site_editor/src/osm_slippy_map.rs
@@ -268,7 +268,7 @@ impl OSMTile {
         Self { xtile, ytile, zoom }
     }
 
-    pub async fn get_map_image<'a, 'b>(&'b self) -> Result<Box<Reader<'a>>, AssetReaderError> {
+    pub async fn get_map_image<'a, 'b>(&'b self) -> Result<Box<dyn Reader>, AssetReaderError> {
         let cache_ok: bool;
         let mut cache_full_path: PathBuf;
         #[cfg(not(target_arch = "wasm32"))]

--- a/rmf_site_editor/src/osm_slippy_map.rs
+++ b/rmf_site_editor/src/osm_slippy_map.rs
@@ -23,7 +23,7 @@ use bevy::{
         AssetPath,
     },
     prelude::{Mesh, Vec2},
-    render::{mesh::Indices, render_resource::PrimitiveTopology},
+    render::{mesh::Indices, render_asset::RenderAssetUsages, render_resource::PrimitiveTopology},
 };
 use itertools::Itertools;
 use utm::{lat_lon_to_zone_number, to_utm_wgs84};
@@ -145,7 +145,10 @@ impl OSMTile {
         let normals: Vec<_> = vertices.iter().map(|(_, n, _)| *n).collect();
         let uvs: Vec<_> = vertices.iter().map(|(_, _, uv)| *uv).collect();
 
-        let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+        let mut mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        );
         mesh.insert_indices(indices);
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);

--- a/rmf_site_editor/src/sdf_loader.rs
+++ b/rmf_site_editor/src/sdf_loader.rs
@@ -18,7 +18,6 @@
 use bevy::asset::{io::Reader, AssetLoader, LoadContext};
 use bevy::prelude::*;
 
-use bevy::utils::BoxedFuture;
 use futures_lite::AsyncReadExt;
 
 use thiserror::Error;
@@ -59,18 +58,16 @@ impl AssetLoader for SdfLoader {
     type Asset = bevy::scene::Scene;
     type Settings = ();
     type Error = SdfError;
-    fn load<'a>(
+    async fn load<'a>(
         &'a self,
-        reader: &'a mut Reader,
+        reader: &'a mut Reader<'_>,
         _settings: &'a (),
-        load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
-        Box::pin(async move {
-            let mut bytes = Vec::new();
-            // TODO(luca) remove unwrap
-            reader.read_to_end(&mut bytes).await.unwrap();
-            Ok(load_model(bytes, load_context)?)
-        })
+        load_context: &'a mut LoadContext<'_>,
+    ) -> Result<Self::Asset, Self::Error> {
+        let mut bytes = Vec::new();
+        // TODO(luca) remove unwrap
+        reader.read_to_end(&mut bytes).await.unwrap();
+        Ok(load_model(bytes, load_context)?)
     }
 
     fn extensions(&self) -> &[&str] {

--- a/rmf_site_editor/src/sdf_loader.rs
+++ b/rmf_site_editor/src/sdf_loader.rs
@@ -58,11 +58,11 @@ impl AssetLoader for SdfLoader {
     type Asset = bevy::scene::Scene;
     type Settings = ();
     type Error = SdfError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a (),
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         let mut bytes = Vec::new();
         // TODO(luca) remove unwrap

--- a/rmf_site_editor/src/sdf_loader.rs
+++ b/rmf_site_editor/src/sdf_loader.rs
@@ -264,7 +264,7 @@ fn load_model<'a, 'b>(
             if let Some(model) = root.model {
                 let mut world = World::default();
                 let e = world
-                    .insert((Transform::IDENTITY, Visibility::Inherited))
+                    .spawn((Transform::IDENTITY, Visibility::Inherited))
                     .id();
                 // TODO(luca) hierarchies and joints, rather than flat link importing
                 // All Open-RMF assets have no hierarchy, for now.

--- a/rmf_site_editor/src/sdf_loader.rs
+++ b/rmf_site_editor/src/sdf_loader.rs
@@ -212,7 +212,7 @@ fn spawn_geometry<'a, 'b>(
                     })
                     .insert(pose)
                     .insert(NameInSite(geometry_name.to_owned()))
-                    .insert(SpatialBundle::INHERITED_IDENTITY)
+                    .insert((Transform::IDENTITY, Visibility::Inherited))
                     .id(),
             )
         }
@@ -224,7 +224,7 @@ fn spawn_geometry<'a, 'b>(
                 })
                 .insert(pose)
                 .insert(NameInSite(geometry_name.to_owned()))
-                .insert(SpatialBundle::INHERITED_IDENTITY)
+                .insert((Transform::IDENTITY, Visibility::Inherited))
                 .id(),
         ),
         SdfGeometry::Cylinder(c) => Some(
@@ -235,7 +235,7 @@ fn spawn_geometry<'a, 'b>(
                 })
                 .insert(pose)
                 .insert(NameInSite(geometry_name.to_owned()))
-                .insert(SpatialBundle::INHERITED_IDENTITY)
+                .insert((Transform::IDENTITY, Visibility::Inherited))
                 .id(),
         ),
         SdfGeometry::Sphere(s) => Some(
@@ -245,7 +245,7 @@ fn spawn_geometry<'a, 'b>(
                 })
                 .insert(pose)
                 .insert(NameInSite(geometry_name.to_owned()))
-                .insert(SpatialBundle::INHERITED_IDENTITY)
+                .insert((Transform::IDENTITY, Visibility::Inherited))
                 .id(),
         ),
         _ => None,
@@ -263,13 +263,15 @@ fn load_model<'a, 'b>(
         Ok(root) => {
             if let Some(model) = root.model {
                 let mut world = World::default();
-                let e = world.spawn(SpatialBundle::INHERITED_IDENTITY).id();
+                let e = world
+                    .insert((Transform::IDENTITY, Visibility::Inherited))
+                    .id();
                 // TODO(luca) hierarchies and joints, rather than flat link importing
                 // All Open-RMF assets have no hierarchy, for now.
                 for link in &model.link {
                     let link_pose = parse_pose(&link.pose);
                     let link_id = world
-                        .spawn(SpatialBundle::from_transform(link_pose.transform()))
+                        .spawn((link_pose.transform(), Visibility::Inherited))
                         .id();
                     world.entity_mut(e).add_child(link_id);
                     for visual in &link.visual {

--- a/rmf_site_editor/src/shapes.rs
+++ b/rmf_site_editor/src/shapes.rs
@@ -25,7 +25,9 @@ use bevy::{
     },
 };
 use bevy_mod_outline::ATTRIBUTE_OUTLINE_NORMAL;
-use bevy_mod_outline::{GenerateOutlineNormalsError, OutlineMeshExt};
+use bevy_mod_outline::{
+    GenerateOutlineNormalsError, GenerateOutlineNormalsSettings, OutlineMeshExt,
+};
 use bevy_polyline::{material::PolylineMaterial, polyline::Polyline};
 use rmf_site_format::Angle;
 use std::collections::{BTreeMap, HashMap};
@@ -36,7 +38,7 @@ pub(crate) trait WithOutlineMeshExt: Sized {
 
 impl WithOutlineMeshExt for Mesh {
     fn with_generated_outline_normals(mut self) -> Result<Self, GenerateOutlineNormalsError> {
-        self.generate_outline_normals()?;
+        self.generate_outline_normals(&GenerateOutlineNormalsSettings::default())?;
         Ok(self)
     }
 }

--- a/rmf_site_editor/src/shapes.rs
+++ b/rmf_site_editor/src/shapes.rs
@@ -21,6 +21,7 @@ use bevy::{
     render::{
         mesh::{Indices, PrimitiveTopology, VertexAttributeValues},
         primitives::Aabb,
+        render_asset::RenderAssetUsages,
     },
 };
 use bevy_mod_outline::ATTRIBUTE_OUTLINE_NORMAL;
@@ -235,7 +236,7 @@ impl MeshBuffer {
     }
 
     pub(crate) fn into_outline(self) -> Mesh {
-        let mut mesh = Mesh::new(PrimitiveTopology::LineList);
+        let mut mesh = Mesh::new(PrimitiveTopology::LineList, RenderAssetUsages::default());
         mesh.insert_indices(Indices::U32(self.outline));
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, self.positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, self.normals);
@@ -250,7 +251,10 @@ impl MeshBuffer {
 
 impl From<MeshBuffer> for Mesh {
     fn from(buffer: MeshBuffer) -> Self {
-        let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+        let mut mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        );
         mesh.insert_indices(Indices::U32(buffer.indices));
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, buffer.positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, buffer.normals);
@@ -631,7 +635,10 @@ pub(crate) fn make_dagger_mesh() -> Mesh {
     let top_height = 0.42;
     let segments = 4u32;
 
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    );
     make_boxy_wrap([lower_ring, upper_ring], segments).merge_into(&mut mesh);
     make_pyramid(upper_ring, [0., 0., top_height], segments).merge_into(&mut mesh);
     make_pyramid(lower_ring.flip_height(), [0., 0., 0.], segments)
@@ -686,7 +693,10 @@ pub(crate) fn make_cylinder_arrow_mesh() -> Mesh {
     };
     let resolution = 32u32;
 
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    );
     make_cone(head_base, tip, resolution).merge_into(&mut mesh);
     make_smooth_wrap([cylinder_top, cylinder_bottom], resolution).merge_into(&mut mesh);
     make_smooth_wrap([head_base, cylinder_top], resolution).merge_into(&mut mesh);
@@ -1025,7 +1035,10 @@ pub(crate) fn make_halo_mesh() -> Mesh {
             .collect(),
     );
 
-    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::default(),
+    );
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
     mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);

--- a/rmf_site_editor/src/shapes.rs
+++ b/rmf_site_editor/src/shapes.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use bevy::math::Affine3A;
+use bevy::math::{primitives, Affine3A};
 use bevy::{
     prelude::*,
     render::{
@@ -136,24 +136,24 @@ impl MeshBuffer {
                     if let Some(Indices::U32(indices)) = mesh.indices_mut() {
                         indices.extend(self.indices.into_iter().map(|i| i + offset as u32));
                     } else {
-                        mesh.set_indices(Some(Indices::U32(
+                        mesh.insert_indices(Indices::U32(
                             self.indices
                                 .into_iter()
                                 .map(|i| i + offset as u32)
                                 .collect(),
-                        )));
+                        ));
                     }
                 }
                 PrimitiveTopology::LineList => {
                     if let Some(Indices::U32(indices)) = mesh.indices_mut() {
                         indices.extend(self.outline.into_iter().map(|i| i + offset as u32));
                     } else {
-                        mesh.set_indices(Some(Indices::U32(
+                        mesh.insert_indices(Indices::U32(
                             self.outline
                                 .into_iter()
                                 .map(|i| i + offset as u32)
                                 .collect(),
-                        )));
+                        ));
                     }
                 }
                 other => {
@@ -219,10 +219,10 @@ impl MeshBuffer {
 
             match mesh.primitive_topology() {
                 PrimitiveTopology::TriangleList => {
-                    mesh.set_indices(Some(Indices::U32(self.indices)));
+                    mesh.insert_indices(Indices::U32(self.indices));
                 }
                 PrimitiveTopology::LineList => {
-                    mesh.set_indices(Some(Indices::U32(self.outline)));
+                    mesh.insert_indices(Indices::U32(self.outline));
                 }
                 other => {
                     panic!(
@@ -236,7 +236,7 @@ impl MeshBuffer {
 
     pub(crate) fn into_outline(self) -> Mesh {
         let mut mesh = Mesh::new(PrimitiveTopology::LineList);
-        mesh.set_indices(Some(Indices::U32(self.outline)));
+        mesh.insert_indices(Indices::U32(self.outline));
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, self.positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, self.normals);
         mesh
@@ -251,7 +251,7 @@ impl MeshBuffer {
 impl From<MeshBuffer> for Mesh {
     fn from(buffer: MeshBuffer) -> Self {
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
-        mesh.set_indices(Some(Indices::U32(buffer.indices)));
+        mesh.insert_indices(Indices::U32(buffer.indices));
         mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, buffer.positions);
         mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, buffer.normals);
         if let Some(uv) = buffer.uv {
@@ -262,26 +262,26 @@ impl From<MeshBuffer> for Mesh {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct Circle {
+pub struct OffsetCircle {
     pub radius: f32,
     pub height: f32,
 }
 
-impl Circle {
+impl OffsetCircle {
     fn flip_height(mut self) -> Self {
         self.height = -self.height;
         self
     }
 }
 
-impl From<(f32, f32)> for Circle {
+impl From<(f32, f32)> for OffsetCircle {
     fn from((radius, height): (f32, f32)) -> Self {
         Self { radius, height }
     }
 }
 
 pub(crate) fn make_circles(
-    circles: impl IntoIterator<Item = Circle>,
+    circles: impl IntoIterator<Item = OffsetCircle>,
     resolution: u32,
     gap: f32,
 ) -> impl Iterator<Item = [f32; 3]> {
@@ -299,7 +299,7 @@ pub(crate) fn make_circles(
         });
 }
 
-pub(crate) fn make_boxy_wrap(circles: [Circle; 2], segments: u32) -> MeshBuffer {
+pub(crate) fn make_boxy_wrap(circles: [OffsetCircle; 2], segments: u32) -> MeshBuffer {
     let (bottom_circle, top_circle) = if circles[0].height < circles[1].height {
         (circles[0], circles[1])
     } else {
@@ -347,7 +347,7 @@ pub(crate) fn make_boxy_wrap(circles: [Circle; 2], segments: u32) -> MeshBuffer 
     return MeshBuffer::new(positions, normals, indices);
 }
 
-pub(crate) fn make_smooth_wrap(circles: [Circle; 2], resolution: u32) -> MeshBuffer {
+pub(crate) fn make_smooth_wrap(circles: [OffsetCircle; 2], resolution: u32) -> MeshBuffer {
     let (bottom_circle, top_circle) = if circles[0].height < circles[1].height {
         (circles[0], circles[1])
     } else {
@@ -383,7 +383,7 @@ pub(crate) fn make_smooth_wrap(circles: [Circle; 2], resolution: u32) -> MeshBuf
     return MeshBuffer::new(positions, normals, indices);
 }
 
-pub(crate) fn make_pyramid(circle: Circle, peak: [f32; 3], segments: u32) -> MeshBuffer {
+pub(crate) fn make_pyramid(circle: OffsetCircle, peak: [f32; 3], segments: u32) -> MeshBuffer {
     let positions: Vec<[f32; 3]> = make_circles([circle, circle], segments + 1, 0.)
         .chain([peak].into_iter().cycle().take(segments as usize))
         .collect();
@@ -422,7 +422,7 @@ pub(crate) fn make_pyramid(circle: Circle, peak: [f32; 3], segments: u32) -> Mes
     return MeshBuffer::new(positions, normals, indices);
 }
 
-pub(crate) fn make_cone(circle: Circle, peak: [f32; 3], resolution: u32) -> MeshBuffer {
+pub(crate) fn make_cone(circle: OffsetCircle, peak: [f32; 3], resolution: u32) -> MeshBuffer {
     let positions: Vec<[f32; 3]> = make_circles([circle], resolution + 1, 0.)
         .take(resolution as usize) // skip the last vertex which would close the circle
         .chain([peak].into_iter().cycle().take(resolution as usize))
@@ -571,7 +571,7 @@ pub(crate) fn make_wall_mesh(
         )
 }
 
-pub(crate) fn make_top_circle(circle: Circle, resolution: u32) -> MeshBuffer {
+pub(crate) fn make_top_circle(circle: OffsetCircle, resolution: u32) -> MeshBuffer {
     let positions: Vec<[f32; 3]> = make_circles([circle], resolution, 0.)
         .take(resolution as usize) // skip the vertex which would close the circle
         .chain([[0., 0., circle.height]].into_iter())
@@ -593,7 +593,7 @@ pub(crate) fn make_top_circle(circle: Circle, resolution: u32) -> MeshBuffer {
     return MeshBuffer::new(positions, normals, indices);
 }
 
-pub(crate) fn make_bottom_circle(circle: Circle, resolution: u32) -> MeshBuffer {
+pub(crate) fn make_bottom_circle(circle: OffsetCircle, resolution: u32) -> MeshBuffer {
     let positions: Vec<[f32; 3]> = make_circles([circle], resolution, 0.)
         .take(resolution as usize) // skip the vertex which would close the circle
         .chain([[0., 0., circle.height]].into_iter())
@@ -615,16 +615,16 @@ pub(crate) fn make_bottom_circle(circle: Circle, resolution: u32) -> MeshBuffer 
     return MeshBuffer::new(positions, normals, indices);
 }
 
-pub(crate) fn make_flat_disk(circle: Circle, resolution: u32) -> MeshBuffer {
+pub(crate) fn make_flat_disk(circle: OffsetCircle, resolution: u32) -> MeshBuffer {
     make_top_circle(circle, resolution).merge_with(make_bottom_circle(circle, resolution))
 }
 
 pub(crate) fn make_dagger_mesh() -> Mesh {
-    let lower_ring = Circle {
+    let lower_ring = OffsetCircle {
         radius: 0.01,
         height: 0.1,
     };
-    let upper_ring = Circle {
+    let upper_ring = OffsetCircle {
         radius: 0.02,
         height: 0.4,
     };
@@ -643,15 +643,15 @@ pub(crate) fn make_dagger_mesh() -> Mesh {
 }
 
 pub(crate) fn make_cylinder(height: f32, radius: f32) -> MeshBuffer {
-    let top_circle = Circle {
+    let top_circle = OffsetCircle {
         height: height / 2.0,
         radius,
     };
-    let mid_circle = Circle {
+    let mid_circle = OffsetCircle {
         height: 0.0,
         radius,
     };
-    let bottom_circle = Circle {
+    let bottom_circle = OffsetCircle {
         height: -height / 2.0,
         radius,
     };
@@ -672,15 +672,15 @@ pub(crate) fn make_cylinder_arrow_mesh() -> Mesh {
     let l_head = 0.2;
     let r_head = 0.15;
     let r_base = 0.1;
-    let head_base = Circle {
+    let head_base = OffsetCircle {
         radius: r_head,
         height: 1.0 - l_head,
     };
-    let cylinder_top = Circle {
+    let cylinder_top = OffsetCircle {
         radius: r_base,
         height: 1.0 - l_head,
     };
-    let cylinder_bottom = Circle {
+    let cylinder_bottom = OffsetCircle {
         radius: r_base,
         height: 0.0,
     };
@@ -861,12 +861,12 @@ pub(crate) fn make_physical_camera_mesh() -> Mesh {
     let lens_hood_protrusion = 0.8;
 
     // Main body
-    let mut mesh: Mesh = shape::Box::new(scale, scale, scale).into();
+    let mut mesh: Mesh = primitives::Cuboid::new(scale, scale, scale).into();
     mesh.remove_attribute(Mesh::ATTRIBUTE_UV_0);
 
     // Outside of the lens hood
     make_pyramid(
-        Circle {
+        OffsetCircle {
             radius: scale,
             height: 0.,
         },
@@ -882,7 +882,7 @@ pub(crate) fn make_physical_camera_mesh() -> Mesh {
 
     // Inside of the lens hood
     make_pyramid(
-        Circle {
+        OffsetCircle {
             radius: scale,
             height: scale,
         },
@@ -901,7 +901,7 @@ pub(crate) fn make_physical_camera_mesh() -> Mesh {
 
 pub(crate) fn make_diamond(tip: f32, width: f32) -> MeshBuffer {
     make_pyramid(
-        Circle {
+        OffsetCircle {
             radius: width,
             height: 0.0,
         },
@@ -910,7 +910,7 @@ pub(crate) fn make_diamond(tip: f32, width: f32) -> MeshBuffer {
     )
     .merge_with(
         make_pyramid(
-            Circle {
+            OffsetCircle {
                 radius: width,
                 height: 0.0,
             },
@@ -1029,7 +1029,7 @@ pub(crate) fn make_halo_mesh() -> Mesh {
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
     mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
-    mesh.set_indices(Some(indices));
+    mesh.insert_indices(indices);
     return mesh;
 }
 
@@ -1235,10 +1235,10 @@ pub(crate) fn make_closed_path_outline(mut initial_positions: Vec<[f32; 3]>) -> 
         .copy_outline_normals()
 }
 
-const X_AXIS_COLOR: Color = Color::rgb(1.0, 0.2, 0.2);
-const Y_AXIS_COLOR: Color = Color::rgb(0.2, 1.0, 0.2);
-const NEG_X_AXIS_COLOR: Color = Color::rgb(0.5, 0.0, 0.0);
-const NEG_Y_AXIS_COLOR: Color = Color::rgb(0.0, 0.5, 0.0);
+const X_AXIS_COLOR: Color = Color::srgb(1.0, 0.2, 0.2);
+const Y_AXIS_COLOR: Color = Color::srgb(0.2, 1.0, 0.2);
+const NEG_X_AXIS_COLOR: Color = Color::srgb(0.5, 0.0, 0.0);
+const NEG_Y_AXIS_COLOR: Color = Color::srgb(0.0, 0.5, 0.0);
 
 const POLYLINE_SEPARATOR: Vec3 = Vec3::splat(std::f32::NAN);
 
@@ -1280,7 +1280,7 @@ pub(crate) fn make_finite_grid(
                 };
                 let material = PolylineMaterial {
                     width,
-                    color,
+                    color: color.into(),
                     depth_bias,
                     perspective,
                 };
@@ -1312,7 +1312,7 @@ pub(crate) fn make_finite_grid(
         let width = *weights.get(&n).unwrap();
         let material = PolylineMaterial {
             width,
-            color,
+            color: color.into(),
             depth_bias,
             perspective,
         };

--- a/rmf_site_editor/src/site/anchor.rs
+++ b/rmf_site_editor/src/site/anchor.rs
@@ -16,10 +16,11 @@
 */
 
 use crate::{site::*, Issue, ValidateWorkspace};
-use bevy::{ecs::system::Command, prelude::*, render::primitives::Sphere, utils::Uuid};
+use bevy::{ecs::world::Command, prelude::*, render::primitives::Sphere};
 use itertools::Itertools;
 use rmf_site_format::{Anchor, LevelElevation, LiftCabin};
 use std::collections::HashMap;
+use uuid::Uuid;
 
 #[derive(Bundle, Debug)]
 pub struct AnchorBundle {

--- a/rmf_site_editor/src/site/assets.rs
+++ b/rmf_site_editor/src/site/assets.rs
@@ -16,7 +16,11 @@
 */
 
 use crate::{shapes::*, site::*};
-use bevy::{asset::embedded_asset, math::Affine3A, prelude::*};
+use bevy::{
+    asset::embedded_asset,
+    math::{primitives, Affine3A},
+    prelude::*,
+};
 
 pub(crate) fn add_site_icons(app: &mut App) {
     // Taken from https://github.com/bevyengine/bevy/issues/10377#issuecomment-1858797002
@@ -109,19 +113,20 @@ impl FromWorld for SiteAssets {
             .get_resource_mut::<Assets<StandardMaterial>>()
             .unwrap();
         let unassigned_lane_material =
-            materials.add(old_default_material(Color::rgb(0.1, 0.1, 0.1)));
-        let select_color = Color::rgb(1., 0.3, 1.);
-        let hover_color = Color::rgb(0.3, 1., 1.);
-        let hover_select_color = Color::rgb(1.0, 0.0, 0.3);
+            materials.add(old_default_material(Color::srgb(0.1, 0.1, 0.1)));
+        let select_color = Color::srgb(1., 0.3, 1.);
+        let hover_color = Color::srgb(0.3, 1., 1.);
+        let hover_select_color = Color::srgb(1.0, 0.0, 0.3);
         let select_material = materials.add(old_default_material(select_color));
         let hover_material = materials.add(old_default_material(hover_color));
         let hover_select_material = materials.add(old_default_material(hover_select_color));
-        // let hover_select_material = materials.add(Color::rgb_u8(177, 178, 255).into());
-        // let hover_select_material = materials.add(Color::rgb_u8(214, 28, 78).into());
-        let measurement_material = materials.add(old_default_material(Color::rgb_u8(250, 234, 72)));
-        let fiducial_material = materials.add(old_default_material(Color::rgb(0.1, 0.1, 0.8)));
+        // let hover_select_material = materials.add(Color::srgb_u8(177, 178, 255));
+        // let hover_select_material = materials.add(Color::srgb_u8(214, 28, 78));
+        let measurement_material =
+            materials.add(old_default_material(Color::srgb_u8(250, 234, 72)));
+        let fiducial_material = materials.add(old_default_material(Color::srgb(0.1, 0.1, 0.8)));
         let passive_anchor_material = materials.add(StandardMaterial {
-            base_color: Color::rgb(0.4, 0.7, 0.6),
+            base_color: Color::srgb(0.4, 0.7, 0.6),
             // unlit: true,
             unlit: false,
             perceptual_roughness: 0.089,
@@ -131,7 +136,7 @@ impl FromWorld for SiteAssets {
         let unassigned_anchor_material = materials.add(StandardMaterial {
             // unlit: true,
             unlit: false,
-            ..old_default_material(Color::rgb(1.0, 0.9, 0.05))
+            ..old_default_material(Color::srgb(1.0, 0.9, 0.05))
         });
         let hover_anchor_material = materials.add(StandardMaterial {
             // unlit: true,
@@ -153,29 +158,29 @@ impl FromWorld for SiteAssets {
             depth_bias: 1.0,
             // unlit: true,
             unlit: false,
-            ..old_default_material(Color::rgba(0.98, 0.91, 0.28, 0.5))
+            ..old_default_material(Color::srgba(0.98, 0.91, 0.28, 0.5))
         });
         let lift_wall_material =
-            materials.add(old_default_material(Color::rgba(0.7, 0.7, 0.7, 1.0)));
-        let lift_floor_material = materials.add(old_default_material(Color::rgb(0.3, 0.3, 0.3)));
+            materials.add(old_default_material(Color::srgba(0.7, 0.7, 0.7, 1.0)));
+        let lift_floor_material = materials.add(old_default_material(Color::srgb(0.3, 0.3, 0.3)));
         let door_body_material = materials.add(StandardMaterial {
             alpha_mode: AlphaMode::Blend,
-            ..old_default_material(Color::rgba(1., 1., 1., 0.8))
+            ..old_default_material(Color::srgba(1., 1., 1., 0.8))
         });
         let translucent_black = materials.add(StandardMaterial {
             alpha_mode: AlphaMode::Blend,
-            ..old_default_material(Color::rgba(0., 0., 0., 0.8))
+            ..old_default_material(Color::srgba(0., 0., 0., 0.8))
         });
         let translucent_white = materials.add(StandardMaterial {
             alpha_mode: AlphaMode::Blend,
-            ..old_default_material(Color::rgba(1., 1., 1., 0.8))
+            ..old_default_material(Color::srgba(1., 1., 1., 0.8))
         });
         let physical_camera_material =
-            materials.add(old_default_material(Color::rgb(0.6, 0.7, 0.8)));
+            materials.add(old_default_material(Color::srgb(0.6, 0.7, 0.8)));
         let occupied_material =
-            materials.add(old_default_material(Color::rgba(0.8, 0.1, 0.1, 0.2)));
+            materials.add(old_default_material(Color::srgba(0.8, 0.1, 0.1, 0.2)));
         let default_mesh_grey_material =
-            materials.add(old_default_material(Color::rgb(0.7, 0.7, 0.7)));
+            materials.add(old_default_material(Color::srgb(0.7, 0.7, 0.7)));
 
         let charger_material = materials.add(old_default_material_t(charger_texture));
         let holding_point_material = materials.add(old_default_material_t(holding_point_texture));
@@ -183,10 +188,9 @@ impl FromWorld for SiteAssets {
 
         let mut meshes = world.get_resource_mut::<Assets<Mesh>>().unwrap();
         let level_anchor_mesh = meshes.add(
-            Mesh::from(shape::UVSphere {
-                radius: 0.05, // TODO(MXG): Make the vertex radius configurable
-                ..Default::default()
-            })
+            Mesh::from(
+                primitives::Sphere::new(0.05), // TODO(MXG): Make the vertex radius configurable
+            )
             .with_generated_outline_normals()
             .unwrap(),
         );
@@ -194,34 +198,27 @@ impl FromWorld for SiteAssets {
             .add(Mesh::from(make_diamond(0.15 / 2.0, 0.15).transform_by(
                 Affine3A::from_translation([0.0, 0.0, 0.15 / 2.0].into()),
             )));
-        let site_anchor_mesh = meshes.add(Mesh::from(shape::UVSphere {
-            radius: 0.05, // TODO(MXG): Make the vertex radius configurable
-            ..Default::default()
-        }));
-        let lane_mid_mesh = meshes.add(make_flat_square_mesh(1.0).into());
-        let lane_mid_outline = meshes.add(make_flat_rect_mesh(1.0, 1.125).into());
-        let lane_end_mesh = meshes.add(
-            make_flat_disk(
-                Circle {
-                    radius: LANE_WIDTH / 2.0,
-                    height: 0.0,
-                },
-                32,
-            )
-            .into(),
-        );
-        let lane_end_outline = meshes.add(
-            make_flat_disk(
-                Circle {
-                    radius: 1.125 * LANE_WIDTH / 2.0,
-                    height: 0.0,
-                },
-                32,
-            )
-            .into(),
-        );
+        let site_anchor_mesh = meshes.add(Mesh::from(
+            primitives::Sphere::new(0.05), // TODO(MXG): Make the vertex radius configurable
+        ));
+        let lane_mid_mesh = meshes.add(make_flat_square_mesh(1.0));
+        let lane_mid_outline = meshes.add(make_flat_rect_mesh(1.0, 1.125));
+        let lane_end_mesh = meshes.add(make_flat_disk(
+            OffsetCircle {
+                radius: LANE_WIDTH / 2.0,
+                height: 0.0,
+            },
+            32,
+        ));
+        let lane_end_outline = meshes.add(make_flat_disk(
+            OffsetCircle {
+                radius: 1.125 * LANE_WIDTH / 2.0,
+                height: 0.0,
+            },
+            32,
+        ));
         let box_mesh = meshes.add(
-            Mesh::from(shape::Box::new(1., 1., 1.))
+            Mesh::from(primitives::Cuboid::new(1., 1., 1.))
                 .with_generated_outline_normals()
                 .unwrap(),
         );
@@ -243,8 +240,7 @@ impl FromWorld for SiteAssets {
             .with_generated_outline_normals()
             .unwrap(),
         );
-        let location_tag_mesh =
-            meshes.add(make_location_icon(1.1 * LANE_WIDTH / 2.0, 0.01, 6).into());
+        let location_tag_mesh = meshes.add(make_location_icon(1.1 * LANE_WIDTH / 2.0, 0.01, 6));
         let physical_camera_mesh = meshes.add(
             make_physical_camera_mesh()
                 .with_generated_outline_normals()

--- a/rmf_site_editor/src/site/deletion.rs
+++ b/rmf_site_editor/src/site/deletion.rs
@@ -399,7 +399,7 @@ fn perform_deletions(all_to_delete: HashSet<Entity>, params: &mut DeletionParams
                 // level because all the existing levels are being deleted.
                 let new_level = params
                     .commands
-                    .spawn(SpatialBundle::default())
+                    .spawn((Transform::default(), Visibility::default()))
                     .insert(LevelProperties {
                         name: NameInSite("<Unnamed>".to_owned()),
                         elevation: LevelElevation(0.0),

--- a/rmf_site_editor/src/site/display_color.rs
+++ b/rmf_site_editor/src/site/display_color.rs
@@ -24,14 +24,14 @@ pub fn add_material_for_display_colors(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     for (e, c) in &new_display {
-        commands
-            .entity(e)
-            .insert(materials.add(old_default_material(Color::srgb_from_array(c.0))));
+        commands.entity(e).insert(MeshMaterial3d(
+            materials.add(old_default_material(Color::srgb_from_array(c.0))),
+        ));
     }
 }
 
 pub fn update_material_for_display_color(
-    changed_color: Query<(&DisplayColor, &Handle<StandardMaterial>), Changed<DisplayColor>>,
+    changed_color: Query<(&DisplayColor, &MeshMaterial3d<StandardMaterial>), Changed<DisplayColor>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     for (color, material) in &changed_color {

--- a/rmf_site_editor/src/site/display_color.rs
+++ b/rmf_site_editor/src/site/display_color.rs
@@ -26,9 +26,7 @@ pub fn add_material_for_display_colors(
     for (e, c) in &new_display {
         commands
             .entity(e)
-            .insert(materials.add(old_default_material(Color::srgba(
-                c.0[0], c.0[1], c.0[2], c.0[3],
-            ))));
+            .insert(materials.add(old_default_material(Color::srgb_from_array(c.0))));
     }
 }
 
@@ -38,7 +36,7 @@ pub fn update_material_for_display_color(
 ) {
     for (color, material) in &changed_color {
         if let Some(m) = materials.get_mut(material) {
-            m.base_color = Color::srgba(color.0[0], color.0[1], color.0[2], color.0[3]);
+            m.base_color = Color::srgb_from_array(color.0);
         }
     }
 }

--- a/rmf_site_editor/src/site/display_color.rs
+++ b/rmf_site_editor/src/site/display_color.rs
@@ -26,7 +26,7 @@ pub fn add_material_for_display_colors(
     for (e, c) in &new_display {
         commands
             .entity(e)
-            .insert(materials.add(old_default_material(Color::rgba(
+            .insert(materials.add(old_default_material(Color::srgba(
                 c.0[0], c.0[1], c.0[2], c.0[3],
             ))));
     }
@@ -38,7 +38,7 @@ pub fn update_material_for_display_color(
 ) {
     for (color, material) in &changed_color {
         if let Some(m) = materials.get_mut(material) {
-            m.base_color = color.0.into();
+            m.base_color = Color::srgba(color.0[0], color.0[1], color.0[2], color.0[3]);
         }
     }
 }

--- a/rmf_site_editor/src/site/door.rs
+++ b/rmf_site_editor/src/site/door.rs
@@ -23,7 +23,10 @@ use crate::{
 };
 use bevy::{
     prelude::*,
-    render::mesh::{Indices, PrimitiveTopology},
+    render::{
+        mesh::{Indices, PrimitiveTopology},
+        render_asset::RenderAssetUsages,
+    },
 };
 use rmf_site_format::{Category, DoorType, Edge, DEFAULT_LEVEL_HEIGHT};
 use std::collections::{BTreeSet, HashMap};
@@ -264,7 +267,10 @@ fn make_door_cues(door_width: f32, kind: &DoorType) -> (Mesh, Mesh) {
                 .into_mesh_and_outline()
         }
         _ => {
-            let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+            let mut mesh = Mesh::new(
+                PrimitiveTopology::TriangleList,
+                RenderAssetUsages::default(),
+            );
             mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, Vec::<[f32; 3]>::new());
             mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, Vec::<[f32; 3]>::new());
             mesh.insert_indices(Indices::U32(vec![]));

--- a/rmf_site_editor/src/site/door.rs
+++ b/rmf_site_editor/src/site/door.rs
@@ -345,8 +345,8 @@ pub fn add_door_visuals(
             })
             .insert(Category::Door)
             .insert(EdgeLabels::LeftRight)
-            .push_children(&[cue_inner, cue_outline])
-            .push_children(&bodies);
+            .add_children(&[cue_inner, cue_outline])
+            .add_children(&bodies);
 
         for anchor in edge.array() {
             if let Ok(mut deps) = dependents.get_mut(anchor) {

--- a/rmf_site_editor/src/site/door.rs
+++ b/rmf_site_editor/src/site/door.rs
@@ -301,31 +301,33 @@ pub fn add_door_visuals(
             .iter()
             .map(|tf| {
                 commands
-                    .spawn(PbrBundle {
-                        mesh: assets.box_mesh.clone(),
-                        material: assets.door_body_material.clone(),
-                        transform: *tf,
-                        ..default()
-                    })
+                    .spawn((
+                        Mesh3d(assets.box_mesh.clone()),
+                        MeshMaterial3d(assets.door_body_material.clone()),
+                        *tf,
+                        Visibility::default(),
+                    ))
                     .insert(Selectable::new(e))
                     .id()
             })
             .collect::<Vec<_>>();
         let body = DoorBodyType::from_door_type(kind, &bodies);
         let cue_inner = commands
-            .spawn(PbrBundle {
-                mesh: meshes.add(cue_inner_mesh),
-                material: assets.translucent_white.clone(),
-                ..default()
-            })
+            .spawn((
+                Mesh3d(meshes.add(cue_inner_mesh)),
+                MeshMaterial3d(assets.translucent_white.clone()),
+                Transform::default(),
+                Visibility::default(),
+            ))
             .id();
 
         let cue_outline = commands
-            .spawn(PbrBundle {
-                mesh: meshes.add(cue_outline_mesh),
-                material: assets.translucent_black.clone(),
-                ..default()
-            })
+            .spawn((
+                Mesh3d(meshes.add(cue_outline_mesh)),
+                MeshMaterial3d(assets.translucent_black.clone()),
+                Transform::default(),
+                Visibility::default(),
+            ))
             .id();
 
         // Level doors for lifts may have already been given a Visibility
@@ -335,11 +337,7 @@ pub fn add_door_visuals(
 
         commands
             .entity(e)
-            .insert(SpatialBundle {
-                transform: pose_tf,
-                visibility,
-                ..default()
-            })
+            .insert((pose_tf, visibility))
             .insert(DoorSegments {
                 body,
                 cue_inner,
@@ -382,12 +380,12 @@ fn update_door_visuals(
     for door_tf in door_tfs.iter().skip(entities.len()) {
         // New doors were added, we need to spawn them
         let id = commands
-            .spawn(PbrBundle {
-                mesh: assets.box_mesh.clone(),
-                material: assets.door_body_material.clone(),
-                transform: *door_tf,
-                ..default()
-            })
+            .spawn((
+                Mesh3d(assets.box_mesh.clone()),
+                MeshMaterial3d(assets.door_body_material.clone()),
+                *door_tf,
+                Visibility::default(),
+            ))
             .insert(Selectable::new(entity))
             .id();
         entities.push(id);

--- a/rmf_site_editor/src/site/door.rs
+++ b/rmf_site_editor/src/site/door.rs
@@ -364,7 +364,7 @@ fn update_door_visuals(
     segments: &DoorSegments,
     anchors: &AnchorParams,
     transforms: &mut Query<&mut Transform>,
-    mesh_handles: &mut Query<&mut Handle<Mesh>>,
+    mesh_handles: &mut Query<&mut Mesh3d>,
     mesh_assets: &mut ResMut<Assets<Mesh>>,
     assets: &Res<SiteAssets>,
 ) -> Option<DoorBodyType> {
@@ -396,9 +396,9 @@ fn update_door_visuals(
         commands.entity(*e).despawn_recursive();
     }
     let mut cue_inner = mesh_handles.get_mut(segments.cue_inner).unwrap();
-    *cue_inner = mesh_assets.add(cue_inner_mesh);
+    *cue_inner = Mesh3d(mesh_assets.add(cue_inner_mesh));
     let mut cue_outline = mesh_handles.get_mut(segments.cue_outline).unwrap();
-    *cue_outline = mesh_assets.add(cue_outline_mesh);
+    *cue_outline = Mesh3d(mesh_assets.add(cue_outline_mesh));
     let new_segments = DoorBodyType::from_door_type(kind, &entities);
     if new_segments != segments.body {
         Some(new_segments)
@@ -421,7 +421,7 @@ pub fn update_changed_door(
     >,
     anchors: AnchorParams,
     mut transforms: Query<&mut Transform>,
-    mut mesh_handles: Query<&mut Handle<Mesh>>,
+    mut mesh_handles: Query<&mut Mesh3d>,
     mut mesh_assets: ResMut<Assets<Mesh>>,
     assets: Res<SiteAssets>,
 ) {
@@ -461,7 +461,7 @@ pub fn update_door_for_moved_anchors(
         ),
     >,
     mut transforms: Query<&mut Transform>,
-    mut mesh_handles: Query<&mut Handle<Mesh>>,
+    mut mesh_handles: Query<&mut Mesh3d>,
     mut mesh_assets: ResMut<Assets<Mesh>>,
     assets: Res<SiteAssets>,
 ) {

--- a/rmf_site_editor/src/site/door.rs
+++ b/rmf_site_editor/src/site/door.rs
@@ -24,10 +24,10 @@ use crate::{
 use bevy::{
     prelude::*,
     render::mesh::{Indices, PrimitiveTopology},
-    utils::Uuid,
 };
 use rmf_site_format::{Category, DoorType, Edge, DEFAULT_LEVEL_HEIGHT};
 use std::collections::{BTreeSet, HashMap};
+use uuid::Uuid;
 
 pub const DOOR_CUE_HEIGHT: f32 = 0.004;
 pub const DOOR_STOP_LINE_THICKNESS: f32 = 0.01;
@@ -267,7 +267,7 @@ fn make_door_cues(door_width: f32, kind: &DoorType) -> (Mesh, Mesh) {
             let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
             mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, Vec::<[f32; 3]>::new());
             mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, Vec::<[f32; 3]>::new());
-            mesh.set_indices(Some(Indices::U32(vec![])));
+            mesh.insert_indices(Indices::U32(vec![]));
             (mesh.clone(), mesh)
         }
     }

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -207,7 +207,7 @@ pub fn handle_loaded_drawing(
                     .entity(entity)
                     // Put a handle for the material into the main entity
                     // so that we can modify it during interactions.
-                    .insert(material)
+                    .insert(MeshMaterial3d(material))
                     .remove::<LoadingDrawing>();
             }
             LoadState::Failed(e) => {
@@ -328,7 +328,7 @@ fn iter_update_drawing_visibility<'a>(
             &'a DrawingSegments,
         ),
     >,
-    material_handles: &Query<&Handle<StandardMaterial>>,
+    material_handles: &Query<&MeshMaterial3d<StandardMaterial>>,
     material_assets: &mut ResMut<Assets<StandardMaterial>>,
     default_drawing_vis: &Query<&GlobalDrawingVisibility>,
 ) {
@@ -363,7 +363,7 @@ pub fn update_drawing_visibility(
         Option<&RecencyRank<DrawingMarker>>,
         &DrawingSegments,
     )>,
-    material_handles: Query<&Handle<StandardMaterial>>,
+    material_handles: Query<&MeshMaterial3d<StandardMaterial>>,
     mut material_assets: ResMut<Assets<StandardMaterial>>,
     default_drawing_vis: Query<&GlobalDrawingVisibility>,
     changed_default_drawing_vis: Query<&Children, Changed<GlobalDrawingVisibility>>,

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -157,14 +157,14 @@ pub fn handle_loaded_drawing(
                 let mesh = make_flat_rect_mesh(width, height).transform_by(
                     Affine3A::from_translation(Vec3::new(width / 2.0, -height / 2.0, 0.0)),
                 );
-                let mesh = mesh_assets.add(mesh.into());
+                let mesh = mesh_assets.add(mesh);
                 let default = parent
                     .map(|p| default_drawing_vis.get(p.get()).ok())
                     .flatten();
                 let (alpha, alpha_mode) = drawing_alpha(vis, rank, default);
                 let material = materials.add(StandardMaterial {
                     base_color_texture: Some(handle.0.clone()),
-                    base_color: *Color::default().set_a(alpha),
+                    base_color: Color::default().with_alpha(alpha),
                     alpha_mode,
                     perceptual_roughness: 0.089,
                     metallic: 0.01,
@@ -205,8 +205,8 @@ pub fn handle_loaded_drawing(
                     .insert(material)
                     .remove::<LoadingDrawing>();
             }
-            LoadState::Failed => {
-                error!("Failed loading drawing {:?}", source);
+            LoadState::Failed(e) => {
+                error!("Failed loading drawing {:?}, reason: [{:?}]", source, e);
                 commands.entity(entity).remove::<LoadingDrawing>();
             }
             _ => {}
@@ -331,7 +331,7 @@ fn iter_update_drawing_visibility<'a>(
                     .map(|p| default_drawing_vis.get(p.get()).ok())
                     .flatten();
                 let (alpha, alpha_mode) = drawing_alpha(vis, rank, default);
-                mat.base_color = *mat.base_color.set_a(alpha);
+                mat.base_color = mat.base_color.with_alpha(alpha);
                 mat.alpha_mode = alpha_mode;
             }
         }

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -190,7 +190,7 @@ pub fn handle_loaded_drawing(
                             Visibility::Inherited,
                         ))
                         .insert(Selectable::new(entity))
-                        .push_children(&[leaf]);
+                        .add_children(&[leaf]);
                     leaf
                 };
                 let z = drawing_layer_height(rank);

--- a/rmf_site_editor/src/site/drawing.rs
+++ b/rmf_site_editor/src/site/drawing.rs
@@ -181,9 +181,14 @@ pub fn handle_loaded_drawing(
                     commands
                         .entity(entity)
                         .insert(DrawingSegments { leaf })
-                        .insert(SpatialBundle::from_transform(pose.transform().with_scale(
-                            Vec3::new(1.0 / pixels_per_meter.0, 1.0 / pixels_per_meter.0, 1.),
-                        )))
+                        .insert((
+                            pose.transform().with_scale(Vec3::new(
+                                1.0 / pixels_per_meter.0,
+                                1.0 / pixels_per_meter.0,
+                                1.,
+                            )),
+                            Visibility::Inherited,
+                        ))
                         .insert(Selectable::new(entity))
                         .push_children(&[leaf]);
                     leaf
@@ -191,12 +196,12 @@ pub fn handle_loaded_drawing(
                 let z = drawing_layer_height(rank);
                 commands
                     .entity(leaf)
-                    .insert(PbrBundle {
-                        mesh,
-                        material: material.clone(),
-                        transform: Transform::from_xyz(0.0, 0.0, z),
-                        ..Default::default()
-                    })
+                    .insert((
+                        Mesh3d(mesh),
+                        MeshMaterial3d(material.clone()),
+                        Transform::from_xyz(0.0, 0.0, z),
+                        Visibility::default(),
+                    ))
                     .insert(Selectable::new(entity));
                 commands
                     .entity(entity)
@@ -269,11 +274,14 @@ pub fn update_drawing_children_to_pixel_coordinates(
                 if let Ok(mut tf) = transforms.get_mut(*child) {
                     tf.scale = Vec3::new(pixels_per_meter.0, pixels_per_meter.0, 1.0);
                 } else {
-                    commands
-                        .entity(*child)
-                        .insert(SpatialBundle::from_transform(Transform::from_scale(
-                            Vec3::new(pixels_per_meter.0, pixels_per_meter.0, 1.0),
-                        )));
+                    commands.entity(*child).insert((
+                        Transform::from_scale(Vec3::new(
+                            pixels_per_meter.0,
+                            pixels_per_meter.0,
+                            1.0,
+                        )),
+                        Visibility::Inherited,
+                    ));
                 }
             }
         }

--- a/rmf_site_editor/src/site/drawing_editor/mod.rs
+++ b/rmf_site_editor/src/site/drawing_editor/mod.rs
@@ -50,7 +50,9 @@ pub struct CurrentEditDrawing {
 
 impl FromWorld for CurrentEditDrawing {
     fn from_world(world: &mut World) -> Self {
-        let editor = world.spawn(SpatialBundle::default()).id();
+        let editor = world
+            .spawn((Transform::default(), Visibility::default()))
+            .id();
         Self {
             editor,
             target: None,
@@ -114,10 +116,7 @@ fn switch_edit_drawing_mode(
             commands
                 .entity(*e)
                 .set_parent(current.editor)
-                .insert(VisibilityBundle {
-                    visibility: Visibility::Inherited,
-                    ..default()
-                })
+                .insert(Visibility::Inherited)
                 .insert(PreventDeletion::because(
                     "Cannot delete a drawing that is currently being edited".to_owned(),
                 ))

--- a/rmf_site_editor/src/site/fiducial.rs
+++ b/rmf_site_editor/src/site/fiducial.rs
@@ -18,8 +18,9 @@
 use crate::interaction::VisualCue;
 use crate::site::*;
 use crate::{Issue, ValidateWorkspace};
-use bevy::{prelude::*, utils::Uuid};
+use bevy::prelude::*;
 use std::collections::HashMap;
+use uuid::Uuid;
 
 #[derive(Component)]
 pub struct FiducialUsage {

--- a/rmf_site_editor/src/site/fiducial.rs
+++ b/rmf_site_editor/src/site/fiducial.rs
@@ -219,14 +219,16 @@ pub fn add_fiducial_visuals(
         }
 
         if tf.is_none() {
-            commands.entity(e).insert(SpatialBundle::INHERITED_IDENTITY);
+            commands
+                .entity(e)
+                .insert((Transform::IDENTITY, Visibility::Inherited));
         }
 
         commands
             .entity(e)
             .insert(assets.fiducial_mesh.clone())
             .insert(assets.fiducial_material.clone())
-            .insert(VisibilityBundle::default())
+            .insert(Visibility::default())
             .insert(Category::Fiducial)
             .insert(VisualCue::outline());
     }

--- a/rmf_site_editor/src/site/fiducial.rs
+++ b/rmf_site_editor/src/site/fiducial.rs
@@ -226,8 +226,8 @@ pub fn add_fiducial_visuals(
 
         commands
             .entity(e)
-            .insert(assets.fiducial_mesh.clone())
-            .insert(assets.fiducial_material.clone())
+            .insert(Mesh3d(assets.fiducial_mesh.clone()))
+            .insert(MeshMaterial3d(assets.fiducial_material.clone()))
             .insert(Visibility::default())
             .insert(Category::Fiducial)
             .insert(VisualCue::outline());

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -16,7 +16,11 @@
 */
 
 use crate::{interaction::Selectable, shapes::*, site::*, RecencyRanking};
-use bevy::{math::Affine3A, prelude::*, render::mesh::PrimitiveTopology};
+use bevy::{
+    math::Affine3A,
+    prelude::*,
+    render::{mesh::PrimitiveTopology, render_asset::RenderAssetUsages},
+};
 use geo::{
     geometry::{LineString, MultiPolygon, Polygon},
     BooleanOps, CoordsIter, TriangulateSpade,
@@ -68,7 +72,10 @@ fn make_floor_mesh(
     lifts: &Query<(&Transform, &LiftCabin<Entity>)>,
 ) -> Mesh {
     if anchor_path.len() == 0 {
-        return Mesh::new(PrimitiveTopology::TriangleList);
+        return Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::default(),
+        );
     } else if anchor_path.len() == 1 {
         let p = anchors
             .point_in_parent_frame_of(anchor_path[0], Category::Floor, entity)

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -219,7 +219,7 @@ fn floor_transparency(
     } else {
         AlphaMode::Opaque
     };
-    (*Color::default().with_alpha(alpha), alpha_mode)
+    (Color::default().with_alpha(alpha), alpha_mode)
 }
 
 pub fn add_floor_visuals(

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -212,7 +212,7 @@ fn floor_transparency(
     } else {
         AlphaMode::Opaque
     };
-    (*Color::default().set_a(alpha), alpha_mode)
+    (*Color::default().with_alpha(alpha), alpha_mode)
 }
 
 pub fn add_floor_visuals(

--- a/rmf_site_editor/src/site/floor.rs
+++ b/rmf_site_editor/src/site/floor.rs
@@ -262,20 +262,18 @@ pub fn add_floor_visuals(
         });
 
         let mesh_entity_id = commands
-            .spawn(PbrBundle {
-                mesh: meshes.add(mesh),
-                material,
-                ..default()
-            })
+            .spawn((
+                Mesh3d(meshes.add(mesh)),
+                MeshMaterial3d(material),
+                Transform::default(),
+                Visibility::default(),
+            ))
             .insert(Selectable::new(e))
             .id();
 
         commands
             .entity(e)
-            .insert(SpatialBundle {
-                transform: Transform::from_xyz(0.0, 0.0, height),
-                ..default()
-            })
+            .insert((Transform::from_xyz(0.0, 0.0, height), Visibility::default()))
             .insert(FloorSegments {
                 mesh: mesh_entity_id,
             })

--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -1,6 +1,6 @@
-use bevy::{asset::AssetPath, prelude::*, window::PrimaryWindow};
+use bevy::{asset::AssetPath, math::Ray3d, prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
-use bevy_mod_raycast::primitives::rays::Ray3d;
+use bevy_mod_raycast::primitives::rays;
 use camera_controls::{CameraControls, ProjectionMode};
 use rmf_site_format::{GeographicComponent, GeographicOffset};
 use std::collections::HashSet;
@@ -424,26 +424,30 @@ pub fn render_map_tiles(
                     let Ok(primary_window) = primary_window.get_single() else {
                         return;
                     };
-                    let top_left_ray = Ray3d::from_screenspace(
+                    let top_left_ray = rays::ray_from_screenspace(
                         Vec2::new(0.0, 0.0),
                         camera,
                         transform,
                         primary_window,
                     );
-                    let top_right_ray = Ray3d::from_screenspace(
+                    let top_right_ray = rays::ray_from_screenspace(
                         Vec2::new(viewport_size.x, 0.0),
                         camera,
                         transform,
                         primary_window,
                     );
-                    let bottom_left_ray = Ray3d::from_screenspace(
+                    let bottom_left_ray = rays::ray_from_screenspace(
                         Vec2::new(0.0, viewport_size.y),
                         camera,
                         transform,
                         primary_window,
                     );
-                    let bottom_right_ray =
-                        Ray3d::from_screenspace(viewport_size, camera, transform, primary_window);
+                    let bottom_right_ray = rays::ray_from_screenspace(
+                        viewport_size,
+                        camera,
+                        transform,
+                        primary_window,
+                    );
 
                     let top_left = ray_groundplane_intersection(&top_left_ray);
                     let top_right = ray_groundplane_intersection(&top_right_ray);
@@ -521,10 +525,10 @@ pub fn render_map_tiles(
 
 fn ray_groundplane_intersection(ray: &Option<Ray3d>) -> Vec3 {
     if let Some(ray) = ray {
-        let t = -ray.origin().z / ray.direction().z;
+        let t = -ray.origin.clone().z / ray.direction.clone().z;
         Vec3::new(
-            ray.origin().x + t * ray.direction().x,
-            ray.origin().y + t * ray.direction().y,
+            ray.origin.clone().x + t * ray.direction.clone().x,
+            ray.origin.clone().y + t * ray.direction.clone().y,
             0.0,
         )
     } else {

--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -304,12 +304,12 @@ fn spawn_tile(
 
     let tile_offset = latlon_to_world(coordinates.0, coordinates.1, reference);
     commands
-        .spawn(PbrBundle {
-            mesh: quad_handle,
-            material: material_handle,
-            transform: Transform::from_xyz(tile_offset.x, tile_offset.y, -0.005),
-            ..default()
-        })
+        .spawn((
+            Mesh3d(quad_handle),
+            MeshMaterial3d(material_handle),
+            Transform::from_xyz(tile_offset.x, tile_offset.y, -0.005),
+            Visibility::default(),
+        ))
         .insert(MapTile(tile));
 }
 

--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -1,6 +1,5 @@
 use bevy::{asset::AssetPath, math::Ray3d, prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
-use bevy_mod_raycast::primitives::rays;
 use camera_controls::{CameraControls, ProjectionMode};
 use rmf_site_format::{GeographicComponent, GeographicOffset};
 use std::collections::HashSet;
@@ -424,30 +423,26 @@ pub fn render_map_tiles(
                     let Ok(primary_window) = primary_window.get_single() else {
                         return;
                     };
-                    let top_left_ray = rays::ray_from_screenspace(
+                    let top_left_ray = ray_from_screenspace(
                         Vec2::new(0.0, 0.0),
                         camera,
                         transform,
                         primary_window,
                     );
-                    let top_right_ray = rays::ray_from_screenspace(
+                    let top_right_ray = ray_from_screenspace(
                         Vec2::new(viewport_size.x, 0.0),
                         camera,
                         transform,
                         primary_window,
                     );
-                    let bottom_left_ray = rays::ray_from_screenspace(
+                    let bottom_left_ray = ray_from_screenspace(
                         Vec2::new(0.0, viewport_size.y),
                         camera,
                         transform,
                         primary_window,
                     );
-                    let bottom_right_ray = rays::ray_from_screenspace(
-                        viewport_size,
-                        camera,
-                        transform,
-                        primary_window,
-                    );
+                    let bottom_right_ray =
+                        ray_from_screenspace(viewport_size, camera, transform, primary_window);
 
                     let top_left = ray_groundplane_intersection(&top_left_ray);
                     let top_right = ray_groundplane_intersection(&top_right_ray);
@@ -523,6 +518,26 @@ pub fn render_map_tiles(
     }
 }
 
+fn ray_from_screenspace(
+    cursor_position: Vec2,
+    camera: &Camera,
+    camera_transform: &GlobalTransform,
+    window: &Window,
+) -> Option<Ray3d> {
+    camera
+        .viewport
+        .as_ref()
+        .map(|viewport| {
+            cursor_position - &viewport.physical_position.as_vec2() / window.scale_factor()
+        })
+        .and_then(|viewport_pos| {
+            camera
+                .viewport_to_world(&camera_transform, viewport_pos)
+                .ok()
+                .map(Ray3d::from)
+        })
+}
+
 fn ray_groundplane_intersection(ray: &Option<Ray3d>) -> Vec3 {
     if let Some(ray) = ray {
         let t = -ray.origin.z / ray.direction.z;
@@ -562,14 +577,14 @@ impl FromWorld for OSMMenu {
         let sub_menu = world
             .spawn(Menu::from_title("Geographic Offset".to_string()))
             .id();
-        world.entity_mut(sub_menu).push_children(&[
+        world.entity_mut(sub_menu).add_children(&[
             set_reference,
             view_reference,
             settings_reference,
         ]);
 
         let tool_header = world.resource::<ToolMenu>().get();
-        world.entity_mut(tool_header).push_children(&[sub_menu]);
+        world.entity_mut(tool_header).add_children(&[sub_menu]);
 
         // Checkbox
         let view_header = world.resource::<ViewMenu>().get();
@@ -578,7 +593,7 @@ impl FromWorld for OSMMenu {
             .id();
         world
             .entity_mut(view_header)
-            .push_children(&[satellite_map_check_button]);
+            .add_children(&[satellite_map_check_button]);
 
         OSMMenu {
             set_reference,

--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -555,7 +555,7 @@ fn ray_groundplane_intersection(ray: &Option<Ray3d>) -> Vec3 {
 fn test_groundplane() {
     let ray = Ray3d::new(
         Vec3::new(1.0, 1.0, 1.0),
-        Dir3::from_xyz_unchecked(1.0, 1.0, 1.0),
+        Dir3::from_xyz(1.0, 1.0, 1.0).unwrap(),
     );
 
     // Ground plane should be at (0,0,0)

--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -553,7 +553,10 @@ fn ray_groundplane_intersection(ray: &Option<Ray3d>) -> Vec3 {
 
 #[test]
 fn test_groundplane() {
-    let ray = Ray3d::new(Vec3::new(1.0, 1.0, 1.0), Vec3::new(1.0, 1.0, 1.0));
+    let ray = Ray3d::new(
+        Vec3::new(1.0, 1.0, 1.0),
+        Dir3::from_xyz_unchecked(1.0, 1.0, 1.0),
+    );
 
     // Ground plane should be at (0,0,0)
     assert!(ray_groundplane_intersection(&Some(ray)).length() < 1e-5);

--- a/rmf_site_editor/src/site/georeference.rs
+++ b/rmf_site_editor/src/site/georeference.rs
@@ -525,10 +525,10 @@ pub fn render_map_tiles(
 
 fn ray_groundplane_intersection(ray: &Option<Ray3d>) -> Vec3 {
     if let Some(ray) = ray {
-        let t = -ray.origin.clone().z / ray.direction.clone().z;
+        let t = -ray.origin.z / ray.direction.z;
         Vec3::new(
-            ray.origin.clone().x + t * ray.direction.clone().x,
-            ray.origin.clone().y + t * ray.direction.clone().y,
+            ray.origin.x + t * ray.direction.x,
+            ray.origin.y + t * ray.direction.y,
             0.0,
         )
     } else {

--- a/rmf_site_editor/src/site/group.rs
+++ b/rmf_site_editor/src/site/group.rs
@@ -71,6 +71,7 @@ impl Command for ChangeMembership {
     fn apply(self, world: &mut World) {
         let last = world
             .get_entity(self.member)
+            .ok()
             .map(|e| e.get::<LastAffiliation>())
             .flatten()
             .cloned();
@@ -81,7 +82,7 @@ impl Command for ChangeMembership {
             }
 
             if let Some(last) = last.0 {
-                if let Some(mut e) = world.get_entity_mut(last) {
+                if let Ok(mut e) = world.get_entity_mut(last) {
                     if let Some(mut members) = e.get_mut::<Members>() {
                         members.0.retain(|m| *m != self.member);
                     }
@@ -90,7 +91,7 @@ impl Command for ChangeMembership {
         }
 
         if let Some(new_group) = self.group {
-            if let Some(mut e) = world.get_entity_mut(new_group) {
+            if let Ok(mut e) = world.get_entity_mut(new_group) {
                 if let Some(mut members) = e.get_mut::<Members>() {
                     members.0.push(self.member);
                 } else {
@@ -99,7 +100,7 @@ impl Command for ChangeMembership {
             }
         }
 
-        if let Some(mut e) = world.get_entity_mut(self.member) {
+        if let Ok(mut e) = world.get_entity_mut(self.member) {
             e.insert(LastAffiliation(self.group));
         }
     }
@@ -112,7 +113,7 @@ pub trait SetMembershipExt {
 impl<'a> SetMembershipExt for EntityCommands<'a> {
     fn set_membership(&mut self, group: Option<Entity>) -> &mut Self {
         let member = self.id();
-        self.commands().add(ChangeMembership { member, group });
+        self.commands().queue(ChangeMembership { member, group });
         self
     }
 }

--- a/rmf_site_editor/src/site/group.rs
+++ b/rmf_site_editor/src/site/group.rs
@@ -15,10 +15,7 @@
  *
 */
 
-use bevy::{
-    ecs::system::{Command, EntityCommands},
-    prelude::*,
-};
+use bevy::{ecs::system::EntityCommands, ecs::world::Command, prelude::*};
 use rmf_site_format::{Affiliation, Group};
 
 #[derive(Event)]
@@ -112,7 +109,7 @@ pub trait SetMembershipExt {
     fn set_membership(&mut self, group: Option<Entity>) -> &mut Self;
 }
 
-impl<'w, 's, 'a> SetMembershipExt for EntityCommands<'w, 's, 'a> {
+impl<'a> SetMembershipExt for EntityCommands<'a> {
     fn set_membership(&mut self, group: Option<Entity>) -> &mut Self {
         let member = self.id();
         self.commands().add(ChangeMembership { member, group });

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -17,9 +17,10 @@
 
 use crate::site::*;
 use crate::{CurrentWorkspace, Issue, ValidateWorkspace};
-use bevy::{prelude::*, utils::Uuid};
+use bevy::prelude::*;
 use rmf_site_format::{Edge, LaneMarker};
 use std::collections::{BTreeSet, HashMap};
+use uuid::Uuid;
 
 pub const SELECTED_LANE_OFFSET: f32 = 0.001;
 pub const HOVERED_LANE_OFFSET: f32 = 0.002;

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -145,7 +145,7 @@ pub fn add_lane_visuals(
             let outline = commands
                 .spawn((
                     Mesh3d(outline_mesh),
-                    MeshMaterial3d::default(),
+                    MeshMaterial3d::<StandardMaterial>::default(),
                     Transform::from_translation(-0.000_5 * Vec3::Z),
                     Visibility::Hidden,
                 ))
@@ -308,7 +308,7 @@ pub fn update_visibility_for_lanes(
         (Entity, &AssociatedGraphs<Entity>, &LaneSegments),
         (With<LaneMarker>, Changed<AssociatedGraphs<Entity>>),
     >,
-    mut materials: Query<&mut Handle<StandardMaterial>, Without<NavGraphMarker>>,
+    mut materials: Query<&mut MeshMaterial3d<StandardMaterial>, Without<NavGraphMarker>>,
     mut transforms: Query<&mut Transform>,
     graph_changed_visibility: Query<
         (),
@@ -366,7 +366,7 @@ pub fn update_visibility_for_lanes(
             let (mat, height) = graphs.display_style(associated_graphs);
             for e in segments.iter() {
                 if let Ok(mut m) = materials.get_mut(e) {
-                    *m = mat.clone();
+                    *m = MeshMaterial3d(mat.clone());
                 }
             }
 
@@ -379,7 +379,7 @@ pub fn update_visibility_for_lanes(
             let (mat, height) = graphs.display_style(associated_graphs);
             for e in segments.iter() {
                 if let Ok(mut m) = materials.get_mut(e) {
-                    *m = mat.clone();
+                    *m = MeshMaterial3d(mat.clone());
                 }
             }
 

--- a/rmf_site_editor/src/site/lane.rs
+++ b/rmf_site_editor/src/site/lane.rs
@@ -127,31 +127,28 @@ pub fn add_lane_visuals(
         // Create a "layer" entity that manages the height of the lane,
         // determined by the DisplayHeight of the graph.
         let layer = commands
-            .spawn(SpatialBundle {
-                transform: Transform::from_xyz(0.0, 0.0, height),
-                ..default()
-            })
+            .spawn((Transform::from_xyz(0.0, 0.0, height), Visibility::default()))
             .set_parent(e)
             .id();
 
         let mut spawn_lane_mesh_and_outline = |lane_tf, lane_mesh, outline_mesh| {
             let mesh = commands
-                .spawn(PbrBundle {
-                    mesh: lane_mesh,
-                    material: lane_material.clone(),
-                    transform: lane_tf,
-                    ..default()
-                })
+                .spawn((
+                    Mesh3d(lane_mesh),
+                    MeshMaterial3d(lane_material.clone()),
+                    lane_tf,
+                    Visibility::default(),
+                ))
                 .set_parent(layer)
                 .id();
 
             let outline = commands
-                .spawn(PbrBundle {
-                    mesh: outline_mesh,
-                    transform: Transform::from_translation(-0.000_5 * Vec3::Z),
-                    visibility: Visibility::Hidden,
-                    ..default()
-                })
+                .spawn((
+                    Mesh3d(outline_mesh),
+                    MeshMaterial3d::default(),
+                    Transform::from_translation(-0.000_5 * Vec3::Z),
+                    Visibility::Hidden,
+                ))
                 .set_parent(mesh)
                 .id();
 
@@ -185,11 +182,10 @@ pub fn add_lane_visuals(
                 end,
                 outlines: [start_outline, mid_outline, end_outline],
             })
-            .insert(SpatialBundle {
-                transform: Transform::from_translation([0., 0., LANE_LAYER_START].into()),
+            .insert((
+                Transform::from_translation([0., 0., LANE_LAYER_START].into()),
                 visibility,
-                ..default()
-            })
+            ))
             .insert(Category::Lane)
             .insert(EdgeLabels::StartEnd);
     }

--- a/rmf_site_editor/src/site/lift.rs
+++ b/rmf_site_editor/src/site/lift.rs
@@ -120,7 +120,7 @@ pub fn add_tags_to_lift(
     for (e, edge) in &new_lifts {
         let mut lift_cmds = commands.entity(e);
         lift_cmds
-            .insert(SpatialBundle::default())
+            .insert((Transform::default(), Visibility::default()))
             .insert(EdgeLabels::LeftRight)
             .insert(Category::Lift);
 
@@ -197,22 +197,24 @@ pub fn update_lift_cabin(
                     .into();
 
                 let cabin_entity = commands
-                    .spawn(SpatialBundle::from_transform(cabin_tf))
+                    .spawn((cabin_tf, Visibility::Inherited))
                     .with_children(|parent| {
                         parent
-                            .spawn(PbrBundle {
-                                mesh: meshes.add(floor_mesh),
-                                material: assets.lift_floor_material.clone(),
-                                ..default()
-                            })
+                            .spawn((
+                                Mesh3d(meshes.add(floor_mesh)),
+                                MeshMaterial3d(assets.lift_floor_material.clone()),
+                                Transform::default(),
+                                Visibility::default(),
+                            ))
                             .insert(Selectable::new(e));
 
                         parent
-                            .spawn(PbrBundle {
-                                mesh: meshes.add(wall_mesh),
-                                material: assets.lift_wall_material.clone(),
-                                ..default()
-                            })
+                            .spawn((
+                                Mesh3d(meshes.add(wall_mesh)),
+                                MeshMaterial3d(assets.lift_wall_material.clone()),
+                                Transform::default(),
+                                Visibility::default(),
+                            ))
                             .insert(Selectable::new(e));
 
                         for (level, level_site) in &levels {
@@ -233,14 +235,15 @@ pub fn update_lift_cabin(
                                 aabb.center.z = LANE_LAYER_LIMIT;
                                 let mesh = make_flat_mesh_for_aabb(aabb);
                                 parent
-                                    .spawn(PbrBundle {
-                                        mesh: meshes.add(mesh),
+                                    .spawn((
+                                        Mesh3d(meshes.add(mesh.into())),
+                                        MeshMaterial3d::default(),
+                                        Transform::default(),
                                         // Doormats are not visible by default.
                                         // Other plugins should make them visible
                                         // if using them as a visual cue.
-                                        visibility: Visibility::Hidden,
-                                        ..default()
-                                    })
+                                        Visibility::Hidden,
+                                    ))
                                     .insert(LiftDoormat {
                                         for_lift: e,
                                         on_level: level,
@@ -301,7 +304,7 @@ pub fn update_lift_cabin(
             }
             None => {
                 let group = commands
-                    .spawn(SpatialBundle::from_transform(cabin_tf))
+                    .spawn((cabin_tf, Visibility::Inherited))
                     .insert(CabinAnchorGroupBundle::default())
                     .id();
                 commands

--- a/rmf_site_editor/src/site/lift.rs
+++ b/rmf_site_editor/src/site/lift.rs
@@ -18,13 +18,10 @@
 use crate::{
     interaction::Selectable, shapes::*, site::*, CurrentWorkspace, Issue, ValidateWorkspace,
 };
-use bevy::{
-    prelude::*,
-    render::primitives::Aabb,
-    utils::{HashMap, Uuid},
-};
+use bevy::{prelude::*, render::primitives::Aabb, utils::HashMap};
 use rmf_site_format::{Edge, LiftCabin};
 use std::collections::BTreeSet;
+use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, Component, Deref, DerefMut)]
 pub struct ChildLiftCabinGroup(pub Entity);
@@ -237,7 +234,7 @@ pub fn update_lift_cabin(
                                 let mesh = make_flat_mesh_for_aabb(aabb);
                                 parent
                                     .spawn(PbrBundle {
-                                        mesh: meshes.add(mesh.into()),
+                                        mesh: meshes.add(mesh),
                                         // Doormats are not visible by default.
                                         // Other plugins should make them visible
                                         // if using them as a visual cue.

--- a/rmf_site_editor/src/site/lift.rs
+++ b/rmf_site_editor/src/site/lift.rs
@@ -236,8 +236,8 @@ pub fn update_lift_cabin(
                                 let mesh = make_flat_mesh_for_aabb(aabb);
                                 parent
                                     .spawn((
-                                        Mesh3d(meshes.add(mesh.into())),
-                                        MeshMaterial3d::default(),
+                                        Mesh3d(meshes.add(mesh)),
+                                        MeshMaterial3d::<StandardMaterial>::default(),
                                         Transform::default(),
                                         // Doormats are not visible by default.
                                         // Other plugins should make them visible

--- a/rmf_site_editor/src/site/light.rs
+++ b/rmf_site_editor/src/site/light.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use crate::site::CurrentLevel;
+use crate::{interaction::main_view_render_layers, site::CurrentLevel};
 use bevy::{
     pbr::CubemapVisibleEntities,
     prelude::{
@@ -64,6 +64,7 @@ pub fn add_physical_lights(
             .insert(VisibleEntities::default())
             .insert(CubemapFrusta::default())
             .insert(CubemapVisibleEntities::default())
+            .insert(main_view_render_layers())
             .insert(Category::Light);
 
         if parent.is_none() {

--- a/rmf_site_editor/src/site/load.rs
+++ b/rmf_site_editor/src/site/load.rs
@@ -88,7 +88,7 @@ fn generate_site_entities(
     };
 
     let site_id = commands
-        .spawn(SpatialBundle::HIDDEN_IDENTITY)
+        .spawn((Transform::IDENTITY, Visibility::Hidden))
         .insert(Category::Site)
         .insert(WorkspaceMarker)
         .id();
@@ -204,7 +204,7 @@ fn generate_site_entities(
 
         commands
             .entity(level_entity)
-            .insert(SpatialBundle::HIDDEN_IDENTITY)
+            .insert((Transform::IDENTITY, Visibility::Hidden))
             .insert(level_data.properties.clone())
             .insert(Category::Level)
             .with_children(|level| {
@@ -251,7 +251,7 @@ fn generate_site_entities(
         let lift_entity = commands.spawn(SiteID(*lift_id)).set_parent(site_id).id();
 
         commands.entity(lift_entity).with_children(|lift| {
-            lift.spawn(SpatialBundle::default())
+            lift.spawn((Transform::default(), Visibility::default()))
                 .insert(CabinAnchorGroupBundle::default())
                 .with_children(|anchor_group| {
                     for (anchor_id, anchor) in &lift_data.cabin_anchors {
@@ -298,7 +298,7 @@ fn generate_site_entities(
 
     for (nav_graph_id, nav_graph_data) in &site_data.navigation.guided.graphs {
         let nav_graph = commands
-            .spawn(SpatialBundle::default())
+            .spawn((Transform::default(), Visibility::default()))
             .insert(nav_graph_data.clone())
             .insert(SiteID(*nav_graph_id))
             .set_parent(site_id)
@@ -721,7 +721,7 @@ fn generate_imported_nav_graphs(
     for (nav_graph_id, nav_graph_data) in &from_site_data.navigation.guided.graphs {
         params.commands.entity(into_site).with_children(|site| {
             let e = site
-                .spawn(SpatialBundle::default())
+                .spawn((Transform::default(), Visibility::default()))
                 .insert(nav_graph_data.clone())
                 .id();
             id_to_entity.insert(*nav_graph_id, e);

--- a/rmf_site_editor/src/site/location.rs
+++ b/rmf_site_editor/src/site/location.rs
@@ -123,25 +123,24 @@ pub fn add_location_visuals(
                 // Workcells are not visualized
                 LocationTag::Workcell(_) => continue,
             };
-            commands.entity(id).insert(PbrBundle {
-                mesh: assets.location_tag_mesh.clone(),
-                material,
-                transform: location_halo_tf(tag),
-                ..default()
-            });
+            commands.entity(id).insert((
+                Mesh3d(assets.location_tag_mesh.clone()),
+                MeshMaterial3d(material),
+                location_halo_tf(tag),
+                Visibility::default(),
+            ));
             commands.entity(e).add_child(id);
         }
 
         // TODO(MXG): Put icons on the different visual squares based on the location tags
         commands
             .entity(e)
-            .insert(PbrBundle {
-                mesh: assets.location_mesh.clone(),
-                transform: Transform::from_translation(position),
-                material,
+            .insert((
+                Mesh3d(assets.location_mesh.clone()),
+                Transform::from_translation(position),
+                MeshMaterial3d(material),
                 visibility,
-                ..default()
-            })
+            ))
             .insert(Spinning::new(-10.0))
             .insert(Category::Location)
             .insert(tag_meshes)
@@ -273,12 +272,12 @@ pub fn update_location_for_changed_location_tags(
                 // Workcells are not visualized
                 LocationTag::Workcell(_) => continue,
             };
-            commands.entity(id).insert(PbrBundle {
-                mesh: assets.location_tag_mesh.clone(),
-                material,
-                transform: location_halo_tf(tag),
-                ..default()
-            });
+            commands.entity(id).insert((
+                Mesh3d(assets.location_tag_mesh.clone()),
+                MeshMaterial3d(material),
+                location_halo_tf(tag),
+                Visibility::default(),
+            ));
             commands.entity(e).add_child(id);
         }
     }

--- a/rmf_site_editor/src/site/location.rs
+++ b/rmf_site_editor/src/site/location.rs
@@ -289,7 +289,7 @@ pub fn update_visibility_for_locations(
             &Point<Entity>,
             &AssociatedGraphs<Entity>,
             &mut Visibility,
-            &mut Handle<StandardMaterial>,
+            &mut MeshMaterial3d<StandardMaterial>,
             // &mut
         ),
         (With<LocationTags>, Without<NavGraphMarker>),
@@ -355,12 +355,12 @@ pub fn update_visibility_for_locations(
 
     if graph_change {
         for (_, associated_graphs, _, mut m) in &mut locations {
-            *m = graphs.display_style(associated_graphs).0;
+            *m = MeshMaterial3d(graphs.display_style(associated_graphs).0);
         }
     } else {
         for e in &locations_with_changed_association {
             if let Ok((_, associated_graphs, _, mut m)) = locations.get_mut(e) {
-                *m = graphs.display_style(associated_graphs).0;
+                *m = MeshMaterial3d(graphs.display_style(associated_graphs).0);
             }
         }
     }

--- a/rmf_site_editor/src/site/measurement.rs
+++ b/rmf_site_editor/src/site/measurement.rs
@@ -51,17 +51,19 @@ pub fn add_measurement_visuals(
         transform.translation.z = DEFAULT_MEASUREMENT_HEIGHT;
 
         let child_id = commands
-            .spawn(PbrBundle {
-                mesh: assets.lane_mid_mesh.clone(),
-                material: assets.measurement_material.clone(),
+            .spawn((
+                Mesh3d(assets.lane_mid_mesh.clone()),
+                MeshMaterial3d(assets.measurement_material.clone()),
                 transform,
-                ..default()
-            })
+                Visibility::default(),
+            ))
             .insert(Selectable::new(e))
             .id();
 
         if tf.is_none() {
-            commands.entity(e).insert(SpatialBundle::INHERITED_IDENTITY);
+            commands
+                .entity(e)
+                .insert((Transform::IDENTITY, Visibility::Inherited));
         }
 
         commands

--- a/rmf_site_editor/src/site/measurement.rs
+++ b/rmf_site_editor/src/site/measurement.rs
@@ -71,7 +71,7 @@ pub fn add_measurement_visuals(
             .insert(Category::Measurement)
             .insert(MeasurementSegment(child_id))
             .insert(EdgeLabels::StartEnd)
-            .push_children(&[child_id]);
+            .add_children(&[child_id]);
 
         for anchor in &edge.array() {
             if let Ok(mut deps) = dependents.get_mut(*anchor) {

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -143,10 +143,10 @@ pub enum SiteUpdateSet {
     Deletion,
     /// Force a command flush after deletion
     DeletionFlush,
-    /// Placed between visibility and transform propagation, to avoid one frame delays
-    BetweenVisibilityAndTransform,
+    /// Placed between transform and visibility propagation, to avoid one frame delays
+    BetweenTransformAndVisibility,
     /// Flush the set above
-    BetweenVisibilityAndTransformFlush,
+    BetweenTransformAndVisibilityFlush,
     /// Used to force a command flush after the change plugin's process changes
     ProcessChanges,
     /// Flush the set above
@@ -175,16 +175,16 @@ impl Plugin for SitePlugin {
             (
                 SiteUpdateSet::AssignOrphans,
                 SiteUpdateSet::AssignOrphansFlush,
-                VisibilitySystems::VisibilityPropagate,
-                SiteUpdateSet::BetweenVisibilityAndTransform,
-                SiteUpdateSet::BetweenVisibilityAndTransformFlush,
                 TransformSystem::TransformPropagate,
+                SiteUpdateSet::BetweenTransformAndVisibility,
+                SiteUpdateSet::BetweenTransformAndVisibilityFlush,
+                VisibilitySystems::VisibilityPropagate,
             )
                 .chain(),
         )
         .add_systems(
             PostUpdate,
-            apply_deferred.in_set(SiteUpdateSet::BetweenVisibilityAndTransformFlush),
+            apply_deferred.in_set(SiteUpdateSet::BetweenTransformAndVisibilityFlush),
         )
         .add_systems(
             PostUpdate,
@@ -336,7 +336,7 @@ impl Plugin for SitePlugin {
                 set_camera_transform_for_changed_site,
             )
                 .run_if(AppState::in_displaying_mode())
-                .in_set(SiteUpdateSet::BetweenVisibilityAndTransform),
+                .in_set(SiteUpdateSet::BetweenTransformAndVisibility),
         )
         .add_systems(
             PostUpdate,
@@ -363,7 +363,7 @@ impl Plugin for SitePlugin {
                 insert_new_instance_modifiers,
             )
                 .run_if(AppState::in_displaying_mode())
-                .in_set(SiteUpdateSet::BetweenVisibilityAndTransform),
+                .in_set(SiteUpdateSet::BetweenTransformAndVisibility),
         )
         .add_systems(
             PostUpdate,
@@ -388,7 +388,7 @@ impl Plugin for SitePlugin {
                 toggle_physical_lights,
             )
                 .run_if(AppState::in_displaying_mode())
-                .in_set(SiteUpdateSet::BetweenVisibilityAndTransform),
+                .in_set(SiteUpdateSet::BetweenTransformAndVisibility),
         )
         .add_systems(
             PostUpdate,
@@ -409,7 +409,7 @@ impl Plugin for SitePlugin {
                 add_physical_camera_visuals,
             )
                 .run_if(AppState::in_displaying_mode())
-                .in_set(SiteUpdateSet::BetweenVisibilityAndTransform),
+                .in_set(SiteUpdateSet::BetweenTransformAndVisibility),
         );
     }
 }

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -190,7 +190,7 @@ impl Plugin for SitePlugin {
             PostUpdate,
             apply_deferred.in_set(SiteUpdateSet::AssignOrphansFlush),
         )
-        .insert_resource(ClearColor(Color::rgb(0., 0., 0.)))
+        .insert_resource(ClearColor(Color::srgb(0., 0., 0.)))
         .init_resource::<SiteAssets>()
         .init_resource::<CurrentLevel>()
         .init_resource::<CurrentScenario>()

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -149,7 +149,7 @@ pub fn spawn_scene_for_loaded_model(
         // Note we can't do an `if let Some()` because get(Handle) panics if the type is
         // not the stored type
         let gltfs = world.resource::<Assets<Gltf>>();
-        let gltf = gltfs.get(&h)?;
+        let gltf = gltfs.get(h.typed::<Gltf>().id())?;
         // Get default scene if present, otherwise index 0
         let scene = gltf
             .default_scene

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -156,20 +156,39 @@ pub fn spawn_scene_for_loaded_model(
             .as_ref()
             .or_else(|| gltf.scenes.get(0))
             .cloned()?;
-        Some((world.spawn(SceneBundle { scene, ..default() }).id(), true))
+        Some((
+            world
+                .spawn((
+                    SceneRoot(scene),
+                    Transform::default(),
+                    GlobalTransform::default(),
+                ))
+                .id(),
+            true,
+        ))
     } else if type_id == TypeId::of::<Scene>() {
         let scene = h.typed::<Scene>();
-        Some((world.spawn(SceneBundle { scene, ..default() }).id(), true))
+        Some((
+            world
+                .spawn((
+                    SceneRoot(scene),
+                    Transform::default(),
+                    GlobalTransform::default(),
+                ))
+                .id(),
+            true,
+        ))
     } else if type_id == TypeId::of::<Mesh>() {
         let site_assets = world.resource::<SiteAssets>();
         let mesh = h.typed::<Mesh>();
         Some((
             world
-                .spawn(PbrBundle {
-                    mesh,
-                    material: site_assets.default_mesh_grey_material.clone(),
-                    ..default()
-                })
+                .spawn((
+                    Mesh3d(mesh),
+                    MeshMaterial3d(site_assets.default_mesh_grey_material.clone()),
+                    Transform::default(),
+                    Visibility::default(),
+                ))
                 .id(),
             false,
         ))
@@ -185,7 +204,7 @@ pub fn spawn_scene_for_loaded_model(
         })
         .add_child(model_id);
     if world.get::<Visibility>(parent).is_none() {
-        world.entity_mut(parent).insert(VisibilityBundle::default());
+        world.entity_mut(parent).insert(Visibility::default());
     }
     Some((model_id, is_scene))
 }

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -699,7 +699,7 @@ pub fn make_models_selectable(
     // If layer should not be visible, don't make it selectable
     if scene_roots
         .get(req.parent)
-        .is_ok_and(|r| r.iter().all(|l| l == MODEL_PREVIEW_LAYER as usize))
+        .is_ok_and(|r| r.iter().all(|l| l == MODEL_PREVIEW_LAYER))
     {
         return req;
     }

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -29,7 +29,7 @@ use bevy::{
     scene::SceneInstance,
 };
 use bevy_impulse::*;
-use bevy_mod_outline::OutlineMeshExt;
+use bevy_mod_outline::{GenerateOutlineNormalsSettings, OutlineMeshExt};
 use rmf_site_format::{
     Affiliation, AssetSource, Group, IssueKey, ModelInstance, ModelMarker, ModelProperty,
     NameInSite, Pending, Scale,
@@ -712,7 +712,10 @@ pub fn make_models_selectable(
 
         if let Ok(mesh_handle) = mesh_handles.get(e) {
             if let Some(mesh) = mesh_assets.get_mut(mesh_handle) {
-                if mesh.generate_outline_normals().is_err() {
+                if mesh
+                    .generate_outline_normals(&GenerateOutlineNormalsSettings::default())
+                    .is_err()
+                {
                     warn!(
                         "WARNING: Unable to generate outline normals for \
                         a model mesh"

--- a/rmf_site_editor/src/site/model.rs
+++ b/rmf_site_editor/src/site/model.rs
@@ -685,7 +685,7 @@ pub fn make_models_selectable(
     pending_or_previews: Query<(), Or<(With<Pending>, With<Preview>)>>,
     scene_roots: Query<&RenderLayers, With<ModelMarker>>,
     all_children: Query<&Children>,
-    mesh_handles: Query<&Handle<Mesh>>,
+    mesh_handles: Query<&Mesh3d>,
     mut mesh_assets: ResMut<Assets<Mesh>>,
 ) -> ModelLoadingRequest {
     // Pending items (i.e. mouse previews) should not be selectable
@@ -737,7 +737,7 @@ pub fn propagate_model_properties(
     render_layers: Query<&RenderLayers>,
     previews: Query<&Preview>,
     pendings: Query<&Pending>,
-    mesh_entities: Query<(), With<Handle<Mesh>>>,
+    mesh_entities: Query<(), With<Mesh3d>>,
     children: Query<&Children>,
 ) -> ModelLoadingRequest {
     propagate_model_property(
@@ -768,7 +768,7 @@ pub fn propagate_model_property<Property: Component + Clone + std::fmt::Debug>(
     root: Entity,
     property_query: &Query<&Property>,
     children: &Query<&Children>,
-    mesh_entities: &Query<(), With<Handle<Mesh>>>,
+    mesh_entities: &Query<(), With<Mesh3d>>,
     commands: &mut Commands,
 ) {
     let Ok(property) = property_query.get(root) else {

--- a/rmf_site_editor/src/site/nav_graph.rs
+++ b/rmf_site_editor/src/site/nav_graph.rs
@@ -25,7 +25,7 @@ pub struct GraphSelect<'w, 's> {
         's,
         (
             Entity,
-            &'static Handle<StandardMaterial>,
+            &'static MeshMaterial3d<StandardMaterial>,
             &'static Visibility,
             &'static RecencyRank<NavGraphMarker>,
         ),
@@ -78,7 +78,7 @@ impl<'w, 's> GraphSelect<'w, 's> {
         }
         .map(|(m, d)| {
             (
-                m,
+                m.0,
                 d.proportion() * (LANE_LAYER_LIMIT - LANE_LAYER_START) + LANE_LAYER_START,
             )
         })

--- a/rmf_site_editor/src/site/physical_camera.rs
+++ b/rmf_site_editor/src/site/physical_camera.rs
@@ -27,12 +27,12 @@ pub fn add_physical_camera_visuals(
     for (e, pose) in &physical_cameras {
         commands
             .entity(e)
-            .insert(PbrBundle {
-                mesh: assets.physical_camera_mesh.clone(),
-                material: assets.physical_camera_material.clone(),
-                transform: pose.transform(),
-                ..default()
-            })
+            .insert((
+                Mesh3d(assets.physical_camera_mesh.clone()),
+                MeshMaterial3d(assets.physical_camera_material.clone()),
+                pose.transform(),
+                Visibility::default(),
+            ))
             .insert(Selectable::new(e))
             .insert(Category::Camera);
         // Now insert the camera as a child, needed to transform it
@@ -45,15 +45,15 @@ pub fn add_physical_camera_visuals(
             ]),
         };
         let child = commands
-            .spawn(Camera3dBundle {
-                transform: camera_sensor_transform.transform(),
-                camera: Camera {
+            .spawn(Camera3d::default())
+            .insert((
+                camera_sensor_transform.transform(),
+                Camera {
                     is_active: false,
                     ..default()
                 },
-                tonemapping: Tonemapping::ReinhardLuminance,
-                ..default()
-            })
+                Tonemapping::ReinhardLuminance,
+            ))
             .id();
         commands.entity(e).push_children(&[child]);
     }

--- a/rmf_site_editor/src/site/physical_camera.rs
+++ b/rmf_site_editor/src/site/physical_camera.rs
@@ -55,6 +55,6 @@ pub fn add_physical_camera_visuals(
                 Tonemapping::ReinhardLuminance,
             ))
             .id();
-        commands.entity(e).push_children(&[child]);
+        commands.entity(e).add_children(&[child]);
     }
 }

--- a/rmf_site_editor/src/site/primitive_shape.rs
+++ b/rmf_site_editor/src/site/primitive_shape.rs
@@ -85,10 +85,7 @@ pub fn handle_new_primitive_shapes(
             .last()
         {
             entity_commands.insert(render_layer.clone());
-            if !render_layer
-                .iter()
-                .all(|l| l == MODEL_PREVIEW_LAYER as usize)
-            {
+            if !render_layer.iter().all(|l| l == MODEL_PREVIEW_LAYER) {
                 spawn_selectable(entity_commands);
             }
         } else {

--- a/rmf_site_editor/src/site/primitive_shape.rs
+++ b/rmf_site_editor/src/site/primitive_shape.rs
@@ -59,11 +59,12 @@ pub fn handle_new_primitive_shapes(
         // If there is a parent with a Selectable component, use it to make this primitive
         // point to it. Otherwise set the Selectable to point to itself.
         let id = commands
-            .spawn(PbrBundle {
-                mesh: meshes.add(mesh),
-                material: site_assets.default_mesh_grey_material.clone(),
-                ..default()
-            })
+            .spawn((
+                Mesh3d(meshes.add(mesh)),
+                MeshMaterial3d(site_assets.default_mesh_grey_material.clone()),
+                Transform::default(),
+                Visibility::default(),
+            ))
             .set_parent(e)
             .id();
 

--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -77,10 +77,10 @@ fn assemble_edited_drawing(world: &mut World) {
         return;
     };
     let Some(c) = c.target() else { return };
-    let Some(mut level) = world.get_entity_mut(c.level) else {
+    let Ok(mut level) = world.get_entity_mut(c.level) else {
         return;
     };
-    level.push_children(&[c.drawing]);
+    level.add_children(&[c.drawing]);
 }
 
 /// Revert the drawing back to the root so it can continue to be edited.
@@ -89,7 +89,7 @@ fn disassemble_edited_drawing(world: &mut World) {
         return;
     };
     let Some(c) = c.target() else { return };
-    let Some(mut level) = world.get_entity_mut(c.level) else {
+    let Ok(mut level) = world.get_entity_mut(c.level) else {
         return;
     };
     level.remove_children(&[c.drawing]);

--- a/rmf_site_editor/src/site/scenario.rs
+++ b/rmf_site_editor/src/site/scenario.rs
@@ -25,8 +25,9 @@ use crate::{
     widgets::view_model_instances::count_scenarios,
     CurrentWorkspace, Issue, ValidateWorkspace,
 };
-use bevy::{prelude::*, utils::Uuid};
+use bevy::prelude::*;
 use std::collections::HashMap;
+use uuid::Uuid;
 
 #[derive(Clone, Copy, Debug, Event)]
 pub struct ChangeCurrentScenario(pub Entity);

--- a/rmf_site_editor/src/site/sdf_exporter.rs
+++ b/rmf_site_editor/src/site/sdf_exporter.rs
@@ -105,7 +105,7 @@ pub fn collect_site_meshes(world: &mut World, site: Entity, folder: &Path) -> Re
         Query<(Entity, &IsStatic, &NameInSite), With<ModelMarker>>,
         Query<(), With<CollisionMeshMarker>>,
         Query<(), With<VisualMeshMarker>>,
-        Query<(&Handle<Mesh>, &Handle<StandardMaterial>)>,
+        Query<(&Mesh3d, &MeshMaterial3d<StandardMaterial>)>,
         Query<(&NameInSite, &LiftCabin<Entity>, &ChildLiftCabinGroup)>,
         Query<(), With<LiftDoormat>>,
         Query<&GlobalTransform>,

--- a/rmf_site_editor/src/site/sdf_exporter.rs
+++ b/rmf_site_editor/src/site/sdf_exporter.rs
@@ -70,7 +70,7 @@ pub fn headless_sdf_export(
             "No site is loaded so we cannot export an SDF file into [{}]",
             export_state.target_path,
         );
-        exit.send(bevy::app::AppExit);
+        exit.send(bevy::app::AppExit::Error(1.try_into().unwrap()));
     }
     if !missing_models.is_empty() {
         // Despawn all drawings, otherwise floors will become transparent.
@@ -89,7 +89,7 @@ pub fn headless_sdf_export(
                 export_state.save_requested = true;
                 export_state.iterations = 0;
             } else if export_state.save_requested && export_state.iterations > 5 {
-                exit.send(bevy::app::AppExit);
+                exit.send(bevy::app::AppExit::Success);
             }
         }
     }
@@ -107,7 +107,7 @@ pub fn collect_site_meshes(world: &mut World, site: Entity, folder: &Path) -> Re
         Query<(), With<VisualMeshMarker>>,
         Query<(&Handle<Mesh>, &Handle<StandardMaterial>)>,
         Query<(&NameInSite, &LiftCabin<Entity>, &ChildLiftCabinGroup)>,
-        Query<((), With<LiftDoormat>)>,
+        Query<(), With<LiftDoormat>>,
         Query<&GlobalTransform>,
         Query<&Transform>,
         Query<&SiteID>,

--- a/rmf_site_editor/src/site/site.rs
+++ b/rmf_site_editor/src/site/site.rs
@@ -132,7 +132,7 @@ pub fn change_site(
                     if !found_level {
                         // Create a new blank level for the user
                         let new_level = commands
-                            .spawn(SpatialBundle::default())
+                            .spawn((Transform::default(), Visibility::default()))
                             .insert(LevelProperties {
                                 name: NameInSite("<unnamed level>".to_owned()),
                                 elevation: LevelElevation(0.),

--- a/rmf_site_editor/src/site/wall.rs
+++ b/rmf_site_editor/src/site/wall.rs
@@ -73,18 +73,19 @@ pub fn add_wall_visual(
         };
         commands
             .entity(e)
-            .insert(PbrBundle {
-                mesh: meshes.add(make_wall(e, edge, &texture, &anchors)),
-                material: materials.add(StandardMaterial {
+            .insert((
+                Mesh3d(meshes.add(make_wall(e, edge, &texture, &anchors))),
+                MeshMaterial3d(materials.add(StandardMaterial {
                     base_color_texture,
                     base_color,
                     alpha_mode,
                     perceptual_roughness: 0.089,
                     metallic: 0.01,
                     ..default()
-                }),
-                ..default()
-            })
+                })),
+                Transform::default(),
+                Visibility::default(),
+            ))
             .insert(Selectable::new(e))
             .insert(Category::Wall)
             .insert(EdgeLabels::StartEnd);

--- a/rmf_site_editor/src/site/wall.rs
+++ b/rmf_site_editor/src/site/wall.rs
@@ -67,7 +67,7 @@ pub fn add_wall_visual(
     for (e, edge, texture_source) in &walls {
         let (base_color_texture, texture) = from_texture_source(texture_source, &textures);
         let (base_color, alpha_mode) = if let Some(alpha) = texture.alpha.filter(|a| a < &1.0) {
-            (*Color::default().set_a(alpha), AlphaMode::Blend)
+            (Color::default().with_alpha(alpha), AlphaMode::Blend)
         } else {
             (Color::default(), AlphaMode::Opaque)
         };
@@ -166,7 +166,7 @@ pub fn update_walls(
         *mesh = meshes.add(make_wall(e, edge, &texture, &anchors));
         if let Some(material) = materials.get_mut(material) {
             let (base_color, alpha_mode) = if let Some(alpha) = texture.alpha.filter(|a| a < &1.0) {
-                (*Color::default().set_a(alpha), AlphaMode::Blend)
+                (Color::default().with_alpha(alpha), AlphaMode::Blend)
             } else {
                 (Color::default(), AlphaMode::Opaque)
             };

--- a/rmf_site_editor/src/site_asset_io.rs
+++ b/rmf_site_editor/src/site_asset_io.rs
@@ -56,29 +56,38 @@ fn generate_remote_asset_url(name: &str) -> Result<String, AssetReaderError> {
     let org_name = match tokens.next() {
         Some(token) => token,
         None => {
-            return Err(AssetReaderError::Io(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Unable to parse into org/model names: {name}"),
-            )));
+            return Err(AssetReaderError::Io(
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Unable to parse into org/model names: {name}"),
+                )
+                .into(),
+            ));
         }
     };
     let model_name = match tokens.next() {
         Some(token) => token,
         None => {
-            return Err(AssetReaderError::Io(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Unable to parse into org/model names: {name}"),
-            )));
+            return Err(AssetReaderError::Io(
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Unable to parse into org/model names: {name}"),
+                )
+                .into(),
+            ));
         }
     };
     // TODO(luca) migrate to split.remainder once
     // https://github.com/rust-lang/rust/issues/77998 is stabilized
     let binding = tokens.fold(String::new(), |prefix, path| prefix + "/" + path);
     if binding.len() < 2 {
-        return Err(AssetReaderError::Io(io::Error::new(
-            io::ErrorKind::Other,
-            format!("File name not found for: {name}"),
-        )));
+        return Err(AssetReaderError::Io(
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("File name not found for: {name}"),
+            )
+            .into(),
+        ));
     }
     let filename = binding.split_at(1).1;
     let uri = format!(
@@ -102,26 +111,36 @@ async fn fetch_asset<'a>(
         Err(poisoned_key) => {
             // Reset the key to None
             *poisoned_key.into_inner() = None;
-            return Err(AssetReaderError::Io(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Lock poisoning detected when reading fuel API key, please set it again."),
-            )));
+            return Err(AssetReaderError::Io(
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "Lock poisoning detected when reading fuel API key, please set it again."
+                    ),
+                )
+                .into(),
+            ));
         }
     }
     let bytes = ehttp::fetch_async(req)
         .await
-        .map_err(|e| AssetReaderError::Io(io::Error::new(io::ErrorKind::Other, e.to_string())))?
+        .map_err(|e| {
+            AssetReaderError::Io(io::Error::new(io::ErrorKind::Other, e.to_string()).into())
+        })?
         .bytes;
 
     match serde_json::from_slice::<FuelErrorMsg>(&bytes) {
         Ok(error) => {
-            return Err(AssetReaderError::Io(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!(
-                    "Failed to fetch asset from fuel {} [errcode {}]: {}",
-                    remote_url, error.errcode, error.msg,
-                ),
-            )));
+            return Err(AssetReaderError::Io(
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "Failed to fetch asset from fuel {} [errcode {}]: {}",
+                        remote_url, error.errcode, error.msg,
+                    ),
+                )
+                .into(),
+            ));
         }
         Err(_) => {
             // This is actually the happy path. When a GET from fuel was

--- a/rmf_site_editor/src/warehouse_generator.rs
+++ b/rmf_site_editor/src/warehouse_generator.rs
@@ -207,19 +207,21 @@ fn warehouse_generator(
             .insert(String::from("concrete_floor"), concrete_floor_handle);
     }
 
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane { size: width as f32 })),
-        material: material_map
-            .materials
-            .get("concrete_floor")
-            .unwrap()
-            .clone(),
-        transform: Transform {
+    commands.spawn((
+        Mesh3d(meshes.add(Mesh::from(shape::Plane { size: width as f32 }))),
+        MeshMaterial3d(
+            material_map
+                .materials
+                .get("concrete_floor")
+                .unwrap()
+                .clone(),
+        ),
+        Transform {
             rotation: Quat::from_rotation_x(1.5707963),
             ..Default::default()
         },
-        ..Default::default()
-    });
+        Visibility::default(),
+    ));
 }
 
 fn add_racks(

--- a/rmf_site_editor/src/widgets/canvas_tooltips.rs
+++ b/rmf_site_editor/src/widgets/canvas_tooltips.rs
@@ -72,7 +72,14 @@ impl CanvasTooltips {
 
         let text = self.tips.join("\n");
 
-        // egui::containers::popup::show_tooltip_text(ctx, "cursor_tooltip".into(), text);
+        egui::Area::new("canvas_tooltip_area".into()).show(ctx, |ui| {
+            egui::containers::popup::show_tooltip_text(
+                ctx,
+                ui.layer_id(),
+                "cursor_tooltip".into(),
+                text,
+            );
+        });
 
         self.previous = self.tips.drain(..).collect();
     }

--- a/rmf_site_editor/src/widgets/canvas_tooltips.rs
+++ b/rmf_site_editor/src/widgets/canvas_tooltips.rs
@@ -72,7 +72,8 @@ impl CanvasTooltips {
 
         let text = self.tips.join("\n");
 
-        egui::containers::popup::show_tooltip_text(ctx, "cursor_tooltip".into(), text);
+        //TODO(@xiyuoh)
+        // egui::containers::popup::show_tooltip_text(ctx, "cursor_tooltip".into(), text);
 
         self.previous = self.tips.drain(..).collect();
     }

--- a/rmf_site_editor/src/widgets/canvas_tooltips.rs
+++ b/rmf_site_editor/src/widgets/canvas_tooltips.rs
@@ -72,7 +72,6 @@ impl CanvasTooltips {
 
         let text = self.tips.join("\n");
 
-        //TODO(@xiyuoh)
         // egui::containers::popup::show_tooltip_text(ctx, "cursor_tooltip".into(), text);
 
         self.previous = self.tips.drain(..).collect();

--- a/rmf_site_editor/src/widgets/console.rs
+++ b/rmf_site_editor/src/widgets/console.rs
@@ -27,8 +27,8 @@ pub struct ConsoleWidgetPlugin {}
 impl Plugin for ConsoleWidgetPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LogHistory>();
-        let widget = PanelWidget::new(console_widget, &mut app.world);
-        app.world.spawn(widget);
+        let widget = PanelWidget::new(console_widget, app.world_mut());
+        app.world_mut().spawn(widget);
     }
 }
 

--- a/rmf_site_editor/src/widgets/creation.rs
+++ b/rmf_site_editor/src/widgets/creation.rs
@@ -461,7 +461,7 @@ impl<'w, 's> WidgetSystem<Tile> for ModelCreation<'w, 's> {
                                         };
 
                                     let mut selected_new_description = None;
-                                    ComboBox::from_id_source("choose_model_description")
+                                    ComboBox::from_id_salt("choose_model_description")
                                         .selected_text(selected_description_text)
                                         .show_ui(ui, |ui| {
                                             let Ok(children) = params.children.get(site_entity)

--- a/rmf_site_editor/src/widgets/diagnostics.rs
+++ b/rmf_site_editor/src/widgets/diagnostics.rs
@@ -38,9 +38,9 @@ impl Plugin for DiagnosticsPlugin {
             .init_resource::<DiagnosticsDisplay>()
             .add_systems(Update, handle_diagnostic_panel_visibility);
 
-        let panel = PanelWidget::new(diagnostics_panel, &mut app.world);
-        let widget = Widget::new::<Diagnostics>(&mut app.world);
-        app.world.spawn((panel, widget));
+        let panel = PanelWidget::new(diagnostics_panel, app.world_mut());
+        let widget = Widget::new::<Diagnostics>(app.world_mut());
+        app.world_mut().spawn((panel, widget));
     }
 }
 

--- a/rmf_site_editor/src/widgets/fuel_asset_browser.rs
+++ b/rmf_site_editor/src/widgets/fuel_asset_browser.rs
@@ -34,9 +34,9 @@ pub struct FuelAssetBrowserPlugin;
 impl Plugin for FuelAssetBrowserPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<AssetGalleryStatus>();
-        let panel = PanelWidget::new(fuel_asset_browser_panel, &mut app.world);
-        let widget = Widget::new::<FuelAssetBrowser>(&mut app.world);
-        app.world.spawn((panel, widget));
+        let panel = PanelWidget::new(fuel_asset_browser_panel, app.world_mut());
+        let widget = Widget::new::<FuelAssetBrowser>(app.world_mut());
+        app.world_mut().spawn((panel, widget));
     }
 }
 

--- a/rmf_site_editor/src/widgets/fuel_asset_browser.rs
+++ b/rmf_site_editor/src/widgets/fuel_asset_browser.rs
@@ -141,7 +141,7 @@ impl<'w, 's> FuelAssetBrowser<'w, 's> {
                                     .clone()
                                     .unwrap_or(owners[0].clone()),
                             };
-                            ComboBox::from_id_source("Asset Owner Filter")
+                            ComboBox::from_id_salt("Asset Owner Filter")
                                 .selected_text(selected.clone())
                                 .show_ui(ui, |ui| {
                                     for owner in owners.into_iter() {
@@ -175,7 +175,7 @@ impl<'w, 's> FuelAssetBrowser<'w, 's> {
                                     .clone()
                                     .unwrap_or(tags[0].clone()),
                             };
-                            ComboBox::from_id_source("Asset Tag Filter")
+                            ComboBox::from_id_salt("Asset Tag Filter")
                                 .selected_text(selected.clone())
                                 .show_ui(ui, |ui| {
                                     for tag in tags.into_iter() {
@@ -200,7 +200,7 @@ impl<'w, 's> FuelAssetBrowser<'w, 's> {
                                 Some(s) => s.clone(),
                                 None => gallery_status.filters.recall_private.unwrap_or(false),
                             };
-                            ComboBox::from_id_source("Asset Private Filter")
+                            ComboBox::from_id_salt("Asset Private Filter")
                                 .selected_text(selected.to_string())
                                 .show_ui(ui, |ui| {
                                     for private in [true, false].into_iter() {

--- a/rmf_site_editor/src/widgets/header_panel.rs
+++ b/rmf_site_editor/src/widgets/header_panel.rs
@@ -44,9 +44,9 @@ where
     W: WidgetSystem<Tile> + 'static + Send + Sync,
 {
     fn build(&self, app: &mut App) {
-        let widget = Widget::<Tile>::new::<W>(&mut app.world);
-        let header_panel = app.world.resource::<HeaderPanel>().id;
-        app.world.spawn(widget).set_parent(header_panel);
+        let widget = Widget::<Tile>::new::<W>(app.world_mut());
+        let header_panel = app.world().resource::<HeaderPanel>().id;
+        app.world_mut().spawn(widget).set_parent(header_panel);
     }
 }
 
@@ -85,9 +85,9 @@ impl Default for HeaderPanelPlugin {
 
 impl Plugin for HeaderPanelPlugin {
     fn build(&self, app: &mut App) {
-        let widget = PanelWidget::new(show_panel_of_tiles, &mut app.world);
+        let widget = PanelWidget::new(show_panel_of_tiles, app.world_mut());
         let id = app
-            .world
+            .world_mut()
             .spawn((
                 widget,
                 self.side,
@@ -105,7 +105,7 @@ impl Plugin for HeaderPanelPlugin {
                 },
             ))
             .id();
-        app.world.insert_resource(HeaderPanel {
+        app.world_mut().insert_resource(HeaderPanel {
             side: self.side,
             id,
         });

--- a/rmf_site_editor/src/widgets/inspector/inspect_angle.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_angle.rs
@@ -45,7 +45,7 @@ impl<'a> InspectAngle<'a> {
                         .min_decimals(0)
                         .max_decimals(1)
                         .speed(1.0)
-                        .clamp_range(self.range_degrees),
+                        .range(self.range_degrees),
                 );
 
                 let response = ui.button("deg").on_hover_text("Click to change to radians");
@@ -60,7 +60,7 @@ impl<'a> InspectAngle<'a> {
                         .min_decimals(2)
                         .max_decimals(4)
                         .speed(std::f32::consts::PI / 180.0)
-                        .clamp_range(
+                        .range(
                             self.range_degrees.start().to_radians()
                                 ..=self.range_degrees.end().to_radians(),
                         ),

--- a/rmf_site_editor/src/widgets/inspector/inspect_asset_source.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_asset_source.rs
@@ -54,7 +54,7 @@ impl<'a> InspectAssetSourceComponent<'a> {
         };
         ui.horizontal(|ui| {
             ui.label("Source");
-            ComboBox::from_id_source("Asset Source")
+            ComboBox::from_id_salt("Asset Source")
                 .selected_text(new_source.label())
                 .show_ui(ui, |ui| {
                     for variant in &[

--- a/rmf_site_editor/src/widgets/inspector/inspect_associated_graphs.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_associated_graphs.rs
@@ -65,7 +65,7 @@ impl<'w, 's> InspectAssociatedGraphs<'w, 's> {
         let mut new_associated = associated.clone();
         ui.horizontal(|ui| {
             ui.label("Associated Graphs");
-            ComboBox::from_id_source("Associated Graphs")
+            ComboBox::from_id_salt("Associated Graphs")
                 .selected_text(new_associated.label())
                 .show_ui(ui, |ui| {
                     for variant in &[
@@ -106,7 +106,7 @@ impl<'w, 's> InspectAssociatedGraphs<'w, 's> {
                             .get(&choice)
                             .map(|n| n.0.clone())
                             .unwrap_or_else(|| "<ERROR>".to_string());
-                        ComboBox::from_id_source("Add Associated Graph")
+                        ComboBox::from_id_salt("Add Associated Graph")
                             .selected_text(choice_text)
                             .show_ui(ui, |ui| {
                                 for (e, name) in unused_graphs.iter() {

--- a/rmf_site_editor/src/widgets/inspector/inspect_default_tasks.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_default_tasks.rs
@@ -25,7 +25,7 @@ pub struct InspectDefaultTasksPlugin {}
 
 impl Plugin for InspectDefaultTasksPlugin {
     fn build(&self, app: &mut App) {
-        app.world.resource_mut::<TaskKinds>().0.insert(
+        app.world_mut().resource_mut::<TaskKinds>().0.insert(
             GoToPlace::label(),
             (
                 |id, task, locations, ui| {
@@ -34,7 +34,7 @@ impl Plugin for InspectDefaultTasksPlugin {
                 |task, locations| InspectGoToPlace::is_valid(task, locations),
             ),
         );
-        app.world.resource_mut::<TaskKinds>().0.insert(
+        app.world_mut().resource_mut::<TaskKinds>().0.insert(
             WaitFor::label(),
             (
                 |id, task, locations, ui| {
@@ -118,7 +118,7 @@ impl<'a> InspectWaitFor<'a> {
         ui.horizontal(|ui| {
             ui.add(
                 DragValue::new(&mut new_wait_for.duration)
-                    .clamp_range(0_f32..=std::f32::INFINITY)
+                    .range(0_f32..=std::f32::INFINITY)
                     .speed(0.01),
             );
             ui.label(" seconds");

--- a/rmf_site_editor/src/widgets/inspector/inspect_default_tasks.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_default_tasks.rs
@@ -75,7 +75,7 @@ impl<'a> InspectGoToPlace<'a> {
         } else {
             new_go_to_place.location.clone()
         };
-        ComboBox::from_id_source(self.id.to_string() + "select_go_to_location")
+        ComboBox::from_id_salt(self.id.to_string() + "select_go_to_location")
             .selected_text(selected_location_name)
             .show_ui(ui, |ui| {
                 for location_name in self.locations.iter() {

--- a/rmf_site_editor/src/widgets/inspector/inspect_door.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_door.rs
@@ -66,7 +66,7 @@ impl<'a> InspectDoorType<'a> {
         let mut new_kind = self.kind.clone();
         ui.horizontal(|ui| {
             ui.label("Door Type:");
-            ComboBox::from_id_source("Door Type")
+            ComboBox::from_id_salt("Door Type")
                 .selected_text(self.kind.label())
                 .show_ui(ui, |ui| {
                     for variant in &[
@@ -141,7 +141,7 @@ impl<'a> InspectSwing<'a> {
     pub fn show(self, ui: &mut Ui) {
         ui.horizontal(|ui| {
             ui.label("Swing:");
-            ComboBox::from_id_source("Door Swing")
+            ComboBox::from_id_salt("Door Swing")
                 .selected_text(self.swing.label())
                 .show_ui(ui, |ui| {
                     for variant in &[

--- a/rmf_site_editor/src/widgets/inspector/inspect_door.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_door.rs
@@ -87,7 +87,7 @@ impl<'a> InspectDoorType<'a> {
                 ui.add(
                     DragValue::new(ratio)
                         .speed(0.01)
-                        .clamp_range(0.01..=std::f32::INFINITY),
+                        .range(0.01..=std::f32::INFINITY),
                 )
                 .on_hover_text("(Left Door Length)/(Right Door Length)");
             });

--- a/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
@@ -241,7 +241,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectFiducial<'w, 's> {
                 }
 
                 let mut clear_filter = false;
-                ComboBox::from_id_source("fiducial_affiliation")
+                ComboBox::from_id_salt("fiducial_affiliation")
                     .selected_text(selected_text)
                     .show_ui(ui, |ui| {
                         if let Some(group_name) = get_group_name(new_affiliation) {

--- a/rmf_site_editor/src/widgets/inspector/inspect_layer.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_layer.rs
@@ -179,11 +179,7 @@ impl<'w, 's> InspectLayer<'w, 's> {
 
             if let Some(LayerVisibility::Alpha(mut alpha)) = vis {
                 if ui
-                    .add(
-                        DragValue::new(&mut alpha)
-                            .clamp_range(0_f32..=1_f32)
-                            .speed(0.01),
-                    )
+                    .add(DragValue::new(&mut alpha).range(0_f32..=1_f32).speed(0.01))
                     .changed()
                 {
                     self.change_layer_visibility

--- a/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
@@ -75,7 +75,7 @@ impl<'w, 's> InspectLiftCabin<'w, 's> {
                     ui.add(
                         DragValue::new(&mut params.width)
                             .suffix("m")
-                            .clamp_range(0.01..=std::f32::INFINITY)
+                            .range(0.01..=std::f32::INFINITY)
                             .fixed_decimals(2)
                             .speed(0.01),
                     );
@@ -86,7 +86,7 @@ impl<'w, 's> InspectLiftCabin<'w, 's> {
                     ui.add(
                         DragValue::new(&mut params.depth)
                             .suffix("m")
-                            .clamp_range(0.01..=std::f32::INFINITY)
+                            .range(0.01..=std::f32::INFINITY)
                             .fixed_decimals(2)
                             .speed(0.01),
                     );
@@ -148,7 +148,7 @@ impl<'w, 's> InspectLiftCabin<'w, 's> {
                                     ui.add(
                                         DragValue::new(&mut placement.width)
                                             .suffix("m")
-                                            .clamp_range(0.001..=cabin_width - 0.001)
+                                            .range(0.001..=cabin_width - 0.001)
                                             .min_decimals(2)
                                             .max_decimals(4)
                                             .speed(0.005),

--- a/rmf_site_editor/src/widgets/inspector/inspect_light.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_light.rs
@@ -20,10 +20,7 @@ use crate::{
     widgets::{prelude::*, Inspect},
 };
 use bevy::prelude::*;
-use bevy_egui::egui::{
-    color_picker::{color_edit_button_rgba, Alpha},
-    ComboBox, DragValue, Rgba, Ui,
-};
+use bevy_egui::egui::{color_picker::color_edit_button_rgb, ComboBox, DragValue, Ui};
 
 #[derive(SystemParam)]
 pub struct InspectLight<'w, 's> {
@@ -157,8 +154,6 @@ impl<'a> InspectLightKind<'a> {
     }
 }
 
-pub fn color_edit(ui: &mut Ui, color: &mut [f32; 4]) {
-    let mut rgba = Rgba::from_rgba_premultiplied(color[0], color[1], color[2], color[3]);
-    color_edit_button_rgba(ui, &mut rgba, Alpha::OnlyBlend);
-    *color = [rgba.r(), rgba.g(), rgba.b(), rgba.a()];
+pub fn color_edit(ui: &mut Ui, color: &mut [f32; 3]) {
+    color_edit_button_rgb(ui, color);
 }

--- a/rmf_site_editor/src/widgets/inspector/inspect_light.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_light.rs
@@ -87,21 +87,19 @@ impl<'a> InspectLightKind<'a> {
                     ui.label("Intensity");
                     ui.add(
                         DragValue::new(&mut point.intensity)
-                            .clamp_range(0_f32..=std::f32::INFINITY)
+                            .range(0_f32..=std::f32::INFINITY)
                             .speed(10),
                     );
                 });
                 ui.horizontal(|ui| {
                     ui.label("Range");
-                    ui.add(
-                        DragValue::new(&mut point.range).clamp_range(0_f32..=std::f32::INFINITY),
-                    );
+                    ui.add(DragValue::new(&mut point.range).range(0_f32..=std::f32::INFINITY));
                 });
                 ui.horizontal(|ui| {
                     ui.label("Radius");
                     ui.add(
                         DragValue::new(&mut point.radius)
-                            .clamp_range(0_f32..=std::f32::INFINITY)
+                            .range(0_f32..=std::f32::INFINITY)
                             .speed(0.1),
                     );
                 });
@@ -116,19 +114,19 @@ impl<'a> InspectLightKind<'a> {
                     ui.label("Intensity");
                     ui.add(
                         DragValue::new(&mut spot.intensity)
-                            .clamp_range(0_f32..=std::f32::INFINITY)
+                            .range(0_f32..=std::f32::INFINITY)
                             .speed(10),
                     );
                 });
                 ui.horizontal(|ui| {
                     ui.label("Range");
-                    ui.add(DragValue::new(&mut spot.range).clamp_range(0_f32..=std::f32::INFINITY));
+                    ui.add(DragValue::new(&mut spot.range).range(0_f32..=std::f32::INFINITY));
                 });
                 ui.horizontal(|ui| {
                     ui.label("Radius");
                     ui.add(
                         DragValue::new(&mut spot.radius)
-                            .clamp_range(0_f32..=std::f32::INFINITY)
+                            .range(0_f32..=std::f32::INFINITY)
                             .speed(0.1),
                     );
                 });
@@ -143,7 +141,7 @@ impl<'a> InspectLightKind<'a> {
                     ui.label("Illuminance");
                     ui.add(
                         DragValue::new(&mut dir.illuminance)
-                            .clamp_range(0_f32..=std::f32::INFINITY)
+                            .range(0_f32..=std::f32::INFINITY)
                             .speed(1000),
                     );
                 });

--- a/rmf_site_editor/src/widgets/inspector/inspect_light.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_light.rs
@@ -61,7 +61,7 @@ impl<'a> InspectLightKind<'a> {
         let mut new_kind = self.kind.clone();
         ui.horizontal(|ui| {
             ui.label("Light Kind:");
-            ComboBox::from_id_source("Inspect Light Kind ComboBox")
+            ComboBox::from_id_salt("Inspect Light Kind ComboBox")
                 .selected_text(self.kind.label())
                 .show_ui(ui, |ui| {
                     for variant in [

--- a/rmf_site_editor/src/widgets/inspector/inspect_location.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_location.rs
@@ -81,7 +81,7 @@ impl<'w, 's> InspectLocation<'w, 's> {
                         }
                         variants.push(recall.assume_workcell());
 
-                        ComboBox::from_id_source("Add Location Tag")
+                        ComboBox::from_id_salt("Add Location Tag")
                             .selected_text(consider.label())
                             .show_ui(ui, |ui| {
                                 for variant in variants {

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
@@ -265,7 +265,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectCircleCollision<'w, 's> {
                             params.gizmos.circle(
                                 Isometry3d::new(
                                     Vec3::new(pose.trans[0], pose.trans[1], pose.trans[2] + 0.01),
-                                    Quat::IDENTITY, // TODO(@xiyuoh) ensure it is facing Vec3::Z
+                                    Quat::IDENTITY,
                                 ),
                                 new_circle_collision.radius,
                                 Colors::RED,

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
@@ -27,6 +27,7 @@ use crate::{
     site::{Change, Group, ModelMarker, ModelProperty, Pose, Robot},
     widgets::{prelude::*, Inspect},
 };
+use bevy::color::palettes::css as Colors;
 use bevy::{ecs::system::SystemParam, prelude::*};
 use bevy_egui::egui::{DragValue, Grid, Ui};
 use rmf_site_format::Recall;
@@ -220,7 +221,7 @@ pub struct InspectCircleCollision<'w, 's> {
         (With<ModelMarker>, With<Group>),
     >,
     poses: Query<'w, 's, &'static Pose>,
-    gizmos: Gizmos<'s>,
+    gizmos: Gizmos<'w, 's>,
     change_robot_property: EventWriter<'w, Change<ModelProperty<Robot>>>,
 }
 
@@ -255,7 +256,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectCircleCollision<'w, 's> {
                     if ui
                         .add(
                             DragValue::new(&mut new_circle_collision.radius)
-                                .clamp_range(0_f32..=std::f32::INFINITY)
+                                .range(0_f32..=std::f32::INFINITY)
                                 .speed(0.01),
                         )
                         .is_pointer_button_down_on()
@@ -263,9 +264,9 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectCircleCollision<'w, 's> {
                         if let Ok(pose) = params.poses.get(selection) {
                             params.gizmos.circle(
                                 Vec3::new(pose.trans[0], pose.trans[1], pose.trans[2] + 0.01),
-                                Vec3::Z,
+                                Dir3::Z,
                                 new_circle_collision.radius,
-                                Color::RED,
+                                Colors::RED,
                             );
                         }
                     };
@@ -280,12 +281,12 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectCircleCollision<'w, 's> {
                     ui.label("");
                     ui.add(
                         DragValue::new(&mut new_circle_collision.offset[0])
-                            .clamp_range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
+                            .range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
                             .speed(0.01),
                     );
                     ui.add(
                         DragValue::new(&mut new_circle_collision.offset[1])
-                            .clamp_range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
+                            .range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
                             .speed(0.01),
                     );
                     ui.end_row();

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_collision.rs
@@ -263,8 +263,10 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectCircleCollision<'w, 's> {
                     {
                         if let Ok(pose) = params.poses.get(selection) {
                             params.gizmos.circle(
-                                Vec3::new(pose.trans[0], pose.trans[1], pose.trans[2] + 0.01),
-                                Dir3::Z,
+                                Isometry3d::new(
+                                    Vec3::new(pose.trans[0], pose.trans[1], pose.trans[2] + 0.01),
+                                    Quat::IDENTITY, // TODO(@xiyuoh) ensure it is facing Vec3::Z
+                                ),
                                 new_circle_collision.radius,
                                 Colors::RED,
                             );

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_mobility.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_mobility.rs
@@ -267,12 +267,12 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectDifferentialDrive<'w, 's> {
                     ui.label("");
                     ui.add(
                         DragValue::new(&mut new_differential_drive.rotation_center_offset[0])
-                            .clamp_range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
+                            .range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
                             .speed(0.01),
                     );
                     ui.add(
                         DragValue::new(&mut new_differential_drive.rotation_center_offset[1])
-                            .clamp_range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
+                            .range(std::f32::NEG_INFINITY..=std::f32::INFINITY)
                             .speed(0.01),
                     );
                     ui.end_row();
@@ -284,7 +284,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectDifferentialDrive<'w, 's> {
                     ui.label("Max Velocity");
                     ui.add(
                         DragValue::new(&mut new_differential_drive.translational_speed)
-                            .clamp_range(0_f32..=std::f32::INFINITY)
+                            .range(0_f32..=std::f32::INFINITY)
                             .speed(0.01),
                     );
                     ui.label("m/s");
@@ -293,7 +293,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectDifferentialDrive<'w, 's> {
                     ui.label("Max Angular");
                     ui.add(
                         DragValue::new(&mut new_differential_drive.rotational_speed)
-                            .clamp_range(0_f32..=std::f32::INFINITY)
+                            .range(0_f32..=std::f32::INFINITY)
                             .speed(0.01),
                     );
                     ui.label("rad/s");

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_robot_properties.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_robot_properties.rs
@@ -65,7 +65,7 @@ impl Plugin for InspectRobotPropertiesPlugin {
     fn build(&self, app: &mut App) {
         // Allows us to toggle Robot as a configurable property
         // from the model description inspector
-        app.world_mut().init_component::<ModelProperty<Robot>>();
+        app.world_mut().register_component::<ModelProperty<Robot>>();
         let component_id = app
             .world()
             .components()
@@ -478,7 +478,7 @@ pub fn show_robot_property_widget<T: RobotProperty>(
             ui.indent("configure_".to_owned() + &property_label, |ui| {
                 ui.horizontal(|ui| {
                     ui.label(property_label.to_owned() + " Kind");
-                    ComboBox::from_id_source("select_".to_owned() + &property_label + "_kind")
+                    ComboBox::from_id_salt("select_".to_owned() + &property_label + "_kind")
                         .selected_text(selected_property_kind)
                         .show_ui(ui, |ui| {
                             for (kind, kind_registration) in widget_registration.kinds.iter() {

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/mod.rs
@@ -106,7 +106,7 @@ pub struct ModelPropertyData {
 impl FromWorld for ModelPropertyData {
     fn from_world(world: &mut World) -> Self {
         let mut required = HashMap::new();
-        world.init_component::<ModelProperty<AssetSource>>();
+        world.register_component::<ModelProperty<AssetSource>>();
         required.insert(
             world
                 .components()
@@ -118,7 +118,7 @@ impl FromWorld for ModelPropertyData {
                 get_remove_model_property_fn::<ModelProperty<AssetSource>>(),
             ),
         );
-        world.init_component::<ModelProperty<Scale>>();
+        world.register_component::<ModelProperty<Scale>>();
         required.insert(
             world
                 .components()
@@ -130,7 +130,7 @@ impl FromWorld for ModelPropertyData {
                 get_remove_model_property_fn::<ModelProperty<Scale>>(),
             ),
         );
-        world.init_component::<ModelProperty<IsStatic>>();
+        world.register_component::<ModelProperty<IsStatic>>();
         required.insert(
             world
                 .components()
@@ -405,7 +405,7 @@ impl<'w, 's> InspectSelectedModelDescription<'w, 's> {
         let mut new_description_entity = current_description_entity.clone();
         ui.horizontal(|ui| {
             ui.label("Description");
-            ComboBox::from_id_source("model_description_affiliation")
+            ComboBox::from_id_salt("model_description_affiliation")
                 .selected_text(current_description_name.0.as_str())
                 .show_ui(ui, |ui| {
                     for (entity, name, ..) in self.model_descriptions.iter() {

--- a/rmf_site_editor/src/widgets/inspector/inspect_motion.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_motion.rs
@@ -108,7 +108,7 @@ impl<'w, 's> InspectReverseMotion<'w, 's> {
 
         let mut new_reverse = reverse.clone();
         ui.label(RichText::new("Reverse Motion").size(18.0));
-        ComboBox::from_id_source("Reverse Lane")
+        ComboBox::from_id_salt("Reverse Lane")
             .selected_text(new_reverse.label())
             .show_ui(ui, |ui| {
                 for variant in &[
@@ -168,7 +168,7 @@ impl<'a> InspectMotionComponent<'a> {
 
                 ui.label("Orientation Constraint");
                 let mut orientation = self.motion.orientation_constraint.clone();
-                ComboBox::from_id_source("Orientation Constraint")
+                ComboBox::from_id_salt("Orientation Constraint")
                     .selected_text(orientation.label())
                     .show_ui(ui, |ui| {
                         for variant in &[

--- a/rmf_site_editor/src/widgets/inspector/inspect_option_f32.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_option_f32.rs
@@ -83,7 +83,7 @@ impl<'a> InspectOptionF32<'a> {
             if has_value {
                 let response = ui.add(
                     DragValue::new(&mut assumed_value)
-                        .clamp_range(self.range)
+                        .range(self.range)
                         .min_decimals(self.min_decimals)
                         .max_decimals_opt(self.max_decimals)
                         .speed(self.speed)

--- a/rmf_site_editor/src/widgets/inspector/inspect_pose.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_pose.rs
@@ -124,7 +124,7 @@ impl<'a> InspectPoseComponent<'a> {
 
         ui.horizontal(|ui| {
             ui.label("Rotation");
-            ComboBox::from_id_source("pose_rotation")
+            ComboBox::from_id_salt("pose_rotation")
                 .selected_text(new_pose.rot.label())
                 .show_ui(ui, |ui| {
                     for variant in &[

--- a/rmf_site_editor/src/widgets/inspector/inspect_pose.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_pose.rs
@@ -161,10 +161,10 @@ impl<'a> InspectPoseComponent<'a> {
                     ui.label("w");
                     ui.end_row();
 
-                    ui.add(DragValue::new(x).speed(0.01).clamp_range(-1.0..=1.0));
-                    ui.add(DragValue::new(y).speed(0.01).clamp_range(-1.0..=1.0));
-                    ui.add(DragValue::new(z).speed(0.01).clamp_range(-1.0..=1.0));
-                    ui.add(DragValue::new(w).speed(0.01).clamp_range(-1.0..=1.0));
+                    ui.add(DragValue::new(x).speed(0.01).range(-1.0..=1.0));
+                    ui.add(DragValue::new(y).speed(0.01).range(-1.0..=1.0));
+                    ui.add(DragValue::new(z).speed(0.01).range(-1.0..=1.0));
+                    ui.add(DragValue::new(w).speed(0.01).range(-1.0..=1.0));
                     ui.end_row();
                 });
 

--- a/rmf_site_editor/src/widgets/inspector/inspect_scale.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_scale.rs
@@ -69,17 +69,17 @@ impl<'a> InspectScaleComponent<'a> {
             ui.label("");
             ui.add(
                 DragValue::new(&mut new_scale.0[0])
-                    .clamp_range(0_f32..=std::f32::INFINITY)
+                    .range(0_f32..=std::f32::INFINITY)
                     .speed(0.01),
             );
             ui.add(
                 DragValue::new(&mut new_scale.0[1])
-                    .clamp_range(0_f32..=std::f32::INFINITY)
+                    .range(0_f32..=std::f32::INFINITY)
                     .speed(0.01),
             );
             ui.add(
                 DragValue::new(&mut new_scale.0[2])
-                    .clamp_range(0_f32..=std::f32::INFINITY)
+                    .range(0_f32..=std::f32::INFINITY)
                     .speed(0.01),
             );
             ui.end_row();

--- a/rmf_site_editor/src/widgets/inspector/inspect_task.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_task.rs
@@ -81,7 +81,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectTasks<'w, 's> {
         ui.indent("inspect_tasks", |ui| {
             Frame::default()
                 .inner_margin(4.0)
-                .rounding(2.0)
+                .corner_radius(2.0)
                 .stroke(Stroke::new(1.0, Color32::GRAY))
                 .show(ui, |ui| {
                     ui.set_min_width(ui.available_width());
@@ -128,7 +128,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectTasks<'w, 's> {
                         }
                     },
                 );
-                ComboBox::from_id_source("select_task_kind")
+                ComboBox::from_id_salt("select_task_kind")
                     .selected_text(params.pending_task.0.kind.clone())
                     .show_ui(ui, |ui| {
                         for (kind, _) in params.tasks.0.iter() {
@@ -175,7 +175,7 @@ fn edit_task_component(
     Frame::default()
         .inner_margin(4.0)
         .fill(Color32::DARK_GRAY)
-        .rounding(2.0)
+        .corner_radius(2.0)
         .show(ui, |ui| {
             ui.set_min_width(ui.available_width());
             ui.horizontal(|ui| {

--- a/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
@@ -228,7 +228,7 @@ impl<'w, 's> InspectTextureAffiliation<'w, 's> {
             }
 
             let mut clear_filter = false;
-            ComboBox::from_id_source("texture_affiliation")
+            ComboBox::from_id_salt("texture_affiliation")
                 .selected_text(current_texture_name)
                 .show_ui(ui, |ui| {
                     for child in children {

--- a/rmf_site_editor/src/widgets/inspector/inspect_value.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_value.rs
@@ -84,7 +84,7 @@ impl<'a, T: Numeric> InspectValue<'a, T> {
             ui.label(self.title);
             let response = ui.add(
                 DragValue::new(&mut new_value)
-                    .clamp_range(self.range)
+                    .range(self.range)
                     .min_decimals(self.min_decimals)
                     .max_decimals_opt(self.max_decimals)
                     .speed(self.speed)

--- a/rmf_site_editor/src/widgets/inspector/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/mod.rs
@@ -263,9 +263,9 @@ where
     W: WidgetSystem<Inspect, ()> + 'static + Send + Sync,
 {
     fn build(&self, app: &mut App) {
-        let inspector = app.world.resource::<MainInspector>().id;
-        let widget = Widget::<Inspect>::new::<W>(&mut app.world);
-        app.world.spawn(widget).set_parent(inspector);
+        let inspector = app.world().resource::<MainInspector>().id;
+        let widget = Widget::<Inspect>::new::<W>(app.world_mut());
+        app.world_mut().spawn(widget).set_parent(inspector);
     }
 }
 

--- a/rmf_site_editor/src/widgets/menu_bar.rs
+++ b/rmf_site_editor/src/widgets/menu_bar.rs
@@ -58,7 +58,7 @@ struct MenuDropdowns<'w, 's> {
     view_menu: Res<'w, ViewMenu>,
     file_menu: Res<'w, FileMenu>,
     children: Query<'w, 's, &'static Children>,
-    top_level_components: Query<'w, 's, ((), Without<Parent>)>,
+    top_level_components: Query<'w, 's, (), Without<Parent>>,
 }
 
 impl<'w, 's> WidgetSystem<Tile> for MenuDropdowns<'w, 's> {

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -318,7 +318,7 @@ impl TryShowWidgetWorld for World {
         Input: 'static + Send + Sync,
         Output: 'static + Send + Sync,
     {
-        let Some(mut entity_mut) = self.get_entity_mut(entity) else {
+        let Ok(mut entity_mut) = self.get_entity_mut(entity) else {
             return Err(ShowError::EntityMissing);
         };
         entity_mut.try_show_out(input, ui)

--- a/rmf_site_editor/src/widgets/panel.rs
+++ b/rmf_site_editor/src/widgets/panel.rs
@@ -36,7 +36,7 @@ use smallvec::SmallVec;
 /// - [`egui::TopBottomPanel::bottom`]
 #[derive(Component)]
 pub struct PanelWidget {
-    inner: Option<BoxedSystem<PanelWidgetInput>>,
+    inner: Option<BoxedSystem<In<PanelWidgetInput>>>,
 }
 
 /// Input provided to panel widgets.
@@ -49,7 +49,10 @@ pub struct PanelWidgetInput {
 
 impl PanelWidget {
     /// Pass in a system that takes takes [`PanelWidgetInput`] as its input parameter.
-    pub fn new<M, S: IntoSystem<PanelWidgetInput, (), M>>(system: S, world: &mut World) -> Self {
+    pub fn new<M, S: IntoSystem<In<PanelWidgetInput>, (), M>>(
+        system: S,
+        world: &mut World,
+    ) -> Self {
         let mut system = Box::new(IntoSystem::into_system(system));
         system.initialize(world);
         Self {

--- a/rmf_site_editor/src/widgets/properties_panel.rs
+++ b/rmf_site_editor/src/widgets/properties_panel.rs
@@ -107,9 +107,9 @@ where
     W: WidgetSystem<Tile> + 'static + Send + Sync,
 {
     fn build(&self, app: &mut App) {
-        let widget = Widget::<Tile>::new::<W>(&mut app.world);
-        let properties_panel = app.world.resource::<PropertiesPanel>().id;
-        app.world.spawn(widget).set_parent(properties_panel);
+        let widget = Widget::<Tile>::new::<W>(app.world_mut());
+        let properties_panel = app.world().resource::<PropertiesPanel>().id;
+        app.world_mut().spawn(widget).set_parent(properties_panel);
     }
 }
 
@@ -151,9 +151,9 @@ impl Default for PropertiesPanelPlugin {
 
 impl Plugin for PropertiesPanelPlugin {
     fn build(&self, app: &mut App) {
-        let widget = PanelWidget::new(show_panel_of_tiles, &mut app.world);
-        let id = app.world.spawn((widget, self.side)).id();
-        app.world.insert_resource(PropertiesPanel {
+        let widget = PanelWidget::new(show_panel_of_tiles, app.world_mut());
+        let id = app.world_mut().spawn((widget, self.side)).id();
+        app.world_mut().insert_resource(PropertiesPanel {
             side: self.side,
             id,
         });

--- a/rmf_site_editor/src/widgets/view_layers.rs
+++ b/rmf_site_editor/src/widgets/view_layers.rs
@@ -158,7 +158,7 @@ impl<'w, 's> ViewLayers<'w, 's> {
                         ui.push_id("Bottom Drawing Count", |ui| {
                             ui.add(
                                 DragValue::new(&mut shown_global.bottom_count)
-                                    .clamp_range(0..=usize::MAX)
+                                    .range(0..=usize::MAX)
                                     .speed(0.05),
                             );
                         });
@@ -206,7 +206,7 @@ impl<'w, 's> ViewLayers<'w, 's> {
 
         if let LayerVisibility::Alpha(alpha) = vis {
             if ui
-                .add(DragValue::new(alpha).clamp_range(0_f32..=1_f32).speed(0.01))
+                .add(DragValue::new(alpha).range(0_f32..=1_f32).speed(0.01))
                 .changed()
             {
                 *default_alpha = *alpha;

--- a/rmf_site_editor/src/widgets/view_levels.rs
+++ b/rmf_site_editor/src/widgets/view_levels.rs
@@ -91,7 +91,8 @@ impl<'w, 's> ViewLevels<'w, 's> {
                     let new_level = self
                         .commands
                         .spawn((
-                            SpatialBundle::default(),
+                            Transform::default(),
+                            Visibility::default(),
                             LevelProperties {
                                 elevation: LevelElevation(show_elevation),
                                 name: NameInSite(show_name.clone()),

--- a/rmf_site_editor/src/widgets/view_model_instances.rs
+++ b/rmf_site_editor/src/widgets/view_model_instances.rs
@@ -110,7 +110,7 @@ impl<'w, 's> ViewModelInstances<'w, 's> {
                             continue;
                         };
                         CollapsingHeader::new(desc_name.0.clone())
-                            .id_source(desc_name.0.clone())
+                            .id_salt(desc_name.0.clone())
                             .default_open(self.selection.0.is_some_and(|e| members.contains(&e)))
                             .show(ui, |ui| {
                                 for member in members.iter() {

--- a/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -133,7 +133,7 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
             ui.text_edit_singleline(&mut self.display_nav_graph.name);
             if add {
                 self.commands
-                    .spawn(SpatialBundle::default())
+                    .spawn((Transform::default(), Visibility::default()))
                     .insert(NavGraph {
                         name: NameInSite(self.display_nav_graph.name.clone()),
                         color: DisplayColor(self.display_nav_graph.color.unwrap().clone()),

--- a/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -253,7 +253,7 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
                             self.save_nav_graphs.send(SaveNavGraphs {
                                 site: current_site,
                                 to_file: export_file.clone(),
-                            })
+                            });
                         } else {
                             error!("No current site??");
                         }

--- a/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -291,7 +291,7 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
 
 #[derive(Resource)]
 pub struct NavGraphDisplay {
-    pub color: Option<[f32; 4]>,
+    pub color: Option<[f32; 3]>,
     pub name: String,
     pub removing: bool,
     pub choosing_file_for_export: Option<Task<Option<std::path::PathBuf>>>,

--- a/rmf_site_editor/src/widgets/view_occupancy.rs
+++ b/rmf_site_editor/src/widgets/view_occupancy.rs
@@ -67,7 +67,7 @@ impl<'w> ViewOccupancy<'w> {
             if ui
                 .add(
                     DragValue::new(&mut self.display_occupancy.cell_size)
-                        .clamp_range(0.01..=f32::INFINITY)
+                        .range(0.01..=f32::INFINITY)
                         .speed(0.01),
                 )
                 .changed()

--- a/rmf_site_editor/src/widgets/view_scenarios.rs
+++ b/rmf_site_editor/src/widgets/view_scenarios.rs
@@ -216,14 +216,14 @@ fn show_scenario_widget(
     });
 
     // Display children recursively
-    // The subversion is used as an id_source so that egui does not
+    // The subversion is used as an id_salt so that egui does not
     // generate errors when collapsing headers of the same name are created
     let mut subversion = 1;
     let children = scenario_children.get(&scenario_entity);
     let num_children = children.map(|c| c.len()).unwrap_or(0);
     CollapsingHeader::new(format!("Child Scenarios:  {}", num_children))
         .default_open(true)
-        .id_source(scenario_version_str.clone())
+        .id_salt(scenario_version_str.clone())
         .show(ui, |ui| {
             if let Some(children) = children {
                 for child in children.iter() {

--- a/rmf_site_editor/src/widgets/view_tasks.rs
+++ b/rmf_site_editor/src/widgets/view_tasks.rs
@@ -69,7 +69,7 @@ impl<'w, 's> ViewTasks<'w, 's> {
     pub fn show_widget(&mut self, ui: &mut Ui) {
         Frame::default()
             .inner_margin(4.0)
-            .rounding(2.0)
+            .corner_radius(2.0)
             .stroke(Stroke::new(1.0, Color32::GRAY))
             .show(ui, |ui| {
                 ui.set_min_width(ui.available_width());
@@ -111,7 +111,7 @@ fn show_task(
     Frame::default()
         .inner_margin(4.0)
         .fill(Color32::DARK_GRAY)
-        .rounding(2.0)
+        .corner_radius(2.0)
         .show(ui, |ui| {
             ui.set_min_width(ui.available_width());
 

--- a/rmf_site_editor/src/wireframe.rs
+++ b/rmf_site_editor/src/wireframe.rs
@@ -40,7 +40,7 @@ impl FromWorld for WireframeMenu {
         let view_header = world.resource::<ViewMenu>().get();
         world
             .entity_mut(view_header)
-            .push_children(&[toggle_wireframe]);
+            .add_children(&[toggle_wireframe]);
 
         WireframeMenu { toggle_wireframe }
     }

--- a/rmf_site_editor/src/wireframe.rs
+++ b/rmf_site_editor/src/wireframe.rs
@@ -51,7 +51,7 @@ fn handle_wireframe_menu_events(
     mut menu_events: EventReader<MenuEvent>,
     mut menu_items: Query<&mut MenuItem>,
     wireframe_menu: Res<WireframeMenu>,
-    meshes: Query<Entity, With<Handle<Mesh>>>,
+    meshes: Query<Entity, With<Mesh3d>>,
     children: Query<&Children>,
     models: Query<Entity, Or<(With<ModelMarker>, With<PrimitiveShape>)>>,
 ) {
@@ -84,7 +84,7 @@ fn handle_wireframe_menu_events(
 
 fn add_wireframe_to_new_models(
     mut commands: Commands,
-    new_meshes: Query<Entity, Added<Handle<Mesh>>>,
+    new_meshes: Query<Entity, Added<Mesh3d>>,
     parents: Query<&Parent>,
     models: Query<Entity, Or<(With<ModelMarker>, With<PrimitiveShape>)>>,
     wireframe_menu: Res<WireframeMenu>,

--- a/rmf_site_editor_web/Cargo.toml
+++ b/rmf_site_editor_web/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["cdylib", "rlib"]
 name = "librmf_site_editor_web"
 
 [dependencies]
-wasm-bindgen = "=0.2.100" # Remember to update the README if we change this version number
+wasm-bindgen = "=0.2.97" # Remember to update the README if we change this version number
 rmf_site_editor = { path = "../rmf_site_editor" }
 console_error_panic_hook = "0.1.7"

--- a/rmf_site_editor_web/Cargo.toml
+++ b/rmf_site_editor_web/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["cdylib", "rlib"]
 name = "librmf_site_editor_web"
 
 [dependencies]
-wasm-bindgen = "=0.2.93" # Remember to update the README if we change this version number
+wasm-bindgen = "=0.2.100" # Remember to update the README if we change this version number
 rmf_site_editor = { path = "../rmf_site_editor" }
 console_error_panic_hook = "0.1.7"

--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "*"
 ron = { git = "https://github.com/ron-rs/ron", branch = "master" }
 thiserror = "*"
 glam = { version = "0.29", features = ["serde"] }
-uuid = { version = "1.1", features = ["v4", "serde"] }
+uuid = { version = "1.13", features = ["v4", "serde"] }
 # add features=["bevy"] to a dependent Cargo.toml to get the bevy-related features
 bevy = { version = "0.15", optional = true }
 sdformat_rs = { git = "https://github.com/open-rmf/sdf_rust_experimental", rev = "9fc35f2"}

--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "*"
 # We need ron v0.9 to be released before RON works correctly for structs with #[serde(flatten)]
 ron = { git = "https://github.com/ron-rs/ron", branch = "master" }
 thiserror = "*"
-glam = { version = "0.27", features = ["serde"] }
+glam = { version = "0.29", features = ["serde"] }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 # add features=["bevy"] to a dependent Cargo.toml to get the bevy-related features
 bevy = { version = "0.15", optional = true }

--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "*"
 glam = { version = "0.27", features = ["serde"] }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 # add features=["bevy"] to a dependent Cargo.toml to get the bevy-related features
-bevy = { version = "0.14", optional = true }
+bevy = { version = "0.15", optional = true }
 sdformat_rs = { git = "https://github.com/open-rmf/sdf_rust_experimental", rev = "9fc35f2"}
 yaserde = "0.7"
 # We depend on a bugfix released specifically in 0.7.3

--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -14,10 +14,10 @@ serde_json = "*"
 # We need ron v0.9 to be released before RON works correctly for structs with #[serde(flatten)]
 ron = { git = "https://github.com/ron-rs/ron", branch = "master" }
 thiserror = "*"
-glam = { version = "0.24", features = ["serde"] }
+glam = { version = "0.27", features = ["serde"] }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 # add features=["bevy"] to a dependent Cargo.toml to get the bevy-related features
-bevy = { version = "0.12", optional = true }
+bevy = { version = "0.14", optional = true }
 sdformat_rs = { git = "https://github.com/open-rmf/sdf_rust_experimental", rev = "9fc35f2"}
 yaserde = "0.7"
 # We depend on a bugfix released specifically in 0.7.3

--- a/rmf_site_format/Cargo.toml
+++ b/rmf_site_format/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "*"
 ron = { git = "https://github.com/ron-rs/ron", branch = "master" }
 thiserror = "*"
 glam = { version = "0.29", features = ["serde"] }
-uuid = { version = "1.13", features = ["v4", "serde"] }
+uuid = { version = "1.12", features = ["v4", "serde"] }
 # add features=["bevy"] to a dependent Cargo.toml to get the bevy-related features
 bevy = { version = "0.15", optional = true }
 sdformat_rs = { git = "https://github.com/open-rmf/sdf_rust_experimental", rev = "9fc35f2"}

--- a/rmf_site_format/src/light.rs
+++ b/rmf_site_format/src/light.rs
@@ -16,6 +16,7 @@
 */
 
 use crate::*;
+use bevy::color::Color;
 #[cfg(feature = "bevy")]
 use bevy::prelude::{
     Bundle, Component, DirectionalLight as BevyDirectionalLight, PointLight as BevyPointLight,
@@ -192,7 +193,7 @@ pub struct PointLight {
 impl PointLight {
     pub fn to_bevy(&self) -> BevyPointLight {
         BevyPointLight {
-            color: self.color.into(),
+            color: Color::srgba(self.color[0], self.color[1], self.color[2], self.color[3]),
             intensity: self.intensity,
             range: self.range,
             radius: self.radius,
@@ -232,7 +233,7 @@ pub struct SpotLight {
 impl SpotLight {
     pub fn to_bevy(&self) -> BevySpotLight {
         BevySpotLight {
-            color: self.color.into(),
+            color: Color::srgba(self.color[0], self.color[1], self.color[2], self.color[3]),
             intensity: self.intensity,
             range: self.range,
             radius: self.radius,
@@ -268,7 +269,7 @@ pub struct DirectionalLight {
 impl DirectionalLight {
     pub fn to_bevy(&self) -> BevyDirectionalLight {
         BevyDirectionalLight {
-            color: self.color.into(),
+            color: Color::srgba(self.color[0], self.color[1], self.color[2], self.color[3]),
             illuminance: self.illuminance,
             shadows_enabled: self.enable_shadows,
             ..Default::default()

--- a/rmf_site_format/src/light.rs
+++ b/rmf_site_format/src/light.rs
@@ -16,11 +16,13 @@
 */
 
 use crate::*;
-use bevy::color::Color;
 #[cfg(feature = "bevy")]
-use bevy::prelude::{
-    Bundle, Component, DirectionalLight as BevyDirectionalLight, PointLight as BevyPointLight,
-    SpotLight as BevySpotLight,
+use bevy::{
+    color::Color,
+    prelude::{
+        Bundle, Component, DirectionalLight as BevyDirectionalLight, PointLight as BevyPointLight,
+        SpotLight as BevySpotLight,
+    },
 };
 use serde::{Deserialize, Serialize};
 

--- a/rmf_site_format/src/light.rs
+++ b/rmf_site_format/src/light.rs
@@ -69,7 +69,7 @@ impl LightKind {
         }
     }
 
-    pub fn color(&self) -> [f32; 4] {
+    pub fn color(&self) -> [f32; 3] {
         match self {
             Self::Point(l) => l.color,
             Self::Spot(l) => l.color,
@@ -156,8 +156,8 @@ impl From<DirectionalLight> for LightKind {
     }
 }
 
-fn white() -> [f32; 4] {
-    [1.0, 1.0, 1.0, 1.0]
+fn white() -> [f32; 3] {
+    [1.0, 1.0, 1.0]
 }
 fn default_range() -> f32 {
     20.0
@@ -178,7 +178,7 @@ fn bool_true() -> bool {
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct PointLight {
     #[serde(default = "white")]
-    pub color: [f32; 4],
+    pub color: [f32; 3],
     #[serde(default = "default_intensity")]
     pub intensity: f32,
     #[serde(default = "default_range")]
@@ -193,7 +193,7 @@ pub struct PointLight {
 impl PointLight {
     pub fn to_bevy(&self) -> BevyPointLight {
         BevyPointLight {
-            color: Color::srgba(self.color[0], self.color[1], self.color[2], self.color[3]),
+            color: Color::srgb_from_array(self.color),
             intensity: self.intensity,
             range: self.range,
             radius: self.radius,
@@ -206,7 +206,7 @@ impl PointLight {
 impl Default for PointLight {
     fn default() -> Self {
         Self {
-            color: [1.0, 1.0, 1.0, 1.0],
+            color: [1.0, 1.0, 1.0],
             intensity: 800.0,
             range: 20.0,
             radius: 0.0,
@@ -218,7 +218,7 @@ impl Default for PointLight {
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct SpotLight {
     #[serde(default = "white")]
-    pub color: [f32; 4],
+    pub color: [f32; 3],
     #[serde(default = "default_intensity")]
     pub intensity: f32,
     #[serde(default = "default_range")]
@@ -233,7 +233,7 @@ pub struct SpotLight {
 impl SpotLight {
     pub fn to_bevy(&self) -> BevySpotLight {
         BevySpotLight {
-            color: Color::srgba(self.color[0], self.color[1], self.color[2], self.color[3]),
+            color: Color::srgb_from_array(self.color),
             intensity: self.intensity,
             range: self.range,
             radius: self.radius,
@@ -246,7 +246,7 @@ impl SpotLight {
 impl Default for SpotLight {
     fn default() -> Self {
         Self {
-            color: [1.0, 1.0, 1.0, 1.0],
+            color: [1.0, 1.0, 1.0],
             intensity: 800.0,
             range: 20.0,
             radius: 0.0,
@@ -258,7 +258,7 @@ impl Default for SpotLight {
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct DirectionalLight {
     #[serde(default = "white")]
-    pub color: [f32; 4],
+    pub color: [f32; 3],
     #[serde(default = "default_illuminance")]
     pub illuminance: f32,
     #[serde(default = "bool_true")]
@@ -269,7 +269,7 @@ pub struct DirectionalLight {
 impl DirectionalLight {
     pub fn to_bevy(&self) -> BevyDirectionalLight {
         BevyDirectionalLight {
-            color: Color::srgba(self.color[0], self.color[1], self.color[2], self.color[3]),
+            color: Color::srgb_from_array(self.color),
             illuminance: self.illuminance,
             shadows_enabled: self.enable_shadows,
             ..Default::default()
@@ -280,7 +280,7 @@ impl DirectionalLight {
 impl Default for DirectionalLight {
     fn default() -> Self {
         Self {
-            color: [1.0, 1.0, 1.0, 1.0],
+            color: [1.0, 1.0, 1.0],
             illuminance: 100000.0,
             enable_shadows: true,
         }

--- a/rmf_site_format/src/nav_graph.rs
+++ b/rmf_site_format/src/nav_graph.rs
@@ -21,15 +21,15 @@ use bevy::prelude::{Bundle, Component, Deref, DerefMut, Entity, Query, With};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 
-pub const DEFAULT_NAV_GRAPH_COLORS: [[f32; 4]; 8] = [
-    [1.0, 0.5, 0.3, 1.0],
-    [0.6, 1.0, 0.5, 1.0],
-    [0.6, 0.8, 1.0, 1.0],
-    [0.6, 0.2, 0.3, 1.0],
-    [0.1, 0.0, 1.0, 1.0],
-    [0.8, 0.4, 0.5, 1.0],
-    [0.9, 1.0, 0.0, 1.0],
-    [0.7, 0.5, 0.1, 1.0],
+pub const DEFAULT_NAV_GRAPH_COLORS: [[f32; 3]; 8] = [
+    [1.0, 0.5, 0.3],
+    [0.6, 1.0, 0.5],
+    [0.6, 0.8, 1.0],
+    [0.6, 0.2, 0.3],
+    [0.1, 0.0, 1.0],
+    [0.8, 0.4, 0.5],
+    [0.9, 1.0, 0.0],
+    [0.7, 0.5, 0.1],
 ];
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -49,7 +49,7 @@ impl Default for NavGraph {
     fn default() -> Self {
         Self {
             name: NameInSite("<Unnamed>".to_string()),
-            color: DisplayColor([1.0, 0.5, 0.3, 1.0]),
+            color: DisplayColor([1.0, 0.5, 0.3]),
             marker: NavGraphMarker,
         }
     }
@@ -58,7 +58,7 @@ impl Default for NavGraph {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(transparent)]
 #[cfg_attr(feature = "bevy", derive(Component, Deref, DerefMut))]
-pub struct DisplayColor(pub [f32; 4]);
+pub struct DisplayColor(pub [f32; 3]);
 
 /// This component is used by graph elements such as [`Lane`] and [`Location`]
 /// to indicate what graphs they can be associated with.


### PR DESCRIPTION
This PR migrates the current editor from Bevy 0.12 to 0.15.

A few items that are worth a closer look at are elaborated in comments below.

Edit: Adding some TODO for tracking
- [ ]  https://github.com/open-rmf/bevy_impulse/pull/70 - Update `bevy_impulse` branch in [Cargo.toml](https://github.com/open-rmf/rmf_site/blob/xiyu/bevy_0.15/rmf_site_editor/Cargo.toml#L55)
- [ ] https://github.com/luca-della-vedova/bevy_gltf_export/pull/4 - Update `bevy_gltf_export` remote/branch in [Cargo.toml](https://github.com/open-rmf/rmf_site/blob/xiyu/bevy_0.15/rmf_site_editor/Cargo.toml#L55)