### PR TITLE
Fix floor toggle SDF plugin

### DIFF
--- a/crates/rmf_site_format/src/sdf.rs
+++ b/crates/rmf_site_format/src/sdf.rs
@@ -626,7 +626,7 @@ impl Site {
                     added = true;
                 }
                 if added {
-                    level_model_names.push(model_description_bundle.name.0.clone());
+                    level_model_names.push(parented_model_instance.bundle.name.0.clone());
                 }
             }
             // Now add all the doors


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fix https://github.com/open-rmf/rmf_site/issues/317

### Fix applied

Just use the model instance rather than the model description name. I suspect using model descriptions would also have failed as soon as duplicated models were spawned in a level.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR. 
- [x] I did not use GenAI