### PR TITLE
Use SDF experimental parameters to export robots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5201,7 +5201,7 @@ dependencies = [
  "urdf-rs",
  "utm",
  "uuid",
- "yaserde",
+ "yaserde 0.12.0",
 ]
 
 [[package]]
@@ -5231,7 +5231,7 @@ dependencies = [
  "thiserror 2.0.12",
  "urdf-rs",
  "uuid",
- "yaserde",
+ "yaserde 0.12.0",
 ]
 
 [[package]]
@@ -5458,13 +5458,13 @@ dependencies = [
 [[package]]
 name = "sdformat_rs"
 version = "0.1.0"
-source = "git+https://github.com/open-rmf/sdf_rust_experimental?rev=9fc35f2#9fc35f2b5f55afab37a4c1906c395fc22d069322"
+source = "git+https://github.com/open-rmf/sdf_rust_experimental?branch=luca%2Fexperimental_params_new_yaserde#0bd26acbb29f1585348ebd44e5ec4a1a56a91d31"
 dependencies = [
  "convert_case",
  "nalgebra",
+ "xml-rs",
  "xmltree",
- "yaserde",
- "yaserde_derive",
+ "yaserde 0.12.0",
 ]
 
 [[package]]
@@ -5524,6 +5524,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6223,8 +6235,8 @@ dependencies = [
  "once_cell",
  "regex",
  "thiserror 1.0.69",
- "yaserde",
- "yaserde_derive",
+ "yaserde 0.7.1",
+ "yaserde_derive 0.7.1",
 ]
 
 [[package]]
@@ -7447,6 +7459,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaserde"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bfa0d2b420fd005aa9b6f99f9584ebd964e6865d7ca787304cc1a3366c39231"
+dependencies = [
+ "log",
+ "xml-rs",
+ "yaserde_derive 0.12.0",
+]
+
+[[package]]
 name = "yaserde_derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7457,6 +7480,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "xml-rs",
+]
+
+[[package]]
+name = "yaserde_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f785831c0e09e0f1a83f917054fd59c088f6561db5b2a42c1c3e1687329325f"
+dependencies = [
+ "heck 0.5.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn 2.0.101",
  "xml-rs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ ron = "0.10"
 thiserror = "*"
 glam = { version = "0.29" }
 uuid = { version = "1.13"}
-yaserde = "0.7"
-sdformat_rs = { git = "https://github.com/open-rmf/sdf_rust_experimental", rev = "9fc35f2"}
+yaserde = "0.12"
+sdformat_rs = { git = "https://github.com/open-rmf/sdf_rust_experimental", branch = "luca/experimental_params_new_yaserde" }
 urdf-rs = { version = "0.7.3"}
 once_cell = "1"
 pathdiff = "*"

--- a/crates/rmf_site_format/src/sdf.rs
+++ b/crates/rmf_site_format/src/sdf.rs
@@ -497,8 +497,6 @@ impl Site {
                 }],
                 ..Default::default()
             });
