### PR TITLE
Add Battery component

### DIFF
--- a/rmf_site_editor/src/sdf_loader.rs
+++ b/rmf_site_editor/src/sdf_loader.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 
 use sdformat_rs::{SdfGeometry, SdfPose, Vector3d};
 
-use crate::site::{CollisionMeshMarker, DifferentialDrive, VisualMeshMarker};
+use crate::site::{Battery, CollisionMeshMarker, DifferentialDrive, VisualMeshMarker};
 use rmf_site_format::{
     Angle, AssetSource, Category, IsStatic, Model, ModelMarker, NameInSite, Pose, PrimitiveShape,
     Rotation, Scale,
@@ -47,6 +47,7 @@ impl Plugin for SdfPlugin {
             .register_type::<CollisionMeshMarker>()
             .register_type::<Category>()
             .register_type::<DifferentialDrive>()
+            .register_type::<Battery>()
             .register_type::<PrimitiveShape>();
     }
 }
@@ -317,45 +318,15 @@ fn load_model<'a, 'b>(
                         }
                     }
                 }
-                // Load DifferentialDrive from slotcar plugin
+                // Load parameters from slotcar plugin
                 for plugin in &model.plugin {
                     if plugin.name == "slotcar".to_string()
                         || plugin.filename == "libslotcar.so".to_string()
                     {
-                        let mut diff_drive = DifferentialDrive::default();
-                        if let Some(reversible) = plugin.elements.get("reversible") {
-                            if let sdformat_rs::ElementData::String(reversible_str) =
-                                &reversible.data
-                            {
-                                diff_drive.bidirectional = if reversible_str == "true" {
-                                    true
-                                } else if reversible_str == "false" {
-                                    false
-                                } else {
-                                    warn!(
-                                        "Found invalid slotcar reversibility data {:?}, 
-                                        setting DifferentialDrive reversibility to false.",
-                                        reversible_str
-                                    );
-                                    false
-                                };
-                            }
-                        }
-                        if let Some(translational_speed) = plugin
-                            .elements
-                            .get("nominal_drive_speed")
-                            .and_then(|speed| f64::try_from(speed.data.clone()).ok())
-                        {
-                            diff_drive.translational_speed = translational_speed as f32;
-                        }
-                        if let Some(rotational_speed) = plugin
-                            .elements
-                            .get("nominal_turn_speed")
-                            .and_then(|speed| f64::try_from(speed.data.clone()).ok())
-                        {
-                            diff_drive.rotational_speed = rotational_speed as f32;
-                        }
-                        world.entity_mut(e).insert(diff_drive);
+                        world
+                            .entity_mut(e)
+                            .insert(DifferentialDrive::from(&plugin.elements))
+                            .insert(Battery::from(&plugin.elements));
                     }
                 }
                 Ok(bevy::scene::Scene::new(world))

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_power_source.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_power_source.rs
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use super::{
+    get_selected_description_entity,
+    inspect_robot_properties::{show_robot_property_widget, RobotPropertyWidgetRegistry},
+};
+use crate::{
+    site::{
+        robot_properties::serialize_and_change_robot_property_kind, Battery, Change, Group,
+        ModelMarker, ModelProperty, ModelPropertyQuery, PowerSource, RecallPowerSource, Robot,
+        RobotProperty,
+    },
+    widgets::{prelude::*, Inspect},
+};
+use bevy::{ecs::system::SystemParam, prelude::*};
+use bevy_egui::egui::{DragValue, Grid, Ui};
+use smallvec::SmallVec;
+
+#[derive(SystemParam)]
+pub struct InspectPowerSource<'w, 's> {
+    robot_property_widgets: Res<'w, RobotPropertyWidgetRegistry>,
+    model_instances: ModelPropertyQuery<'w, 's, Robot>,
+    model_descriptions:
+        Query<'w, 's, &'static ModelProperty<Robot>, (With<ModelMarker>, With<Group>)>,
+    power_source: Query<'w, 's, &'static PowerSource, (With<ModelMarker>, With<Group>)>,
+    change_robot_property: EventWriter<'w, Change<ModelProperty<Robot>>>,
+    children: Query<'w, 's, &'static Children>,
+    recall_power_source:
+        Query<'w, 's, &'static RecallPowerSource, (With<ModelMarker>, With<Group>)>,
+}
+
+impl<'w, 's> WidgetSystem<Inspect> for InspectPowerSource<'w, 's> {
+    fn show(
+        Inspect {
+            selection,
+            inspection: _,
+            panel,
+        }: Inspect,
+        ui: &mut Ui,
+        state: &mut SystemState<Self>,
+        world: &mut World,
+    ) {
+        let params = state.get_mut(world);
+        let Some(description_entity) = get_selected_description_entity(
+            selection,
+            &params.model_instances,
+            &params.model_descriptions,
+        ) else {
+            return;
+        };
+        let Ok(ModelProperty(robot)) = params.model_descriptions.get(description_entity) else {
+            return;
+        };
+
+        let recall_power_source: Option<PowerSource> =
+            match params.recall_power_source.get(description_entity) {
+                Ok(recall) => Some(PowerSource {
+                    kind: recall.kind.clone().unwrap_or_default(),
+                    config: recall.config.clone().unwrap_or_default(),
+                }),
+                Err(_) => None,
+            };
+
+        show_robot_property_widget::<PowerSource>(
+            ui,
+            params.power_source,
+            recall_power_source,
+            params.change_robot_property,
+            robot,
+            &params.robot_property_widgets,
+            description_entity,
+        );
+
+        // Show children widgets
+        if let Some(widget_registration) = params.robot_property_widgets.get(&PowerSource::label())
+        {
+            let children_widgets: Result<SmallVec<[_; 16]>, _> = params
+                .children
+                .get(widget_registration.property_widget)
+                .map(|c| c.iter().collect());
+            let Ok(children_widgets) = children_widgets else {
+                return;
+            };
+
+            for child in children_widgets {
+                let inspect = Inspect {
+                    selection,
+                    inspection: child,
+                    panel,
+                };
+                ui.add_space(10.0);
+                let _ = world.try_show_in(child, inspect, ui);
+            }
+        }
+    }
+}
+
+#[derive(SystemParam)]
+pub struct InspectBattery<'w, 's> {
+    model_instances: ModelPropertyQuery<'w, 's, Robot>,
+    model_descriptions: Query<
+        'w,
+        's,
+        (&'static ModelProperty<Robot>, &'static Battery),
+        (With<ModelMarker>, With<Group>),
+    >,
+    change_robot_property: EventWriter<'w, Change<ModelProperty<Robot>>>,
+}
+
+impl<'w, 's> WidgetSystem<Inspect> for InspectBattery<'w, 's> {
+    fn show(
+        Inspect { selection, .. }: Inspect,
+        ui: &mut Ui,
+        state: &mut SystemState<Self>,
+        world: &mut World,
+    ) {
+        let mut params = state.get_mut(world);
+        let Some(description_entity) = get_selected_description_entity(
+            selection,
+            &params.model_instances,
+            &params.model_descriptions,
+        ) else {
+            return;
+        };
+        let Ok((ModelProperty(robot), battery)) =
+            params.model_descriptions.get_mut(description_entity)
+        else {
+            return;
+        };
+
+        let mut new_battery = battery.clone();
+
+        ui.indent("inspect_battery_properties", |ui| {
+            Grid::new("inspect_battery").num_columns(3).show(ui, |ui| {
+                ui.label("Voltage")
+                    .on_hover_text("The nominal voltage of the battery in Volts");
+                ui.add(
+                    DragValue::new(&mut new_battery.voltage)
+                        .range(0_f32..=std::f32::INFINITY)
+                        .speed(0.01),
+                );
+                ui.label("V");
+                ui.end_row();
+
+                ui.label("Capacity")
+                    .on_hover_text("The nominal capacity of the battery in Ampere-hours");
+                ui.add(
+                    DragValue::new(&mut new_battery.capacity)
+                        .range(0_f32..=std::f32::INFINITY)
+                        .speed(0.01),
+                );
+                ui.label("Ahr");
+                ui.end_row();
+
+                ui.label("Charging Current")
+                    .on_hover_text("The rated current in Amperes for charging the battery");
+                ui.add(
+                    DragValue::new(&mut new_battery.charging_current)
+                        .range(0_f32..=std::f32::INFINITY)
+                        .speed(0.01),
+                );
+                ui.label("A");
+                ui.end_row();
+
+                ui.label("Power").on_hover_text(
+                    "The rated nominal power consumption in Watts for this power system",
+                );
+                ui.add(
+                    DragValue::new(&mut new_battery.power)
+                        .range(0_f32..=std::f32::INFINITY)
+                        .speed(0.01),
+                );
+                ui.label("W");
+                ui.end_row();
+            });
+        });
+
+        if new_battery != *battery {
+            serialize_and_change_robot_property_kind::<PowerSource, Battery>(
+                &mut params.change_robot_property,
+                new_battery,
+                robot,
+                description_entity,
+            );
+        }
+    }
+}

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/mod.rs
@@ -43,6 +43,9 @@ pub use inspect_collision::*;
 pub mod inspect_mobility;
 pub use inspect_mobility::*;
 
