### PR TITLE
Improve load / import / export

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags = '--cfg getrandom_backend="wasm_js"'

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = '--cfg getrandom_backend="wasm_js"'

--- a/rmf_site_editor/src/interaction/mod.rs
+++ b/rmf_site_editor/src/interaction/mod.rs
@@ -169,82 +169,85 @@ impl Plugin for InteractionPlugin {
                 CategoryVisibilityPlugin::<MeasurementMarker>::visible(true),
                 CategoryVisibilityPlugin::<WallMarker>::visible(true),
             ))
-            .add_plugins((CameraControlsPlugin, ModelPreviewPlugin));
+            .add_plugins((
+                CameraControlsPlugin,
+                ModelPreviewPlugin,
+                SelectionPlugin::default(),
+            ));
 
         if !self.headless {
-            app.add_plugins(SelectionPlugin::default())
-                .add_systems(
-                    Update,
-                    (
-                        make_lift_doormat_gizmo,
-                        update_doormats_for_level_change,
-                        update_physical_light_visual_cues,
-                        make_selectable_entities_pickable,
-                        update_anchor_visual_cues.after(SelectionServiceStages::Select),
-                        update_popups.after(SelectionServiceStages::Select),
-                        update_unassigned_anchor_cues,
-                        update_anchor_proximity_xray.after(SelectionServiceStages::PickFlush),
-                        remove_deleted_supports_from_visual_cues,
-                        on_highlight_anchors_change,
-                    )
-                        .run_if(in_state(InteractionState::Enable)),
+            app.add_systems(
+                Update,
+                (
+                    make_lift_doormat_gizmo,
+                    update_doormats_for_level_change,
+                    update_physical_light_visual_cues,
+                    make_selectable_entities_pickable,
+                    update_anchor_visual_cues.after(SelectionServiceStages::Select),
+                    update_popups.after(SelectionServiceStages::Select),
+                    update_unassigned_anchor_cues,
+                    update_anchor_proximity_xray.after(SelectionServiceStages::PickFlush),
+                    remove_deleted_supports_from_visual_cues,
+                    on_highlight_anchors_change,
                 )
-                // Split the above because of a compile error when the tuple is too large
-                .add_systems(
-                    Update,
-                    (
-                        update_model_instance_visual_cues.after(SelectionServiceStages::Select),
-                        update_lane_visual_cues.after(SelectionServiceStages::Select),
-                        update_edge_visual_cues.after(SelectionServiceStages::Select),
-                        update_point_visual_cues.after(SelectionServiceStages::Select),
-                        update_path_visual_cues.after(SelectionServiceStages::Select),
-                        update_outline_visualization.after(SelectionServiceStages::Select),
-                        update_highlight_visualization.after(SelectionServiceStages::Select),
-                        update_cursor_hover_visualization.after(SelectionServiceStages::Select),
-                        update_gizmo_click_start.after(SelectionServiceStages::Select),
-                        update_gizmo_release,
-                        update_drag_motions
-                            .after(update_gizmo_click_start)
-                            .after(update_gizmo_release),
-                        handle_lift_doormat_clicks.after(update_gizmo_click_start),
-                        manage_previews,
-                        update_physical_camera_preview,
-                        dirty_changed_lifts,
-                        handle_preview_window_close,
-                    )
-                        .run_if(in_state(InteractionState::Enable)),
+                    .run_if(in_state(InteractionState::Enable)),
+            )
+            // Split the above because of a compile error when the tuple is too large
+            .add_systems(
+                Update,
+                (
+                    update_model_instance_visual_cues.after(SelectionServiceStages::Select),
+                    update_lane_visual_cues.after(SelectionServiceStages::Select),
+                    update_edge_visual_cues.after(SelectionServiceStages::Select),
+                    update_point_visual_cues.after(SelectionServiceStages::Select),
+                    update_path_visual_cues.after(SelectionServiceStages::Select),
+                    update_outline_visualization.after(SelectionServiceStages::Select),
+                    update_highlight_visualization.after(SelectionServiceStages::Select),
+                    update_cursor_hover_visualization.after(SelectionServiceStages::Select),
+                    update_gizmo_click_start.after(SelectionServiceStages::Select),
+                    update_gizmo_release,
+                    update_drag_motions
+                        .after(update_gizmo_click_start)
+                        .after(update_gizmo_release),
+                    handle_lift_doormat_clicks.after(update_gizmo_click_start),
+                    manage_previews,
+                    update_physical_camera_preview,
+                    dirty_changed_lifts,
+                    handle_preview_window_close,
                 )
-                .add_systems(
-                    PostUpdate,
-                    (
-                        add_anchor_visual_cues,
-                        remove_interaction_for_subordinate_anchors,
-                        add_lane_visual_cues,
-                        add_edge_visual_cues,
-                        add_point_visual_cues,
-                        add_path_visual_cues,
-                        add_outline_visualization,
-                        add_highlight_visualization,
-                        add_cursor_hover_visualization,
-                        add_physical_light_visual_cues,
-                        add_popups,
-                    )
-                        .run_if(in_state(InteractionState::Enable))
-                        .in_set(InteractionUpdateSet::AddVisuals),
+                    .run_if(in_state(InteractionState::Enable)),
+            )
+            .add_systems(
+                PostUpdate,
+                (
+                    add_anchor_visual_cues,
+                    remove_interaction_for_subordinate_anchors,
+                    add_lane_visual_cues,
+                    add_edge_visual_cues,
+                    add_point_visual_cues,
+                    add_path_visual_cues,
+                    add_outline_visualization,
+                    add_highlight_visualization,
+                    add_cursor_hover_visualization,
+                    add_physical_light_visual_cues,
+                    add_popups,
                 )
-                .add_systems(
-                    Update,
-                    propagate_visual_cues
-                        .run_if(in_state(InteractionState::Enable))
-                        .in_set(InteractionUpdateSet::ProcessVisuals),
-                )
-                .add_systems(OnExit(InteractionState::Enable), hide_cursor)
-                .add_systems(
-                    PostUpdate,
-                    (move_anchor.before(update_anchor_transforms), move_pose)
-                        .run_if(in_state(InteractionState::Enable)),
-                )
-                .add_systems(First, update_picked);
+                    .run_if(in_state(InteractionState::Enable))
+                    .in_set(InteractionUpdateSet::AddVisuals),
+            )
+            .add_systems(
+                Update,
+                propagate_visual_cues
+                    .run_if(in_state(InteractionState::Enable))
+                    .in_set(InteractionUpdateSet::ProcessVisuals),
+            )
+            .add_systems(OnExit(InteractionState::Enable), hide_cursor)
+            .add_systems(
+                PostUpdate,
+                (move_anchor.before(update_anchor_transforms), move_pose)
+                    .run_if(in_state(InteractionState::Enable)),
+            )
+            .add_systems(First, update_picked);
         }
     }
 }

--- a/rmf_site_editor/src/lib.rs
+++ b/rmf_site_editor/src/lib.rs
@@ -69,15 +69,20 @@ pub use osm_slippy_map::*;
 
 #[cfg_attr(not(target_arch = "wasm32"), derive(Parser))]
 pub struct CommandLineArgs {
-    /// Filename of a Site (.site.ron) or Building (.building.yaml) file to load.
+    /// Filename of a Site (.site.ron / .site.json) or Building (.building.yaml) file to load.
     /// Exclude this argument to get the main menu.
     pub filename: Option<String>,
-    /// Name of a Site (.site.ron) file to import on top of the base FILENAME.
+    /// Name of a Site (.site.json or .site.ron) file to import on top of the base FILENAME.
     #[cfg_attr(not(target_arch = "wasm32"), arg(short, long))]
     pub import: Option<String>,
     /// Run in headless mode and export the loaded site to the requested path.
+    /// This requires you to specify FILENAME, and it can be used with export_nav.
     #[cfg_attr(not(target_arch = "wasm32"), arg(long))]
-    pub headless_export: Option<String>,
+    pub export_sdf: Option<String>,
+    /// Run in headless mode and export the nav graphs to the requested path.
+    /// This requires you to specify FILENAME, and it can be used with export_sdf.
+    #[cfg_attr(not(target_arch = "wasm32"), arg(long))]
+    pub export_nav: Option<String>,
 }
 
 #[derive(Clone, Default, Eq, PartialEq, Debug, Hash, States)]
@@ -100,7 +105,8 @@ impl AppState {
 
 pub fn run(command_line_args: Vec<String>) {
     let mut app = App::new();
-    let mut _headless_export = None;
+    let mut _export_sdf = None;
+    let mut _export_nav = None;
 
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -111,17 +117,26 @@ pub fn run(command_line_args: Vec<String>) {
                 command_line_args.import.map(Into::into),
             ));
         }
-        _headless_export = command_line_args.headless_export;
+        _export_sdf = command_line_args.export_sdf;
+        _export_nav = command_line_args.export_nav;
     }
 
