### PR TITLE
Update bevy mod outline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mod_outline"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fb205ce648281ec42dc1f82bb3143ff7c8b244974db5216bcd8c3b8a650cc6"
+checksum = "815a232a6616cdef3fadaa789269daca91eb598ffa22612218f8b5ed55dff7b5"
 dependencies = [
  "bevy",
  "bitfield 0.15.0",

--- a/rmf_site_editor/Cargo.toml
+++ b/rmf_site_editor/Cargo.toml
@@ -16,7 +16,7 @@ name = "extending_site_editor"
 path = "examples/extending_menu.rs"
 
 [dependencies]
-bevy_mod_outline = "0.10"
+bevy_mod_outline = "0.10.1"
 bevy_gltf_export = { git = "https://github.com/luca-della-vedova/bevy_gltf_export", rev = "098fc7c" }
 bevy_stl = "0.16"
 bevy_obj = { version = "0.16", features = ["scene"] }


### PR DESCRIPTION
Bumps `bevy_mod_outline` to 0.10.1 for https://github.com/open-rmf/rmf_site/issues/283