+pub mod inspect_power_source;
+pub use inspect_power_source::*;
+
 pub mod inspect_required_properties;
 pub use inspect_required_properties::*;
 

--- a/rmf_site_editor/src/widgets/inspector/mod.rs
+++ b/rmf_site_editor/src/widgets/inspector/mod.rs
@@ -212,30 +212,42 @@ impl Plugin for StandardInspectorPlugin {
                 InspectModelDescriptionPlugin::default(),
                 InspectLiftPlugin::default(),
             ))
-            .add_plugins((
-                // Required model properties
-                InspectModelPropertyPlugin::<InspectModelScale, Scale>::new("Scale".to_string()),
-                InspectModelPropertyPlugin::<InspectModelAssetSource, AssetSource>::new(
-                    "Asset Source".to_string(),
+            .add_plugins(
+                (
+                    // Required model properties
+                    InspectModelPropertyPlugin::<InspectModelScale, Scale>::new(
+                        "Scale".to_string(),
+                    ),
+                    InspectModelPropertyPlugin::<InspectModelAssetSource, AssetSource>::new(
+                        "Asset Source".to_string(),
+                    ),
+                    InspectRobotPropertiesPlugin::default(),
+                    InspectRobotPropertyPlugin::<InspectMobility, Mobility, RecallMobility>::new(),
+                    InspectRobotPropertyPlugin::<InspectCollision, Collision, RecallCollision>::new(
+                    ),
+                    InspectRobotPropertyPlugin::<InspectPowerSource, PowerSource, RecallPowerSource>::new(),
+                    InspectRobotPropertyKindPlugin::<
+                        InspectDifferentialDrive,
+                        DifferentialDrive,
+                        Mobility,
+                        RecallDifferentialDrive,
+                    >::new(),
+                    InspectRobotPropertyKindPlugin::<
+                        InspectCircleCollision,
+                        CircleCollision,
+                        Collision,
+                        RecallCircleCollision,
+                    >::new(),
+                    InspectRobotPropertyKindPlugin::<
+                        InspectBattery,
+                        Battery,
+                        PowerSource,
+                        RecallBattery,
+                    >::new(),
+                    InspectTaskPlugin::default(),
+                    InspectDefaultTasksPlugin::default(),
                 ),
-                InspectRobotPropertiesPlugin::default(),
-                InspectRobotPropertyPlugin::<InspectMobility, Mobility, RecallMobility>::new(),
-                InspectRobotPropertyPlugin::<InspectCollision, Collision, RecallCollision>::new(),
-                InspectRobotPropertyKindPlugin::<
-                    InspectDifferentialDrive,
-                    DifferentialDrive,
-                    Mobility,
-                    RecallDifferentialDrive,
-                >::new(),
-                InspectRobotPropertyKindPlugin::<
-                    InspectCircleCollision,
-                    CircleCollision,
-                    Collision,
-                    RecallCircleCollision,
-                >::new(),
-                InspectTaskPlugin::default(),
-                InspectDefaultTasksPlugin::default(),
-            ));
+            );
     }
 }
 


### PR DESCRIPTION
Following [this discussion](https://github.com/open-rmf/rmf_site/pull/272#issuecomment-2966127138), this PR adds another robot property `Power Source` and property kind `Battery` to the site editor, and updates slotcar's SDF import/export workflow to include these battery-related parameters.