-            // TODO(luca) We need this because there is no concept of ingestor or dispenser in
-            // rmf_site yet. Remove when there is
             for (model_instance_id, _) in &default_scenario.instances {
                 let parented_model_instance = self.model_instances.get(model_instance_id).ok_or(
                     SdfConversionError::BrokenModelInstanceReference(*model_instance_id),
@@ -513,6 +511,8 @@ impl Site {
                     )?;
 
                 let mut added = false;
+                // TODO(luca) We need this because there is no concept of ingestor or dispenser in
+                // rmf_site yet. Remove when there is
                 if model_description_bundle.source.0
                     == AssetSource::Search("OpenRobotics/TeleportIngestor".to_string())
                 {
@@ -535,10 +535,9 @@ impl Site {
                     added = true;
                 }
                 // Non static models are included separately and are not part of the static world
-                // TODO(luca) this will duplicate multiple instances of the model since it uses
-                // NameInSite instead of AssetSource for the URI, fix
                 else if !model_description_bundle.is_static.0 .0 {
                     let mut model_plugins: Vec<SdfPlugin> = Vec::new();
+                    let mut slotcar_definition = None;
                     for (label, export_data) in parented_model_instance.bundle.export_data.0.iter()
                     {
                         let mut sdf_plugin = SdfPlugin {
@@ -551,41 +550,83 @@ impl Site {
                                 sdf_plugin.elements.push(element.clone());
                             }
                         }
-                        model_plugins.push(sdf_plugin);
+                        if label == "slotcar" {
+                            slotcar_definition = Some(sdf_plugin);
+                        } else {
+                            model_plugins.push(sdf_plugin);
+                        }
                     }
-                    world.model.push(SdfModel {
-                        name: parented_model_instance.bundle.name.0.clone(),
-                        r#static: Some(model_description_bundle.is_static.0 .0),
-                        pose: Some(parented_model_instance.bundle.pose.to_sdf()),
-                        link: vec![SdfLink {
-                            name: "link".into(),
-                            collision: vec![SdfCollision {
-                                name: "collision".into(),
-                                geometry: SdfGeometry::Mesh(SdfMeshShape {
-                                    uri: format!(
-                                        "meshes/model_{}_collision.glb",
-                                        model_description_id
-                                    ),
-                                    ..Default::default()
-                                }),
-                                ..Default::default()
-                            }],
-                            visual: vec![SdfVisual {
-                                name: "visual".into(),
-                                geometry: SdfGeometry::Mesh(SdfMeshShape {
-                                    uri: format!(
-                                        "meshes/model_{}_visual.glb",
-                                        model_description_id
-                                    ),
-                                    ..Default::default()
-                                }),
-                                ..Default::default()
-                            }],
+                    // For slotcar robots we just want to include them and add experimental
+                    // params update
+                    if let Some(slotcar) = slotcar_definition {
+                        let mut replacement = SdfParams::default();
+                        let mut plugin_element = XmlElement::default();
+                        plugin_element
+                            .attributes
+                            .insert("name".into(), slotcar.name.clone());
+                        plugin_element
+                            .attributes
+                            .insert("filename".into(), slotcar.filename);
+                        plugin_element
+                            .attributes
+                            .insert("element_id".into(), slotcar.name);
+                        plugin_element
+                            .attributes
+                            .insert("action".into(), "replace".into());
+                        plugin_element.name = "plugin".into();
+                        plugin_element.data = ElementData::Nested(slotcar.elements);
+                        replacement.0.push(plugin_element);
+                        // Extract the name as the content of the asset source after the last '/'
+                        let asset_path = unsafe {
+                            model_description_bundle
+                                .source
+                                .0
+                                .as_unvalidated_asset_path()
+                        };
+                        // Unwrap safe because split will always have at least one item
+                        let model_name = asset_path.split("/").last().unwrap();
+                        world.include.push(SdfWorldInclude {
+                            uri: format!("model://{}", model_name),
+                            experimental_params: Some(replacement),
+                            name: Some(parented_model_instance.bundle.name.0.clone()),
+                            pose: Some(parented_model_instance.bundle.pose.to_sdf()),
                             ..Default::default()
-                        }],
-                        plugin: model_plugins,
-                        ..Default::default()
-                    });
+                        });
+                    } else {
+                        world.model.push(SdfModel {
+                            name: parented_model_instance.bundle.name.0.clone(),
+                            r#static: Some(model_description_bundle.is_static.0 .0),
+                            pose: Some(parented_model_instance.bundle.pose.to_sdf()),
+                            link: vec![SdfLink {
+                                name: "link".into(),
+                                collision: vec![SdfCollision {
+                                    name: "collision".into(),
+                                    geometry: SdfGeometry::Mesh(SdfMeshShape {
+                                        uri: format!(
+                                            "meshes/model_{}_collision.glb",
+                                            model_description_id
+                                        ),
+                                        ..Default::default()
+                                    }),
+                                    ..Default::default()
+                                }],
+                                visual: vec![SdfVisual {
+                                    name: "visual".into(),
+                                    geometry: SdfGeometry::Mesh(SdfMeshShape {
+                                        uri: format!(
+                                            "meshes/model_{}_visual.glb",
+                                            model_description_id
+                                        ),
+                                        ..Default::default()
+                                    }),
+                                    ..Default::default()
+                                }],
+                                ..Default::default()
+                            }],
+                            plugin: model_plugins,
+                            ..Default::default()
+                        });
+                    }
                     added = true;
                 }
                 if added {
@@ -858,15 +899,6 @@ impl Site {
                 }
             }
         }
-        // TODO(luca) these fields are set as required in the specification but seem not to be in
-        // practice (rightly so because not everyone wants to manually specify gravity, earth
-        // magnetic field and atmosphere model)
-        world.atmosphere = SdfAtmosphere {
-            r#type: "adiabatic".to_string(),
-            ..Default::default()
-        };
-        world.gravity = Vector3d::new(0.0, 0.0, -9.80);
-        world.magnetic_field = Vector3d::new(5.64e-6, 2.29e-5, -4.24e-5);
         Ok(root)
     }
 }

--- a/crates/rmf_site_format/src/templates/gz_world.sdf
+++ b/crates/rmf_site_format/src/templates/gz_world.sdf
@@ -4,6 +4,7 @@
     <physics name="10ms" type="ode">
       <max_step_size>0.01</max_step_size>
       <real_time_factor>1.0</real_time_factor>
