### PR TITLE
Add lane arrow shader for overlapping arrows

### DIFF
--- a/crates/rmf_site_editor/src/site/assets.rs
+++ b/crates/rmf_site_editor/src/site/assets.rs
@@ -19,14 +19,48 @@ use crate::site::*;
 use bevy::{
     asset::embedded_asset,
     math::{primitives, Affine3A},
+    pbr::MaterialExtension,
     prelude::*,
+    render::render_resource::{AsBindGroup, ShaderRef},
 };
 use rmf_site_mesh::*;
 
-pub(crate) fn add_site_icons(app: &mut App) {
+const LANE_SHADER_PATH: &str = "embedded://librmf_site_editor/site/shaders/lane_arrow_shader.wgsl";
+
+pub(crate) fn add_site_assets(app: &mut App) {
     embedded_asset!(app, "src/", "icons/battery.png");
     embedded_asset!(app, "src/", "icons/parking.png");
     embedded_asset!(app, "src/", "icons/stopwatch.png");
+
+    embedded_asset!(app, "src/", "shaders/lane_arrow_shader.wgsl");
+}
+
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone, Component)]
+pub struct LaneArrowMaterial {
+    #[uniform(100)]
+    pub single_arrow_color: LinearRgba,
+    #[uniform(101)]
+    pub double_arrow_color: LinearRgba,
+    #[uniform(102)]
+    pub background_color: LinearRgba,
+    #[uniform(103)]
+    pub number_of_arrows: f32,
+    #[uniform(104)]
+    pub forward_speed: f32,
+    #[uniform(105)]
+    pub backward_speed: f32,
+    #[uniform(106)]
+    pub bidirectional: u32,
+}
+
+impl MaterialExtension for LaneArrowMaterial {
+    fn fragment_shader() -> ShaderRef {
+        LANE_SHADER_PATH.into()
+    }
+
+    fn deferred_fragment_shader() -> ShaderRef {
+        LANE_SHADER_PATH.into()
+    }
 }
 
 #[derive(Resource)]

--- a/crates/rmf_site_editor/src/site/mod.rs
+++ b/crates/rmf_site_editor/src/site/mod.rs
@@ -152,7 +152,10 @@ use crate::recency::{RecencyRank, RecencyRankingPlugin};
 use crate::{AppState, RegisterIssueType};
 pub use rmf_site_format::{DirectionalLight, PointLight, SpotLight, Style, *};
 
-use bevy::{prelude::*, render::view::visibility::VisibilitySystems, transform::TransformSystem};
+use bevy::{
+    pbr::ExtendedMaterial, prelude::*, render::view::visibility::VisibilitySystems,
+    transform::TransformSystem,
+};
 
 use bevy_infinite_grid::*;
 