-    app.add_plugins(SiteEditor::default().headless_export(_headless_export));
+    app.add_plugins(
+        SiteEditor::default()
+        .export_sdf(_export_sdf)
+        .export_nav(_export_nav)
+    );
     app.run();
 }
 
 #[derive(Default)]
 pub struct SiteEditor {
-    /// Contains Some(path) if the site editor is running in headless mode exporting its site.
-    headless_export: Option<String>,
+    /// Contains Some(path) if the site editor is running in headless mode
+    /// exporting its site as an SDF.
+    export_sdf: Option<String>,
+    /// Contains Some(path) if the site editor is running in headless mode
+    /// exporting its nav graphs.
+    export_nav: Option<String>,
 }
 
 impl SiteEditor {
@@ -129,9 +144,24 @@ impl SiteEditor {
         Self::default()
     }
 
-    pub fn headless_export(mut self, export_to_file: Option<String>) -> Self {
-        self.headless_export = export_to_file;
+    pub fn export_sdf(mut self, export_to_file: Option<String>) -> Self {
+        self.export_sdf = export_to_file;
         self
+    }
+
+    pub fn export_nav(mut self, export_to_file: Option<String>) -> Self {
+        self.export_nav = export_to_file;
+        self
+    }
+
+    pub fn is_headless(&self) -> bool {
+        self.export_sdf.is_some() || self.export_nav.is_some()
+    }
+
+    // This is a separate function from is_headless just in case there are other
+    // reasons to run headless in the future, e.g. headless simulation.
+    pub fn is_headless_export(&self) -> bool {
+        self.export_sdf.is_some() || self.export_nav.is_some()
     }
 }
 
@@ -147,7 +177,7 @@ impl Plugin for SiteEditor {
         let headless = {
             #[cfg(not(target_arch = "wasm32"))]
             {
-                self.headless_export.is_some()
+                self.is_headless()
             }
             #[cfg(target_arch = "wasm32")]
             {
@@ -214,7 +244,7 @@ impl Plugin for SiteEditor {
                 ExitConfirmationPlugin,
                 KeyboardInputPlugin,
                 SitePlugin,
-                InteractionPlugin::new().headless(self.headless_export.is_some()),
+                InteractionPlugin::new().headless(self.is_headless()),
                 AnimationPlugin,
                 OccupancyPlugin,
                 WorkspacePlugin,
@@ -222,21 +252,24 @@ impl Plugin for SiteEditor {
                 bevy_impulse::ImpulsePlugin::default(),
             ));
 
-        if self.headless_export.is_none() {
+        if !self.is_headless() {
             app.add_plugins((StandardUiPlugin::default(), MainMenuPlugin))
                 // Note order matters, plugins that edit the menus must be initialized after the UI
                 .add_plugins((site::ViewMenuPlugin, OSMViewPlugin, SiteWireframePlugin));
         }
 
-        if let Some(path) = &self.headless_export {
+        if self.is_headless_export() {
             // We really don't need a high update rate here since we are IO bound, set a low rate
             // to save CPU.
             // TODO(luca) this still seems to take quite some time, check where the bottleneck is.
             app.add_plugins(ScheduleRunnerPlugin::run_loop(
                 std::time::Duration::from_secs_f64(1.0 / 10.0),
             ));
-            app.insert_resource(site::HeadlessSdfExportState::new(path));
-            app.add_systems(Last, site::headless_sdf_export);
+            app.insert_resource(site::HeadlessExportState::new(
+                self.export_sdf.clone(),
+                self.export_nav.clone(),
+            ));
+            app.add_systems(Last, site::headless_export);
         }
     }
 }

--- a/rmf_site_editor/src/main_menu.rs
+++ b/rmf_site_editor/src/main_menu.rs
@@ -16,7 +16,7 @@
 */
 
 use super::demo_world::*;
-use crate::{AppState, Autoload, WorkspaceData, WorkspaceLoader};
+use crate::{site::LoadSite, AppState, Autoload, WorkspaceLoader};
 use bevy::{app::AppExit, prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
 
@@ -57,7 +57,8 @@ fn egui_ui(
 
             ui.horizontal(|ui| {
                 if ui.button("View demo map").clicked() {
-                    workspace_loader.load_from_data(WorkspaceData::LegacyBuilding(demo_office()));
+                    workspace_loader
+                        .load_site(async move { LoadSite::from_data(&demo_office(), None) });
                 }
 
                 if ui.button("Open a file").clicked() {

--- a/rmf_site_editor/src/site/headless_export.rs
+++ b/rmf_site_editor/src/site/headless_export.rs
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::prelude::*;
+
+use crate::WorkspaceSaver;
+
+use crate::{
+    site::{
+        ChildLiftCabinGroup, CollisionMeshMarker, DoorSegments, DrawingMarker, FloorSegments,
+        LiftDoormat, ModelLoadingState, VisualMeshMarker,
+    },
+    Autoload, WorkspaceLoader,
+};
+use rmf_site_format::NameOfSite;
+
+/// Manages a simple state machine where we:
+///   * Wait for a few iterations,
+///   * Make sure the world is loaded.
+///   * Send a save event.
+///   * Wait for a few iterations.
+///   * Exit.
+//
+// TODO(@mxgrey): Introduce a "workspace has finished loading" event, and create
+// a workflow that reacts to that event.
+#[derive(Debug, Resource)]
+pub struct HeadlessExportState {
+    iterations: u32,
+    world_loaded: bool,
+    save_requested: bool,
+    sdf_target_path: Option<String>,
+    nav_target_path: Option<String>,
+}
+
+impl HeadlessExportState {
+    pub fn new(
+        sdf_target_path: Option<String>,
+        nav_target_path: Option<String>,
+    ) -> Self {
+        Self {
+            iterations: 0,
+            world_loaded: false,
+            save_requested: false,
+            sdf_target_path,
+            nav_target_path,
+        }
+    }
+}
+
+pub fn headless_export(
+    mut commands: Commands,
+    mut workspace_saver: WorkspaceSaver,
+    mut exit: EventWriter<bevy::app::AppExit>,
+    missing_models: Query<(), With<ModelLoadingState>>,
+    mut export_state: ResMut<HeadlessExportState>,
+    sites: Query<(Entity, &NameOfSite)>,
+    drawings: Query<Entity, With<DrawingMarker>>,
+    autoload: Option<ResMut<Autoload>>,
+    mut workspace_loader: WorkspaceLoader,
+) {
+    if let Some(mut autoload) = autoload {
+        if let Some(filename) = autoload.filename.take() {
+            workspace_loader.load_from_path(filename);
+        }
+    } else {
+        error!("Cannot perform a headless export since no site file was specified for loading");
+        exit.write(bevy::app::AppExit::error());
+        return;
+    }
+
+    export_state.iterations += 1;
+    if export_state.iterations < 5 {
+        return;
+    }
+    if sites.is_empty() {
+        error!("No site is loaded so we cannot export anything");
+        exit.write(bevy::app::AppExit::error());
+    }
+    if !missing_models.is_empty() {
+        // Despawn all drawings, otherwise floors will become transparent.
+        for e in drawings.iter() {
+            commands.entity(e).despawn();
+        }
+        // TODO(luca) implement a timeout logic?
+    } else {
+        if !export_state.world_loaded {
+            export_state.iterations = 0;
+            export_state.world_loaded = true;
+        } else {
+            if !export_state.save_requested && export_state.iterations > 5 {
+                if let Some(sdf_target_path) = &export_state.sdf_target_path {
+                    let path = std::path::PathBuf::from(sdf_target_path.clone());
+                    workspace_saver.export_sdf_to_path(path);
+                }
+
+                if let Some(nav_target_path) = &export_state.nav_target_path {
+
+                }
+
+                export_state.save_requested = true;
+                export_state.iterations = 0;
+            } else if export_state.save_requested && export_state.iterations > 5 {
+                exit.write(bevy::app::AppExit::Success);
+            }
+        }
+    }
+}

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -54,6 +54,9 @@ pub use georeference::*;
 pub mod group;
 pub use group::*;
 
+pub mod headless_export;
+pub use headless_export::*;
+
 pub mod lane;
 pub use lane::*;
 

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -270,6 +270,7 @@ impl Plugin for SitePlugin {
             ChangePlugin::<ModelProperty<AssetSource>>::default(),
             ChangePlugin::<ModelProperty<Scale>>::default(),
             ChangePlugin::<ModelProperty<IsStatic>>::default(),
+            ChangePlugin::<ModelProperty<Robot>>::default(),
             RecallPlugin::<RecallInstance>::default(),
             SlotcarSdfPlugin,
         ))

--- a/rmf_site_editor/src/site/mod.rs
+++ b/rmf_site_editor/src/site/mod.rs
@@ -204,7 +204,6 @@ impl Plugin for SitePlugin {
         .add_event::<RemoveScenario>()
         .add_event::<UpdateInstanceEvent>()
         .add_event::<SaveSite>()
-        .add_event::<SaveNavGraphs>()
         .add_event::<ExportLights>()
         .add_event::<ConsiderAssociatedGraph>()
         .add_event::<ConsiderLocationTag>()
@@ -300,7 +299,7 @@ impl Plugin for SitePlugin {
         )
         .add_systems(
             Update,
-            (save_site, save_nav_graphs, change_site.after(load_site))
+            (save_site, change_site.after(load_site))
                 .run_if(AppState::in_displaying_mode()),
         )
         .add_systems(

--- a/rmf_site_editor/src/site/save.rs
+++ b/rmf_site_editor/src/site/save.rs
@@ -34,14 +34,8 @@ use rmf_site_format::*;
 #[derive(Event)]
 pub struct SaveSite {
     pub site: Entity,
-    pub to_file: PathBuf,
+    pub to_location: PathBuf,
     pub format: ExportFormat,
-}
-
-#[derive(Event)]
-pub struct SaveNavGraphs {
-    pub site: Entity,
-    pub in_directory: PathBuf,
 }
 
 // TODO(MXG): Change all these errors to use u32 SiteIDs instead of entities
@@ -1477,7 +1471,7 @@ pub fn generate_site(
 pub fn save_site(world: &mut World) {
     let save_events: Vec<_> = world.resource_mut::<Events<SaveSite>>().drain().collect();
     for save_event in save_events {
-        let mut new_path = save_event.to_file;
+        let mut new_path = dbg!(save_event.to_location);
         let path_str = match new_path.to_str() {
             Some(s) => s,
             None => {
@@ -1599,7 +1593,6 @@ pub fn save_site(world: &mut World) {
                 }
 
                 migrate_relative_paths(save_event.site, &sdf_path, world);
-                let graphs = legacy::nav_graph::NavGraph::from_site(&site);
                 let sdf = match site.to_sdf() {
                     Ok(sdf) => sdf,
                     Err(err) => {
@@ -1616,15 +1609,19 @@ pub fn save_site(world: &mut World) {
                     error!("Failed serializing site to sdf: {e}");
                     continue;
                 }
-                let mut navgraph_dir = new_path.clone();
-                navgraph_dir.push("nav_graphs");
-                if let Err(e) = std::fs::create_dir_all(&navgraph_dir) {
-                    error!("Unable to create folder {}: {e}", navgraph_dir.display());
-                    continue;
-                }
-                for (name, graph) in &graphs {
-                    let mut graph_file = navgraph_dir.clone();
-                    graph_file.push(name.to_owned() + ".yaml");
+            }
+            ExportFormat::NavGraph => {
+                let site = match generate_site(world, save_event.site) {
+                    Ok(site) => site,
+                    Err(err) => {
+                        error!("Unable to compile site: {err}");
+                        continue;
+                    }
+                };
+
+                dbg!(&new_path);
+                for (name, nav_graph) in legacy::nav_graph::NavGraph::from_site(&site) {
+                    let graph_file = new_path.clone().join(name + ".nav.yaml");
                     info!(
                         "Saving legacy nav graph to {}",
                         graph_file.to_str().unwrap_or("<failed to render??>")
@@ -1636,63 +1633,16 @@ pub fn save_site(world: &mut World) {
                             continue;
                         }
                     };
-                    if let Err(err) = serde_yaml::to_writer(f, &graph) {
+                    if let Err(err) = serde_yaml::to_writer(f, &nav_graph) {
                         error!("Failed to save nav graph: {err}");
-                        continue;
                     }
                 }
+
+                info!(
+                    "Saving all site nav graphs to {}",
+                    new_path.to_str().unwrap_or("<failed to render??>")
+                );
             }
         }
-    }
-}
-
-pub fn save_nav_graphs(world: &mut World) {
-    let save_events: Vec<_> = world
-        .resource_mut::<Events<SaveNavGraphs>>()
-        .drain()
-        .collect();
-    for save_event in save_events {
-        let path = save_event.in_directory;
-
-        let mut site = match generate_site(world, save_event.site) {
-            Ok(site) => site,
-            Err(err) => {
-                error!("Unable to compile site: {err}");
-                continue;
-            }
-        };
-
-        for (name, nav_graph) in legacy::nav_graph::NavGraph::from_site(&site) {
-            let mut graph_file = path.clone();
-            graph_file.set_file_name(name + ".nav.yaml");
-            info!(
-                "Saving legacy nav graph to {}",
-                graph_file.to_str().unwrap_or("<failed to render??>")
-            );
-            let f = match std::fs::File::create(graph_file) {
-                Ok(f) => f,
-                Err(err) => {
-                    error!("Unable to save nav graph: {err}");
-                    continue;
-                }
-            };
-            if let Err(err) = serde_yaml::to_writer(f, &nav_graph) {
-                error!("Failed to save nav graph: {err}");
-            }
-        }
-
-        // Clear the elements that are not related to nav graphs
-        for (_, level) in &mut site.levels {
-            level.doors.clear();
-            level.drawings.clear();
-            level.floors.clear();
-            level.lights.clear();
-            level.walls.clear();
-        }
-
-        info!(
-            "Saving all site nav graphs to {}",
-            path.to_str().unwrap_or("<failed to render??>")
-        );
     }
 }

--- a/rmf_site_editor/src/widgets/icons.rs
+++ b/rmf_site_editor/src/widgets/icons.rs
@@ -54,7 +54,7 @@ pub struct Icon {
 impl Icon {
     // TODO(luca) consider exposing parameter for size, all occurences in the codebase currently
     // use [18., 18.]
-    pub fn egui(&self) -> ImageSource {
+    pub fn egui(&self) -> ImageSource<'_> {
         ImageSource::Texture((self.egui_handle, [18., 18.].into()).into())
     }
 }
@@ -148,7 +148,7 @@ impl FromWorld for Icons {
 }
 
 impl Icons {
-    pub fn layer_visibility_of(&self, vis: Option<LayerVisibility>) -> ImageSource {
+    pub fn layer_visibility_of(&self, vis: Option<LayerVisibility>) -> ImageSource<'_> {
         match vis {
             Some(v) => match v {
                 LayerVisibility::Opaque => self.opaque.egui(),
@@ -159,7 +159,7 @@ impl Icons {
         }
     }
 
-    pub fn move_rank(&self, adjustment: RankAdjustment) -> ImageSource {
+    pub fn move_rank(&self, adjustment: RankAdjustment) -> ImageSource<'_> {
         match adjustment {
             RankAdjustment::Delta(delta) => {
                 if delta < 0 {

--- a/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_robot_properties.rs
+++ b/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_robot_properties.rs
@@ -18,9 +18,9 @@
 use super::*;
 use crate::{
     site::{
-        recall_plugin::UpdateRecallSet, robot_properties::*, update_model_instances, Change,
-        ChangePlugin, Group, IssueKey, ModelMarker, ModelProperty, ModelPropertyQuery, NameInSite,
-        Recall, RecallPlugin, Robot, SiteUpdateSet,
+        recall_plugin::UpdateRecallSet, robot_properties::*, update_model_instances, Change, Group,
+        IssueKey, ModelMarker, ModelProperty, ModelPropertyQuery, NameInSite, Recall, RecallPlugin,
+        Robot, SiteUpdateSet,
     },
     widgets::Inspect,
     AppState, Issue, ModelPropertyData, ValidateWorkspace,
@@ -70,8 +70,7 @@ impl Plugin for InspectRobotPropertiesPlugin {
             .components()
             .component_id::<ModelProperty<Robot>>()
             .unwrap();
-        app.add_plugins(ChangePlugin::<ModelProperty<Robot>>::default())
-            .add_systems(PreUpdate, update_model_instances::<Robot>)
+        app.add_systems(PreUpdate, update_model_instances::<Robot>)
             .init_resource::<ModelPropertyData>()
             .world_mut()
             .resource_mut::<ModelPropertyData>()

--- a/rmf_site_editor/src/widgets/mod.rs
+++ b/rmf_site_editor/src/widgets/mod.rs
@@ -177,6 +177,8 @@ impl Plugin for StandardUiPlugin {
                 UserCameraDisplayPlugin::default(),
                 #[cfg(not(target_arch = "wasm32"))]
                 SdfExportMenuPlugin::default(),
+                #[cfg(not(target_arch = "wasm32"))]
+                NavGraphIoPlugin::default(),
             ))
             .add_systems(Startup, init_ui_style)
             .add_systems(
@@ -189,7 +191,6 @@ impl Plugin for StandardUiPlugin {
                 PostUpdate,
                 (
                     resolve_light_export_file,
-                    resolve_nav_graph_import_export_files,
                 )
                     .run_if(AppState::in_displaying_mode()),
             );

--- a/rmf_site_editor/src/widgets/sdf_export_menu.rs
+++ b/rmf_site_editor/src/widgets/sdf_export_menu.rs
@@ -35,10 +35,12 @@ impl FromWorld for SdfExportMenu {
     fn from_world(world: &mut World) -> Self {
         let file_header = world.resource::<FileMenu>().get();
         let export_sdf = world
-            .spawn(MenuItem::Text(
-                TextMenuItem::new("Export Sdf").shortcut("Ctrl-E"),
+            .spawn((
+                MenuItem::Text(
+                    TextMenuItem::new("Export Sdf").shortcut("Ctrl-E"),
+                ),
+                ChildOf(file_header),
             ))
-            .insert(ChildOf(file_header))
             .id();
 
         SdfExportMenu { export_sdf }

--- a/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -18,22 +18,22 @@
 use crate::{
     recency::RecencyRanking,
     site::{
-        Change, Delete, DisplayColor, ImportNavGraphs, NameInSite, NameOfSite, NavGraph,
-        NavGraphMarker, SaveNavGraphs, DEFAULT_NAV_GRAPH_COLORS,
+        Change, Delete, DisplayColor, NameInSite, NavGraph,
+        NavGraphMarker, DEFAULT_NAV_GRAPH_COLORS,
     },
-    widgets::{inspector::color_edit, prelude::*, Icons, MoveLayerButton, SelectorWidget},
-    AppState, Autoload, ChangeRank, CurrentWorkspace,
+    widgets::{
+        inspector::color_edit,
+        prelude::*,
+        Icons, MoveLayerButton, SelectorWidget, FileMenu, MenuItem, TextMenuItem,
+        MenuEvent,
+    },
+    AppState, ChangeRank, CurrentWorkspace, WorkspaceLoader, WorkspaceSaver,
 };
 use bevy::{
     ecs::system::SystemParam,
     prelude::*,
-    tasks::{AsyncComputeTaskPool, Task},
 };
 use bevy_egui::egui::{CollapsingHeader, ImageButton, Ui};
-use futures_lite::future;
-
-#[cfg(not(target_arch = "wasm32"))]
-use rfd::AsyncFileDialog;
 
 /// Add a widget for viewing and editing navigation graphs.
 #[derive(Default)]
@@ -43,6 +43,16 @@ impl Plugin for ViewNavGraphsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<NavGraphDisplay>()
             .add_plugins(PropertiesTilePlugin::<ViewNavGraphs>::new());
+    }
+}
+
+#[derive(Default)]
+pub struct NavGraphIoPlugin {}
+
+impl Plugin for NavGraphIoPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<NavGraphIoMenu>()
+            .add_systems(Update, handle_nav_graph_io_events);
     }
 }
 
@@ -60,7 +70,6 @@ pub struct ViewNavGraphs<'w, 's> {
         With<NavGraphMarker>,
     >,
     icons: Res<'w, Icons>,
-    open_sites: Query<'w, 's, Entity, With<NameOfSite>>,
     current_workspace: ResMut<'w, CurrentWorkspace>,
     display_nav_graph: ResMut<'w, NavGraphDisplay>,
     delete: EventWriter<'w, Delete>,
@@ -68,7 +77,6 @@ pub struct ViewNavGraphs<'w, 's> {
     change_name: EventWriter<'w, Change<NameInSite>>,
     change_color: EventWriter<'w, Change<DisplayColor>>,
     change_rank: EventWriter<'w, ChangeRank<NavGraphMarker>>,
-    save_nav_graphs: EventWriter<'w, SaveNavGraphs>,
     selector: SelectorWidget<'w, 's>,
     commands: Commands<'w, 's>,
     app_state: Res<'w, State<AppState>>,
@@ -203,89 +211,6 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
                 MoveLayerButton::to_bottom(e, &mut self.change_rank, &self.icons).show(ui);
             });
         }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            ui.separator();
-            if ui.button("Import Graphs...").clicked() {
-                match self.current_workspace.to_site(&self.open_sites) {
-                    Some(into_site) => match &self.display_nav_graph.choosing_file_to_import {
-                        Some(_) => {
-                            warn!("A file is already being chosen!");
-                        }
-                        None => {
-                            let future = AsyncComputeTaskPool::get().spawn(async move {
-                                // TODO(luca) change this to use FileDialogServices
-                                // https://github.com/open-rmf/rmf_site/issues/248
-                                let file = match AsyncFileDialog::new().pick_file().await {
-                                    Some(file) => file,
-                                    None => return None,
-                                };
-
-                                match rmf_site_format::Site::from_bytes_ron(&file.read().await) {
-                                    Ok(from_site) => Some((
-                                        file.path().to_owned(),
-                                        ImportNavGraphs {
-                                            into_site,
-                                            from_site,
-                                        },
-                                    )),
-                                    Err(err) => {
-                                        error!("Unable to parse file:\n{err}");
-                                        None
-                                    }
-                                }
-                            });
-                            self.display_nav_graph.choosing_file_to_import = Some(future);
-                        }
-                    },
-                    None => {
-                        error!("No current site??");
-                    }
-                }
-            }
-            ui.separator();
-            ui.horizontal(|ui| {
-                if let Some(export_file) = &self.display_nav_graph.export_file {
-                    if ui.button("Export").clicked() {
-                        if let Some(current_site) = self.current_workspace.to_site(&self.open_sites)
-                        {
-                            self.save_nav_graphs.write(SaveNavGraphs {
-                                site: current_site,
-                                in_directory: export_file.clone(),
-                            });
-                        } else {
-                            error!("No current site??");
-                        }
-                    }
-                }
-                if ui.button("Export Graphs As...").clicked() {
-                    match &self.display_nav_graph.choosing_file_for_export {
-                        Some(_) => {
-                            warn!("A file is already being chosen!");
-                        }
-                        None => {
-                            let future = AsyncComputeTaskPool::get().spawn(async move {
-                                let file = match AsyncFileDialog::new().save_file().await {
-                                    Some(file) => file,
-                                    None => return None,
-                                };
-                                Some(file.path().to_path_buf())
-                            });
-                            self.display_nav_graph.choosing_file_for_export = Some(future);
-                        }
-                    }
-                }
-            });
-            if let Some(export_file) = &self.display_nav_graph.export_file {
-                if let Some(export_file) = export_file.as_os_str().to_str() {
-                    ui.horizontal(|ui| {
-                        ui.label("Chosen file:");
-                        ui.label(export_file);
-                    });
-                }
-            }
-        }
     }
 }
 
@@ -294,69 +219,72 @@ pub struct NavGraphDisplay {
     pub color: Option<[f32; 3]>,
     pub name: String,
     pub removing: bool,
-    pub choosing_file_for_export: Option<Task<Option<std::path::PathBuf>>>,
-    pub export_file: Option<std::path::PathBuf>,
-    pub choosing_file_to_import: Option<Task<Option<(std::path::PathBuf, ImportNavGraphs)>>>,
 }
 
-impl FromWorld for NavGraphDisplay {
-    fn from_world(world: &mut World) -> Self {
-        let export_file = world
-            .get_resource::<Autoload>()
-            .map(|a| a.import.clone())
-            .flatten();
+impl Default for NavGraphDisplay {
+    fn default() -> Self {
         Self {
             color: None,
             name: "<Unnamed>".to_string(),
             removing: false,
-            choosing_file_for_export: None,
-            export_file,
-            choosing_file_to_import: None,
         }
     }
 }
 
-pub fn resolve_nav_graph_import_export_files(
-    mut nav_graph_display: ResMut<NavGraphDisplay>,
-    mut save_nav_graphs: EventWriter<SaveNavGraphs>,
-    mut import_nav_graphs: EventWriter<ImportNavGraphs>,
-    open_sites: Query<Entity, With<NameOfSite>>,
-    current_workspace: Res<CurrentWorkspace>,
-) {
-    if 'resolved: {
-        if let Some(task) = &mut nav_graph_display.choosing_file_for_export {
-            if let Some(result) = future::block_on(future::poll_once(task)) {
-                if let Some(result) = result {
-                    if let Some(current_site) = current_workspace.to_site(&open_sites) {
-                        save_nav_graphs.write(SaveNavGraphs {
-                            site: current_site,
-                            in_directory: result.clone(),
-                        });
-                    }
-                    nav_graph_display.export_file = Some(result)
-                }
+#[derive(Resource)]
+pub struct NavGraphIoMenu {
+    export_nav_graph: Entity,
+    import_nav_graph: Entity,
+}
 
-                break 'resolved true;
-            }
-        }
-        false
-    } {
-        nav_graph_display.choosing_file_for_export = None;
+impl NavGraphIoMenu {
+    pub fn get_export_widget(&self) -> Entity {
+        self.export_nav_graph
     }
 
-    if 'resolved: {
-        if let Some(task) = &mut nav_graph_display.choosing_file_to_import {
-            if let Some(result) = future::block_on(future::poll_once(task)) {
-                if let Some((path, request)) = result {
-                    import_nav_graphs.write(request);
-                    nav_graph_display.export_file = Some(path);
-                }
+    pub fn get_import_widget(&self) -> Entity {
+        self.import_nav_graph
+    }
+}
 
-                break 'resolved true;
-            }
+impl FromWorld for NavGraphIoMenu {
+    fn from_world(world: &mut World) -> Self {
+        let file_header = world.resource::<FileMenu>().get();
+        let export_nav_graph = world
+            .spawn((
+                MenuItem::Text(TextMenuItem::new("Export Nav Graphs")),
+                ChildOf(file_header),
+            ))
+            .id();
+
+        let import_nav_graph = world
+            .spawn((
+                MenuItem::Text(TextMenuItem::new("Import Nav Graphs")),
+                ChildOf(file_header),
+            ))
+            .id();
+
+        NavGraphIoMenu { export_nav_graph, import_nav_graph }
+    }
+}
+
+fn handle_nav_graph_io_events(
+    mut menu_events: EventReader<MenuEvent>,
+    nav_graph_menu: Res<NavGraphIoMenu>,
+    mut saver: WorkspaceSaver,
+    mut loader: WorkspaceLoader,
+) {
+    for event in menu_events.read() {
+        if !event.clicked() {
+            continue;
         }
-        false
-    } {
-        nav_graph_display.choosing_file_to_import = None;
+
+        if event.source() == nav_graph_menu.get_export_widget() {
+            saver.export_nav_graphs_to_dialog();
+        }
+
+        if event.source() == nav_graph_menu.get_import_widget() {
+            loader.import_nav_graphs_from_dialog();
+        }
     }
 }

--- a/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -252,7 +252,7 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
                         {
                             self.save_nav_graphs.write(SaveNavGraphs {
                                 site: current_site,
-                                to_file: export_file.clone(),
+                                in_directory: export_file.clone(),
                             });
                         } else {
                             error!("No current site??");
@@ -330,7 +330,7 @@ pub fn resolve_nav_graph_import_export_files(
                     if let Some(current_site) = current_workspace.to_site(&open_sites) {
                         save_nav_graphs.write(SaveNavGraphs {
                             site: current_site,
-                            to_file: result.clone(),
+                            in_directory: result.clone(),
                         });
                     }
                     nav_graph_display.export_file = Some(result)

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -768,6 +768,12 @@ impl<'w, 's> WorkspaceSaver<'w, 's> {
             .request((), self.workspace_saving.export_nav_graphs_to_dialog)
             .detach();
     }
+
+    pub fn export_nav_graphs_to_path(&mut self, path: PathBuf) {
+        self.commands
+            .request(path, self.workspace_saving.export_nav_graphs_to_path)
+            .detach();
+    }
 }
 
 /// `SystemParam` used to request for workspace loading operations

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -338,14 +338,14 @@ impl FromWorld for WorkspaceLoadingServices {
             FileDialogFilter {
                 name: "Structured file".into(),
                 extensions: vec![
-                    ".ron".into(),
-                    ".json".into(),
-                    ".yaml".into(),
+                    "ron".into(),
+                    "json".into(),
+                    "yaml".into(),
                 ]
             },
             FileDialogFilter {
                 name: "All files".into(),
-                extensions: vec![],
+                extensions: vec!["*".into()],
             },
         ];
         // Spawn all the services

--- a/rmf_site_editor/src/workspace.rs
+++ b/rmf_site_editor/src/workspace.rs
@@ -328,12 +328,24 @@ impl FromWorld for WorkspaceLoadingServices {
             .clone();
         let loading_filters = vec![
             FileDialogFilter {
-                name: "Legacy building".into(),
-                extensions: vec!["building.yaml".into()],
+                name: "Site or Building".into(),
+                extensions: vec![
+                    "site.ron".into(),
+                    "site.json".into(),
+                    "building.yaml".into(),
+                ],
             },
             FileDialogFilter {
-                name: "Site".into(),
-                extensions: vec!["site.ron".into(), "site.json".into()],
+                name: "Structured file".into(),
+                extensions: vec![
+                    ".ron".into(),
+                    ".json".into(),
+                    ".yaml".into(),
+                ]
+            },
+            FileDialogFilter {
+                name: "All files".into(),
+                extensions: vec![],
             },
         ];
         // Spawn all the services
@@ -519,7 +531,7 @@ impl FromWorld for WorkspaceSavingServices {
         let pick_folder = world.resource::<FileDialogServices>().pick_folder.clone();
         let saving_filters = vec![FileDialogFilter {
             name: "Site".into(),
-            extensions: vec!["site.ron".into(), "site.json".into()],
+            extensions: vec!["site.json".into(), "site.ron".into()],
         }];
         // Spawn all the services
         let save_workspace_to_dialog = world.spawn_workflow(|scope, builder| {


### PR DESCRIPTION
This PR introduces a few improvements to loading files, importing, and exporting:
* The load dialog will look filter to include all `.building.yaml`, `.site.ron`, and `.site.json` by default, whereas it used to bias in favor of `.building.yaml`.
* The nav graph importing feature is now in File. The UI for this could probably be improved further, but for now at least it's reduced clutter in the Properties panel.
* There is now an option to export either/both SDF files and nav graphs in headless mode. You specify a different export path for each.