### PR TITLE
Fix floor flickering when moving lifts

### DIFF
--- a/crates/rmf_site_editor/src/site/floor.rs
+++ b/crates/rmf_site_editor/src/site/floor.rs
@@ -391,15 +391,18 @@ pub fn update_floors_for_changed_lifts(
     anchors: AnchorParams,
     textures: Query<(Option<&TextureImage>, &Texture)>,
     mut mesh_assets: ResMut<Assets<Mesh>>,
-    mut mesh_handles: Query<&mut Mesh3d>,
+    mesh_handles: Query<&Mesh3d>,
 ) {
     if changed_lifts.is_empty() && removed_lifts.is_empty() {
         return;
     }
     for (e, segments, path, texture_source) in floors.iter() {
         let (_, texture) = from_texture_source(texture_source, &textures);
-        if let Ok(mut mesh) = mesh_handles.get_mut(segments.mesh) {
-            *mesh = Mesh3d(mesh_assets.add(make_floor_mesh(e, path, &texture, &anchors, &lifts)));
+        if let Ok(mesh_handle) = mesh_handles.get(segments.mesh) {
+            let Some(mesh) = mesh_assets.get_mut(&mesh_handle.0) else {
+                continue;
+            };
+            *mesh = make_floor_mesh(e, path, &texture, &anchors, &lifts);
         }
     }
 }


### PR DESCRIPTION
## Bug fix

### Fixed bug

Closes #329

### Fix applied

There is a relation between floors and lifts. When we move lifts around we automatically generate a hole in the floor to make sure there is no collision between lift cabins and floors.
This logic was not ported to the new mesh update strategy that we need for Bevy 0.16.
This PR uses the same logic, there is still a bit of flickering here and there but it's likely due to the path subtraction that can sometimes be a bit unstable, but the major flickering should be gone.