@@ -184,7 +187,7 @@ pub struct SitePlugin;
 
 impl Plugin for SitePlugin {
     fn build(&self, app: &mut App) {
-        add_site_icons(app);
+        add_site_assets(app);
         app.configure_sets(
             PreUpdate,
             (
@@ -300,6 +303,7 @@ impl Plugin for SitePlugin {
             PropertyPlugin::<TaskParams, Task>::default(),
             PropertyPlugin::<OnLevel<Entity>, Robot>::default(),
             SlotcarSdfPlugin,
+            MaterialPlugin::<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>::default(),
         ))
         .add_plugins((InfiniteGridPlugin,))
         .add_issue_type(&DUPLICATED_DOOR_NAME_ISSUE_UUID, "Duplicate door name")
@@ -449,6 +453,7 @@ impl Plugin for SitePlugin {
                 check_selected_is_included,
                 check_for_missing_root_modifiers::<InstanceMarker>,
                 update_default_scenario,
+                update_lane_motion_visuals,
             )
                 .run_if(AppState::in_displaying_mode())
                 .in_set(SiteUpdateSet::BetweenTransformAndVisibility),

--- a/crates/rmf_site_editor/src/site/shaders/lane_arrow_shader.wgsl
+++ b/crates/rmf_site_editor/src/site/shaders/lane_arrow_shader.wgsl
@@ -1,0 +1,149 @@
+#import bevy_pbr::{
+    mesh_view_bindings::globals,
+    pbr_fragment::pbr_input_from_standard_material,
+    pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
+    forward_io::{VertexOutput, FragmentOutput},
+}
+
+@group(2) @binding(100)
+var<uniform> single_arrow_base_color: vec4<f32>;
+@group(2) @binding(101)
+var<uniform> double_arrow_base_color: vec4<f32>;
+@group(2) @binding(102)
+var<uniform> background_base_color: vec4<f32>;
+@group(2) @binding(103)
+var<uniform> number_of_tiles: f32;
+@group(2) @binding(104)
+var<uniform> forward_speed: f32;
+@group(2) @binding(105)
+var<uniform> backward_speed: f32;
+@group(2) @binding(106)
+var<uniform> bidirectional: u32;
+
+@fragment
+fn fragment(
+    in: VertexOutput,
+    @builtin(front_facing) is_front: bool,
+) -> FragmentOutput{
+    let is_bidirectional = (bidirectional == 1);
+
+    let single_arrow_color = single_arrow_base_color.rgb;
+    let double_arrow_color = double_arrow_base_color.rgb;
+    let background_color = background_base_color.rgb;
+    
+    var is_forward = false;
+    var is_backward = false;
+
+    let side_margin = 0.1;
+    let tile_length = 1.0 / number_of_tiles;
+    let thickness = 0.2 / number_of_tiles;
+
+    if in.uv.y > side_margin
+        && in.uv.y < (1.0 - side_margin)
+        && in.uv.x >= tile_length * 0.5
+        && in.uv.x <= (1.0 - tile_length * 0.5)
+    {
+        let forward_progress = fract(globals.time * forward_speed * 0.5);
+        is_forward = check_forward_pixel(
+            in.uv.x,
+            in.uv.y,
+            forward_progress,
+            thickness,
+            number_of_tiles,
+            tile_length,
+        );
+
+        if is_bidirectional & !is_forward {
+            let backward_progress = fract(globals.time * backward_speed * 0.5);
+            is_backward = check_backward_pixel(
+                in.uv.x,
+                in.uv.y,
+                backward_progress,
+                thickness,
+                number_of_tiles,
+                tile_length,
+            );
+        }
+    }
+
+    let is_arrow_pixel = is_forward || is_backward;
+    let final_arrow_color = select(single_arrow_color, double_arrow_color, is_backward);
+    let final_pixel_color = select(background_color, final_arrow_color, is_arrow_pixel);
+
+    var pbr_input = pbr_input_from_standard_material(in, true);
+    pbr_input.material.base_color = vec4<f32>(final_pixel_color, 1.0);
+
+    var out: FragmentOutput;
+    out.color = apply_pbr_lighting(pbr_input);
+    out.color = main_pass_post_lighting_processing(pbr_input, out.color);
+    return out;
+}
+
+fn check_forward_pixel (
+    x: f32,
+    y: f32,
+    progress: f32,
+    thickness: f32,
+    number_of_tiles: f32,
+    tile_length: f32,
+) -> bool {
+    var x_top = 0.5 - abs(y - 0.5) + progress;
+    var overlap_x_top = 0.0;
+    var overlap = false;
+
+    if x_top > 1.0 {
+        overlap = true;
+        overlap_x_top = x_top;
+        x_top -= 1.0;
+    }
+
+    x_top /= number_of_tiles;
+    overlap_x_top /= number_of_tiles;
+
+    for (var i = 0.0; i < number_of_tiles; i += 1.0) {
+        let x_top_tile = (tile_length * i) + x_top;
+        let overlap_x_top_tile = (tile_length * i) + overlap_x_top;
+
+
+        if (x <= x_top_tile && x >= (x_top_tile - thickness))
+            || (overlap && x <= overlap_x_top_tile && x >= (overlap_x_top_tile - thickness))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn check_backward_pixel (
+    x: f32,
+    y: f32,
+    progress: f32,
+    thickness: f32,
+    number_of_tiles: f32,
+    tile_length: f32,
+) -> bool {
+    var x_top = 0.5 + abs(y - 0.5) - progress;
+    var overlap_x_top = 1.0;
+    var overlap = false;
+
+    if x_top < 0.0 {
+        overlap = true;
+        overlap_x_top = x_top;
+        x_top += 1.0;
+    }
+    
+    x_top /= number_of_tiles;
+    overlap_x_top /= number_of_tiles;
+
+    for (var i = 0.0; i < number_of_tiles; i += 1.0) {
+        let x_top_tile = (tile_length * i) + x_top;
+        let overlap_x_top_tile = (tile_length * i) + overlap_x_top;
+
+        if (x >= x_top_tile && x <= (x_top_tile + thickness))
+            || (overlap && x >= overlap_x_top_tile && x <= (overlap_x_top_tile + thickness))
+        {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
This PR aims to add a lane arrow shader for better visualisation of lane directions. The direction and speed of the arrows should reflect the speed limit and Reverse Motion options that the user selects in the Inspector.

The shader shows overlapping arrows in different directions as per below. This PR is to be compared with another [PR #371](https://github.com/open-rmf/rmf_site/pull/371) which show the arrows in adjacent lanes instead. The implementation for the lane shader in both PRs are the same, the only difference is the shader file code, and the color of the arrows moving in the reverse direction.

https://github.com/user-attachments/assets/b2bd4c0d-9b48-488d-ad7e-fb2b99da6dd4

Some points noted:
- There weren't any shaders in the site editor that I could refer to, please let me know if the way I imported it is alright!
- The bidirectional boolean value has to be passed into the shader as a u32 as WGSL cannot take in bool values.
- When instantiating new lane visuals under add_lane_visuals, the choice has been made to directly instantiate a new ExtendedMaterial, instead of cloning from the Assets. 

```
        let mid = commands
            .spawn((
                Mesh3d(assets.lane_mid_mesh.clone()),
                MeshMaterial3d(extended_materials.add(ExtendedMaterial {
                    base: StandardMaterial {
                        depth_bias: 3.0,
                        ..default()
                    },
                    extension: assets::LaneArrowMaterial {
                        single_arrow_color: LANE_SINGLE_ARROW_COLOR.into(),
                        double_arrow_color: LANE_DOUBLE_ARROW_COLOR.into(),
                        background_color: LANE_BASE_COLOR.into(),
                        number_of_arrows: (start_anchor - end_anchor).length() / LANE_WIDTH,
                        forward_speed: forward_speed_limit,
                        backward_speed: backward_speed_limit,
                        bidirectional: is_bidirectional as u32,
                    },
                })),
                ...
```

As each lane material has its own unique values (e.g. forward_speed, bidirectional), doing the alternative and cloning the ExtendedMaterial from Assets, would result in the code looking like this:

```
        let lane_arrow_handle = assets.lane_arrow_material.clone();
        let Some(material) = extended_materials.get_mut(&lane_arrow_handle) else {
            return;
        };
        let mut material_instance = material.clone();

        material_instance.extension.number_of_arrows = (start_anchor - end_anchor).length() / LANE_WIDTH;
        material_instance.extension.forward_speed = forward_speed_limit;
        material_instance.extension.backward_speed = backward_speed_limit;
        material_instance.extension.bidirectional = is_bidirectional as u32;

        let mid = commands
            .spawn((
                Mesh3d(assets.lane_mid_mesh.clone()),
                MeshMaterial3d(extended_materials.add(material_instance)),
                ...
```

This involves 2 cloning operations, then adding the new material instance to extended_materials again. From my understanding, this seems to be more inefficient than directly instantiating a new ExtendedMaterial as per above. However, if this method is preferred, I can change it to this instead.