### PR TITLE
Update bevy_gltf_export branch and add Bevy patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,8 +498,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "bevy"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5cd3b24a5adb7c7378da7b3eea47639877643d11b6b087fc8a8094f2528615"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_internal",
 ]
@@ -507,8 +506,7 @@ dependencies = [
 [[package]]
 name = "bevy_a11y"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ed969a58fbe449ef35ebec58ab19578302537f34ee8a35d04e5a038b3c40f5"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -520,8 +518,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3647b67c6bfd456922b2720ccef980dec01742d155d0eb454dc3d8fdc65e7aff"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -554,8 +551,7 @@ dependencies = [
 [[package]]
 name = "bevy_app"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b6267ac23a9947d5b2725ff047a1e1add70076d85fa9fb73d044ab9bea1f3c"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -577,8 +573,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0698040d63199391ea77fd02e039630748e3e335c3070c6d932fd96cbf80f5d6"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -617,8 +612,7 @@ dependencies = [
 [[package]]
 name = "bevy_asset_macros"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf8c00b5d532f8e5ac7b49af10602f9f7774a2d522cf0638323b5dfeee7b31c"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -629,8 +623,7 @@ dependencies = [
 [[package]]
 name = "bevy_audio"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e54154e6369abdbaf5098e20424d59197c9b701d4f79fe8d0d2bde03d25f12"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -647,8 +640,7 @@ dependencies = [
 [[package]]
 name = "bevy_color"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf6a5ad35496bbc41713efbcf06ab72b9a310fabcab0f9db1debb56e8488c6e"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -663,8 +655,7 @@ dependencies = [
 [[package]]
 name = "bevy_core_pipeline"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c2310717b9794e4a45513ee5946a7be0838852a4c1e185884195e1a8688ff3"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -693,8 +684,7 @@ dependencies = [
 [[package]]
 name = "bevy_derive"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f626531b9c05c25a758ede228727bd11c2c2c8498ecbed9925044386d525a2a3"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -704,8 +694,7 @@ dependencies = [
 [[package]]
 name = "bevy_diagnostic"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a1ff3944a534b8472516866284181eef0a75b6dd4d39b6e5925715e350766"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -722,8 +711,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e807b5d9aab3bb8dfe47e7a44c9ff088bad2ceefe299b80ac77609a87fe9d4"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -750,8 +738,7 @@ dependencies = [
 [[package]]
 name = "bevy_ecs_macros"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d7bb98aeb8dd30f36e6a773000c12a891d4f1bee2adc3841ec89cc8eaf54e"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -799,8 +786,7 @@ dependencies = [
 [[package]]
 name = "bevy_encase_derive"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bb31dc1090c6f8fabbf6b21994d19a12766e786885ee48ffc547f0f1fa7863"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -809,8 +795,7 @@ dependencies = [
 [[package]]
 name = "bevy_gilrs"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950c84596dbff8a9691a050c37bb610ef9398af56369c2c2dd6dc41ef7b717a5"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -826,8 +811,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54af8145b35ab2a830a6dd1058e23c1e1ddc4b893db79d295259ef82f51c7520"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -851,8 +835,7 @@ dependencies = [
 [[package]]
 name = "bevy_gizmos_macros"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40137ace61f092b7a09eba41d7d1e6aef941f53a7818b06ef86dcce7b6a1fd3f"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -863,8 +846,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa25b809ee024ef2682bafc1ca22ca8275552edb549dc6f69a030fdffd976c63"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -898,7 +880,7 @@ dependencies = [
 [[package]]
 name = "bevy_gltf_export"
 version = "0.1.0"
-source = "git+https://github.com/xiyuoh/bevy_gltf_export?branch=xiyu%2Fbevy_0.16#d85393ba6d0333168be0345c27f573fc9d0a46fe"
+source = "git+https://github.com/luca-della-vedova/bevy_gltf_export#098fc7c64e40bffb796ae6945177e7f708a20cc9"
 dependencies = [
  "bevy_asset",
  "bevy_color",
@@ -917,8 +899,7 @@ dependencies = [
 [[package]]
 name = "bevy_image"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840b25f7f58894c641739f756959028a04f519c448db7e2cd3e2e29fc5fd188d"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -982,8 +963,7 @@ dependencies = [
 [[package]]
 name = "bevy_input"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763410715714f3d4d2dcdf077af276e2e4ea93fd8081b183d446d060ea95baaa"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1000,8 +980,7 @@ dependencies = [
 [[package]]
 name = "bevy_input_focus"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e7b4ed65e10927a39a987cf85ef98727dd319aafb6e6835f2cb05b883c6d66"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1016,8 +995,7 @@ dependencies = [
 [[package]]
 name = "bevy_internal"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526ffd64c58004cb97308826e896c07d0e23dc056c243b97492e31cdf72e2830"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1059,8 +1037,7 @@ dependencies = [
 [[package]]
 name = "bevy_log"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7156df8d2f11135cf71c03eb4c11132b65201fd4f51648571e59e39c9c9ee2f6"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1076,8 +1053,7 @@ dependencies = [
 [[package]]
 name = "bevy_macro_utils"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2473db70d8785b5c75d6dd951a2e51e9be2c2311122db9692c79c9d887517b"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1089,8 +1065,7 @@ dependencies = [
 [[package]]
 name = "bevy_math"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a3a926d02dc501c6156a047510bdb538dcb1fa744eeba13c824b73ba88de55"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1109,8 +1084,7 @@ dependencies = [
 [[package]]
 name = "bevy_mesh"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12af58280c7453e32e2f083d86eaa4c9b9d03ea8683977108ded8f1930c539f2"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1134,8 +1108,7 @@ dependencies = [
 [[package]]
 name = "bevy_mikktspace"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e0258423c689f764556e36b5d9eebdbf624b29a1fd5b33cd9f6c42dcc4d5f3"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "glam",
 ]
@@ -1168,8 +1141,7 @@ dependencies = [
 [[package]]
 name = "bevy_pbr"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fe0de43b68bf9e5090a33efc963f125e9d3f9d97be9ebece7bcfdde1b6da80"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1202,8 +1174,7 @@ dependencies = [
 [[package]]
 name = "bevy_picking"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73674f62b1033006bd75c89033f5d3516386cfd7d43bb9f7665012c0ab14d22"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1227,8 +1198,7 @@ dependencies = [
 [[package]]
 name = "bevy_platform"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704db2c11b7bc31093df4fbbdd3769f9606a6a5287149f4b51f2680f25834ebc"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1245,14 +1215,12 @@ dependencies = [
 [[package]]
 name = "bevy_ptr"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 
 [[package]]
 name = "bevy_reflect"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607ebacc31029cf2f39ac330eabf1d4bc411b159528ec08dbe6b0593eaccfd41"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1278,8 +1246,7 @@ dependencies = [
 [[package]]
 name = "bevy_reflect_derive"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf35e45e4eb239018369f63f2adc2107a54c329f9276d020e01eee1625b0238b"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1291,8 +1258,7 @@ dependencies = [
 [[package]]
 name = "bevy_render"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7306235b3343b032801504f3e884b93abfb7ba58179fc555c479df509f349"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1343,8 +1309,7 @@ dependencies = [
 [[package]]
 name = "bevy_render_macros"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85c4fb26b66d3a257b655485d11b9b6df9d3c85026493ba8092767a5edfc1b2"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1355,8 +1320,7 @@ dependencies = [
 [[package]]
 name = "bevy_scene"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b628f560f2d2fe9f35ecd4526627ba3992f082de03fd745536e4053a0266fe"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1376,8 +1340,7 @@ dependencies = [
 [[package]]
 name = "bevy_sprite"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f97bf54fb1c37a1077139b59bb32bc77f7ca53149cfcaa512adbb69a2d492c"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1406,8 +1369,7 @@ dependencies = [
 [[package]]
 name = "bevy_state"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682c343c354b191fe6669823bce3b0695ee1ae4ac36f582e29c436a72b67cdd5"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1422,8 +1384,7 @@ dependencies = [
 [[package]]
 name = "bevy_state_macros"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b4bf3970c4f0e60572901df4641656722172c222d71a80c430d36b0e31426c"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1445,8 +1406,7 @@ dependencies = [
 [[package]]
 name = "bevy_tasks"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444c450b65e108855f42ecb6db0c041a56ea7d7f10cc6222f0ca95e9536a7d19"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1467,8 +1427,7 @@ dependencies = [
 [[package]]
 name = "bevy_text"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef071262c5a9afbc39caba4c0b282c7d045fbb5cf33bdab1924bd2343403833"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1497,8 +1456,7 @@ dependencies = [
 [[package]]
 name = "bevy_time"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456369ca10f8e039aaf273332744674844827854833ee29e28f9e161702f2f55"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1512,8 +1470,7 @@ dependencies = [
 [[package]]
 name = "bevy_transform"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8479cdd5461246943956a7c8347e4e5d6ff857e57add889fb50eee0b5c26ab48"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1530,8 +1487,7 @@ dependencies = [
 [[package]]
 name = "bevy_ui"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110dc5d0059f112263512be8cd7bfe0466dfb7c26b9bf4c74529355249fd23f9"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1565,8 +1521,7 @@ dependencies = [
 [[package]]
 name = "bevy_utils"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2da3b3c1f94dadefcbe837aaa4aa119fcea37f7bdc5307eb05b4ede1921e24"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1575,8 +1530,7 @@ dependencies = [
 [[package]]
 name = "bevy_window"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d83327cc5584da463d12b7a88ddb97f9e006828832287e1564531171fffdeb4"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1595,8 +1549,7 @@ dependencies = [
 [[package]]
 name = "bevy_winit"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b14928923ae4274f4b867dce3d0e7b2c8a31bebcb0f6e65a4261c3e0765064"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -7563,3 +7516,18 @@ checksum = "99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028"
 dependencies = [
  "zune-core",
 ]
+
+[[patch.unused]]
+name = "bevy_dev_tools"
+version = "0.16.0"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+
+[[patch.unused]]
+name = "bevy_dylib"
+version = "0.16.0"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+
+[[patch.unused]]
+name = "bevy_remote"
+version = "0.16.0"
+source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,49 @@ opt-level = 1
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]
 opt-level = 3
+
+[patch.crates-io]
+bevy = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_a11y = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_animation = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_app = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_asset = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_audio = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_color = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_core_pipeline = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_derive = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_dev_tools = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_diagnostic = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_dylib = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_ecs = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_encase_derive = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_gilrs = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_gizmos = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_gltf = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_image = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_input = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_input_focus = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_internal = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_log = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_macro_utils = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_math = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_mesh = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_mikktspace = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_pbr = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_picking = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_platform = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_ptr = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_reflect = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_remote = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_render = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_scene = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_sprite = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_state = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_tasks = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_text = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_time = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_transform = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_ui = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_utils = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_window = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy_winit = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -17,7 +17,7 @@ path = "examples/extending_menu.rs"
 
 [dependencies]
 bevy_mod_outline = { git = "https://github.com/komadori/bevy_mod_outline", branch = "bevy-0.16"}
-bevy_gltf_export = { git = "https://github.com/xiyuoh/bevy_gltf_export", branch = "xiyu/bevy_0.16"}
+bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export" }
 bevy_stl = "0.16"
 bevy_obj = { version = "0.16", features = ["scene"] }
 smallvec = "*"


### PR DESCRIPTION
Following https://github.com/open-rmf/rmf_site/pull/281 we've found a bug in Bevy that panics when entities are spawned in `PostUpdate`. This is evident in the site editor as we currently experience crashes when creating lanes and locations. The fix is already available (https://github.com/bevyengine/bevy/pull/19064), but it may take some time before they're merged and released. Tested and verified that it stops the crashes.

This PR temporarily and manually adds a patch for Bevy `v0.16.0` with the fix cherry picked. This allows us to keep `main` functional. We can remove the patch when `v0.16.1` is released.

I've also updated the branch for `bevy_gltf_export` back to Luca's repo for general housekeeping.