+      <real_time_update_rate>100</real_time_update_rate>
     </physics>
     <plugin
       filename="libgz-sim-physics-system.so"
@@ -26,10 +27,18 @@
       name="lift">
     </plugin>
 
+    <!-- TODO(luca) these fields are set as required in the specification but seem not to be in
+      practice (rightly so because not everyone wants to manually specify gravity, earth
+      magnetic field and atmosphere model) -->
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>5.64e-6 2.29e-5 -4.24e-5</magnetic_field>
+    <atmosphere type="adiabatic" />
+
     <scene>
       <ambient>1 1 1</ambient>
       <background>0.8 0.8 0.8</background>
       <grid>false</grid>
+      <shadows>true</shadows>
     </scene>
 
     <gui fullscreen="0">


### PR DESCRIPTION
## Bug fix

### Fixed bug

This PR brings the "old" approach of integrating robots to the site editor of using `<include>` tags rather than building the SDF manually.
Specifically, experimental [parameter passing in SDF](http://sdformat.org/tutorials?tut=param_passing_proposal) is used to update the slotcar parameters of the robot, while the rest of the plugin is included as is.

### Fix applied

With this update, exported non-static models look the same:

```
    <model name="Coke">
      <static>false</static>
      <pose>17.70439 -5.2915354 0 0 0 1.5708001</pose>
      <link name="link">
        <collision name="collision">
          <geometry>
            <mesh>
              <uri>meshes/model_158_collision.glb</uri>
            </mesh>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <mesh>
              <uri>meshes/model_158_visual.glb</uri>
            </mesh>
          </geometry>
        </visual>
      </link>
    </model>
```

Non static models that include a slotcar plugin instead, will look like this:

```
    <include>
      <uri>model://TinyRobot</uri>
      <name>tinyRobot1</name>
      <pose>10.433054 -5.5750957 0 0 0 0</pose>
      <experimental:params>
        <plugin action="replace" element_id="slotcar" filename="libslotcar.so" name="slotcar">
          <nominal_drive_speed>0.5</nominal_drive_speed>
          <nominal_drive_acceleration>0.25</nominal_drive_acceleration>
          <nominal_turn_speed>0.6</nominal_turn_speed>
          <nominal_turn_acceleration>1.5</nominal_turn_acceleration>
          <reversible>true</reversible>
          <nominal_voltage>12</nominal_voltage>
          <nominal_capacity>24</nominal_capacity>
          <charging_current>5</charging_current>
          <mass>20</mass>
          <inertia>10</inertia>
          <friction_coefficient>0.22</friction_coefficient>
          <nominal_power>20</nominal_power>
        </plugin>
      </experimental:params>
    </include>
```

Note that to get this to work I needed to update the `yaserde` dependency on the `sdf_rust_experimental` level (the old version didn't allow for `:` in XML field names). Among other things they removed the `Default` implementation / requirement for all structs that need to be serialized or deserialized.
This will cause errors whenever models that actually don't follow the specifications are used. For example, the [Coke](https://app.gazebosim.org/OpenRobotics/fuel/models/Coke) model had  the following `model.sdf`:

```
<sdf version="1.6">
  <model name='Coke'>
    <static>true</static>
    <link name="body">
      <pose>0 0 0 0 0 0</pose>

        <visual name="visual">
          <geometry>
            <mesh><uri>model://Coke/meshes/coke.obj</uri></mesh>
          </geometry>
        </visual>

        <collision name="collision">
          <geometry>
            <mesh><uri>model://Coke/meshes/coke.obj</uri></mesh>
          </geometry>
        </collision>

        <!-- TODO: Replace with accurate values of mass and inertia -->
        <inertial>
          <mass>1.0</mass>
          <inertia>
            <ixx>0.003366666666666667</ixx>
            <iyy>0.0008666666666666667</iyy>
            <izz>0.0041666666666666675</izz>
          </inertia>
        </inertial>
    </link>
  </model>
</sdf>
```

According to the SDF specification however, [all](http://sdformat.org/spec?ver=1.6&elem=link#inertia_iyz) elements of `inertia` are required, which means this model doesn't follow the specification and will fail to be deserialized.
Previously, becase `yaserde` used `Default` behind the scenes, it would just silently fallback to the default of `0.0`, which _happens to be_ what we need.
Since the model itself doesn't follow the specification my proposal is to fix this at the asset level and add tags for the missing inertia values set to their default of `0.0`. This is the only broken model in the demo world but I can't rule out that more models will have issues.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR. 
- [x] I did not use GenAI
