### PR TITLE
Remove dependency on custom bevy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,8 +517,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8369c16b7c017437021341521f8b4a0d98e1c70113fb358c3258ae7d661d79"
 dependencies = [
  "bevy_dylib",
  "bevy_internal",
@@ -571,8 +572,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_a11y"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3561712cf49074d89e9989bfc2e6c6add5d33288f689db9a0c333300d2d004"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -583,8 +585,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49796627726d0b9a722ad9a0127719e7c1868f474d6575ec0f411e8299c4d7bb"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -616,8 +619,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4491cc4c718ae76b4c6883df58b94cc88b32dcd894ea8d5b603c7c7da72ca967"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -638,8 +642,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56111d9b88d8649f331a667d9d72163fb26bd09518ca16476d238653823db1e"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -677,8 +682,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4cca3e67c0ec760d8889d42293d987ce5da92eaf9c592bf5d503728a63b276d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -688,8 +694,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b4f6f2a5c6c0e7c6825e791d2a061c76c2d6784f114c8f24382163fabbfaaa"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -705,8 +712,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.16.1"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c101cbe1e26b8d701eb77263b14346e2e0cbbd2a6e254b9b1aead814e5ca8d3"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -720,8 +728,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed46363cad80dc00f08254c3015232bd6f640738403961c6d63e7ecfc61625"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -749,8 +758,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b837bf6c51806b10ebfa9edf1844ad80a3a0760d6c5fac4e90761df91a8901a"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -759,8 +769,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48797366f312a8f31e237d08ce3ee70162591282d2bfe7c5ad8be196fb263e55"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -776,16 +787,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_dylib"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dc3602098b2604941b2829a04ac316de1e36aad949cbffce8861896b9b32532"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_ecs"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -811,8 +824,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38748d6f3339175c582d751f410fb60a93baf2286c3deb7efebb0878dce7f413"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -859,8 +873,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8148f4edee470a2ea5cad010184c492a4c94c36d7a7158ea28e134ea87f274ab"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -868,8 +883,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97efef87c631949e67d06bb5d7dfd2a5f936b3b379afb6b1485b08edbb219b87"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -884,8 +900,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7823154a9682128c261d8bddb3a4d7192a188490075c527af04520c2f0f8aad6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -908,8 +925,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f378f3b513218ddc78254bbe76536d9de59c1429ebd0c14f5d8f2a25812131ad"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -919,8 +937,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a080237c0b8842ccc15a06d3379302c68580eeea4497b1c7387e470eda1f07"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
@@ -972,8 +991,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e6e900cfecadbc3149953169e36b9e26f922ed8b002d62339d8a9dc6129328"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1036,8 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d6b6516433f6f7d680f648d04eb1866bb3927a1782d52f74831b62042f3cd1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1053,8 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2d079fda74d1416e0a57dac29ea2b79ff77f420cd6b87f833d3aa29a46bc4d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1068,8 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857da8785678fde537d02944cd20dec9cafb7d4c447efe15f898dc60e733cacd"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1110,8 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a61ee8aef17a974f5ca481dcedf0c2bd52670e231d4c4bc9ddef58328865f9"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1126,8 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052eeebcb8e7e072beea5031b227d9a290f8a7fbbb947573ab6ec81df0fb94be"
 dependencies = [
  "parking_lot",
  "proc-macro2",
@@ -1138,8 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68553e0090fe9c3ba066c65629f636bd58e4ebd9444fdba097b91af6cd3e243f"
 dependencies = [
  "approx",
  "bevy_reflect",
@@ -1157,8 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mesh"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10399c7027001edbc0406d7d0198596b1f07206c1aae715274106ba5bdcac40"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1181,8 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb60c753b968a2de0fd279b76a3d19517695e771edb4c23575c7f92156315de"
 dependencies = [
  "glam",
 ]
@@ -1216,8 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_pbr"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e0b4eb871f364a0d217f70f6c41d7fdc6f9f931fa1abbf222180c03d0ae410"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1249,8 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_picking"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed04757938655ed8094ea1efb533f99063a8b22abffc22010c694d291522850"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1273,8 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7573dc824a1b08b4c93fdbe421c53e1e8188e9ca1dd74a414455fe571facb47"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1290,13 +1321,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeb91a63a1a4df00aa58da8cc4ddbd4b9f16ab8bb647c5553eb156ce36fa8c2"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1321,8 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ddadc55fe16b45faaa54ab2f9cb00548013c74812e8b018aa172387103cce6"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1333,8 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef91fed1f09405769214b99ebe4390d69c1af5cdd27967deae9135c550eb1667"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1384,8 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd42cf6c875bcf38da859f8e731e119a6aff190d41dd0a1b6000ad57cf2ed3d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1395,8 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c52ca165200995fe8afd2a1a6c03e4ffee49198a1d4653d32240ea7f217d4ab"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1415,8 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ccae7bab2cb956fb0434004c359e432a3a1a074a6ef4eb471f1fb099f0b620b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1444,8 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155d3cd97b900539008cdcaa702f88b724d94b08977b8e591a32536ce66faa8c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1459,8 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2481c1304fd2a1851a0d4cb63a1ce6421ae40f3f0117cbc9882963ee4c9bb609"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1481,8 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b674242641cab680688fc3b850243b351c1af49d4f3417a576debd6cca8dcf5"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1502,8 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d76c85366159f5f54110f33321c76d8429cfd8f39638f26793a305dae568b60"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1531,8 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc98eb356c75be04fbbc77bb3d8ffa24c8bacd99f76111cee23d444be6ac8c9c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1545,8 +1588,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df218e440bb9a19058e1b80a68a031c887bcf7bd3a145b55f361359a2fa3100d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1562,8 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4a4d2ba51865bc3039af29a26b4f52c48b54cc758369f52004caf4b6f03770"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1596,8 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f7a8905a125d2017e8561beefb7f2f5e67e93ff6324f072ad87c5fd6ec3b99"
 dependencies = [
  "bevy_platform",
  "thread_local",
@@ -1605,8 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7e8ad0c17c3cc23ff5566ae2905c255e6986037fb041f74c446216f5c38431"
 dependencies = [
  "android-activity",
  "bevy_app",
@@ -1624,8 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5e7f00c6b3b6823df5ec2a5e9067273607208919bc8c211773ebb9643c87f0"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -8223,13 +8271,3 @@ checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
 dependencies = [
  "zune-core",
 ]
-
-[[patch.unused]]
-name = "bevy_dev_tools"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"
-
-[[patch.unused]]
-name = "bevy_remote"
-version = "0.16.0"
-source = "git+https://github.com/xiyuoh/bevy?branch=fix-specialize-panic#490b43eaaf2b5a57a194a2a2c4718a007a8a6593"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,93 +74,47 @@ bytemuck = {version = "1.22"}
 testdir = "*"
 file_diff = "*"
 
-bevy = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_a11y = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_animation = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_app = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_asset = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_audio = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_color = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_core_pipeline = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_derive = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_dev_tools = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_diagnostic = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_dylib = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_ecs = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_encase_derive = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_gilrs = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_gizmos = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_gltf = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_image = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_input = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_input_focus = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_internal = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_log = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_macro_utils = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_math = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_mesh = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_mikktspace = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_pbr = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_picking = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_platform = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_ptr = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_reflect = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_remote = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_render = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_scene = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_sprite = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_state = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_tasks = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_text = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_time = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_transform = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_ui = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_utils = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_window = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_winit = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-
-[patch.crates-io]
-bevy = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_a11y = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_animation = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_app = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_asset = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_audio = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_color = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_core_pipeline = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_derive = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_dev_tools = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_diagnostic = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_dylib = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_ecs = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_encase_derive = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_gilrs = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_gizmos = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_gltf = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_image = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_input = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_input_focus = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_internal = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_log = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_macro_utils = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_math = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_mesh = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_mikktspace = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_pbr = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_picking = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_platform = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_ptr = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_reflect = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_remote = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_render = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_scene = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_sprite = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_state = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_tasks = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_text = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_time = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_transform = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_ui = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_utils = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_window = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
-bevy_winit = { git = "https://github.com/xiyuoh/bevy", branch = "fix-specialize-panic" }
+bevy = "0.16"
+bevy_a11y = "0.16"
+bevy_animation = "0.16"
+bevy_app = "0.16"
+bevy_asset = "0.16"
+bevy_audio = "0.16"
+bevy_color = "0.16"
+bevy_core_pipeline = "0.16"
+bevy_derive = "0.16"
+bevy_dev_tools = "0.16"
+bevy_diagnostic = "0.16"
+bevy_dylib = "0.16"
+bevy_ecs = "0.16"
+bevy_encase_derive = "0.16"
+bevy_gilrs = "0.16"
+bevy_gizmos = "0.16"
+bevy_gltf = "0.16"
+bevy_image = "0.16"
+bevy_input = "0.16"
+bevy_input_focus = "0.16"
+bevy_internal = "0.16"
+bevy_log = "0.16"
+bevy_macro_utils = "0.16"
+bevy_math = "0.16"
+bevy_mesh = "0.16"
+bevy_mikktspace = "0.16"
+bevy_pbr = "0.16"
+bevy_picking = "0.16"
+bevy_platform = "0.16"
+bevy_ptr = "0.16"
+bevy_reflect = "0.16"
+bevy_remote = "0.16"
+bevy_render = "0.16"
+bevy_scene = "0.16"
+bevy_sprite = "0.16"
+bevy_state = "0.16"
+bevy_tasks = "0.16"
+bevy_text = "0.16"
+bevy_time = "0.16"
+bevy_transform = "0.16"
+bevy_ui = "0.16"
+bevy_utils = "0.16"
+bevy_window = "0.16"
+bevy_winit = "0.16"

--- a/crates/rmf_site_editor/src/site/mod.rs
+++ b/crates/rmf_site_editor/src/site/mod.rs
@@ -200,6 +200,9 @@ impl Plugin for SitePlugin {
                 SiteUpdateSet::BetweenTransformAndVisibility,
                 SiteUpdateSet::BetweenTransformAndVisibilityFlush,
                 VisibilitySystems::VisibilityPropagate,
+                // TODO(luca) remove this when https://github.com/bevyengine/bevy/pull/19064 (or
+                // alternative fix) is merged and released
+                bevy::asset::AssetEvents,
             )
                 .chain(),
         )


### PR DESCRIPTION
It's been too long, the [upstream PR that we need](https://github.com/bevyengine/bevy/pull/19064) seems to be semi-abandoned, this workaround also forces downstream users to rely on the same custom bevy version.

Just add a workaround in the code instead. Specifically, the "guilty" bevy system is scheduled to run [after](https://github.com/bevyengine/bevy/pull/19064/files#diff-5db119571c62eac9218400a8191eee2417503cd13d3921cd711e5a7fecf8f936L291) `AssetEvents`, if we schedule all our systems to run _before_ `AssetEvents`, we should be able to get all our changes in. Furthermore, because of the automatically inserted command flush, all entities should be spawned before the system that used to panic is run.

### Test it!

I only tested it with lane spawning that seems to be fine, if you comment the only change in the code you should see that it crashes on lane spawning without it and it works fine with.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI