### PR TITLE
Add lane arrow shader for adjacent arrows

### DIFF
--- a/crates/rmf_site_editor/src/site/assets.rs
+++ b/crates/rmf_site_editor/src/site/assets.rs
@@ -19,14 +19,48 @@ use crate::site::*;
 use bevy::{
     asset::embedded_asset,
     math::{primitives, Affine3A},
+    pbr::MaterialExtension,
     prelude::*,
+    render::render_resource::{AsBindGroup, ShaderRef},
 };
 use rmf_site_mesh::*;
 
-pub(crate) fn add_site_icons(app: &mut App) {
+const LANE_SHADER_PATH: &str = "embedded://librmf_site_editor/site/shaders/lane_arrow_shader.wgsl";
+
+pub(crate) fn add_site_assets(app: &mut App) {
     embedded_asset!(app, "src/", "icons/battery.png");
     embedded_asset!(app, "src/", "icons/parking.png");
     embedded_asset!(app, "src/", "icons/stopwatch.png");
+
+    embedded_asset!(app, "src/", "shaders/lane_arrow_shader.wgsl");
+}
+
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone, Component)]
+pub struct LaneArrowMaterial {
+    #[uniform(100)]
+    pub single_arrow_color: LinearRgba,
+    #[uniform(101)]
+    pub double_arrow_color: LinearRgba,
+    #[uniform(102)]
+    pub background_color: LinearRgba,
+    #[uniform(103)]
+    pub number_of_arrows: f32,
+    #[uniform(104)]
+    pub forward_speed: f32,
+    #[uniform(105)]
+    pub backward_speed: f32,
+    #[uniform(106)]
+    pub bidirectional: u32,
+}
+
+impl MaterialExtension for LaneArrowMaterial {
+    fn fragment_shader() -> ShaderRef {
+        LANE_SHADER_PATH.into()
+    }
+
+    fn deferred_fragment_shader() -> ShaderRef {
+        LANE_SHADER_PATH.into()
+    }
 }
 
 #[derive(Resource)]

--- a/crates/rmf_site_editor/src/site/lane.rs
+++ b/crates/rmf_site_editor/src/site/lane.rs
@@ -18,6 +18,7 @@
 use crate::site::*;
 use crate::{CurrentWorkspace, Issue, ValidateWorkspace};
 use bevy::ecs::{hierarchy::ChildOf, relationship::AncestorIter};
+use bevy::pbr::ExtendedMaterial;
 use bevy::prelude::*;
 use rmf_site_format::{Edge, LaneMarker};
 use std::collections::{BTreeSet, HashMap};
@@ -27,6 +28,9 @@ pub const SELECTED_LANE_OFFSET: f32 = 0.001;
 pub const HOVERED_LANE_OFFSET: f32 = 0.002;
 pub const LANE_LAYER_START: f32 = FLOOR_LAYER_START + 0.001;
 pub const LANE_LAYER_LIMIT: f32 = LANE_LAYER_START + SELECTED_LANE_OFFSET;
+const LANE_BASE_COLOR: Color = Color::srgb(1.0, 0.5, 0.3);
+const LANE_SINGLE_ARROW_COLOR: Color = Color::srgb(0.83, 0.33, 0.09);
+const LANE_DOUBLE_ARROW_COLOR: Color = Color::srgb(1.0, 0.70, 0.48);
 
 // TODO(MXG): Make this configurable, perhaps even a field in the Lane data
 // so users can customize the lane width per lane.
@@ -88,7 +92,17 @@ pub fn assign_orphan_nav_elements_to_site(
 
 pub fn add_lane_visuals(
     mut commands: Commands,
-    lanes: Query<(Entity, &Edge<Entity>, &AssociatedGraphs<Entity>), Added<LaneMarker>>,
+    lanes: Query<
+        (
+            Entity,
+            &Motion,
+            &ReverseLane,
+            Option<&RecallMotion>,
+            &Edge<Entity>,
+            &AssociatedGraphs<Entity>,
+        ),
+        Added<LaneMarker>,
+    >,
     graphs: GraphSelect,
     anchors: AnchorParams,
     child_of: Query<&ChildOf>,
@@ -96,8 +110,9 @@ pub fn add_lane_visuals(
     mut dependents: Query<&mut Dependents, With<Anchor>>,
     assets: Res<SiteAssets>,
     current_level: Res<CurrentLevel>,
+    mut extended_materials: ResMut<Assets<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
 ) {
-    for (e, edge, associated_graphs) in &lanes {
+    for (e, motion, reverse, recall, edge, associated_graphs) in &lanes {
         for anchor in &edge.array() {
             if let Ok(mut deps) = dependents.get_mut(*anchor) {
                 deps.insert(e);
@@ -162,17 +177,54 @@ pub fn add_lane_visuals(
             assets.lane_end_outline.clone(),
         );
 
-        let (mid, mid_outline) = spawn_lane_mesh_and_outline(
-            line_stroke_transform(&start_anchor, &end_anchor, LANE_WIDTH),
-            assets.lane_mid_mesh.clone(),
-            assets.lane_mid_outline.clone(),
-        );
-
         let (end, end_outline) = spawn_lane_mesh_and_outline(
             Transform::from_translation(end_anchor),
             assets.lane_end_mesh.clone(),
             assets.lane_end_outline.clone(),
         );
+
+        let is_bidirectional = *reverse != ReverseLane::Disable;
+        let forward_speed_limit = motion.speed_limit.unwrap_or(1.0);
+        let backward_speed_limit = match reverse {
+            ReverseLane::Same => forward_speed_limit,
+            _ => recall
+                .map(|rec: &RecallMotion| rec.speed_limit.unwrap_or(1.0))
+                .unwrap_or(1.0),
+        };
+
+        let mid = commands
+            .spawn((
+                Mesh3d(assets.lane_mid_mesh.clone()),
+                MeshMaterial3d(extended_materials.add(ExtendedMaterial {
+                    base: StandardMaterial {
+                        depth_bias: 3.0,
+                        ..default()
+                    },
+                    extension: assets::LaneArrowMaterial {
+                        single_arrow_color: LANE_SINGLE_ARROW_COLOR.into(),
+                        double_arrow_color: LANE_DOUBLE_ARROW_COLOR.into(),
+                        background_color: LANE_BASE_COLOR.into(),
+                        number_of_arrows: (start_anchor - end_anchor).length() / LANE_WIDTH,
+                        forward_speed: forward_speed_limit,
+                        backward_speed: backward_speed_limit,
+                        bidirectional: is_bidirectional as u32,
+                    },
+                })),
+                line_stroke_transform(&start_anchor, &end_anchor, LANE_WIDTH),
+                Visibility::default(),
+            ))
+            .insert(ChildOf(layer))
+            .id();
+
+        let mid_outline: Entity = commands
+            .spawn((
+                Mesh3d(assets.lane_mid_outline.clone()),
+                MeshMaterial3d::<StandardMaterial>::default(),
+                Transform::from_translation(-0.000_5 * Vec3::Z),
+                Visibility::Hidden,
+            ))
+            .insert(ChildOf(mid))
+            .id();
 
         commands
             .entity(e)
@@ -198,6 +250,8 @@ fn update_lane_visuals(
     segments: &LaneSegments,
     anchors: &AnchorParams,
     transforms: &mut Query<&mut Transform>,
+    lane_materials: Query<&MeshMaterial3d<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
+    extended_materials: &mut ResMut<Assets<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
 ) {
     let start_anchor = anchors
         .point_in_parent_frame_of(edge.left(), Category::Lane, entity)
@@ -211,9 +265,55 @@ fn update_lane_visuals(
     }
     if let Some(mut tf) = transforms.get_mut(segments.mid).ok() {
         *tf = line_stroke_transform(&start_anchor, &end_anchor, LANE_WIDTH);
+
+        if let Ok(mat) = lane_materials.get(segments.mid) {
+            if let Some(lane_mat) = extended_materials.get_mut(&mat.0) {
+                lane_mat.extension.number_of_arrows =
+                    (start_anchor - end_anchor).length() / LANE_WIDTH;
+            }
+        }
     }
     if let Some(mut tf) = transforms.get_mut(segments.end).ok() {
         *tf = Transform::from_translation(end_anchor);
+    }
+}
+
+pub fn update_lane_motion_visuals(
+    mut lanes: Query<
+        (
+            &LaneSegments,
+            &Motion,
+            &ReverseLane,
+            Option<&RecallReverseLane>,
+        ),
+        Or<(Changed<Motion>, Changed<ReverseLane>, Changed<RecallMotion>)>,
+    >,
+    mut lane_materials: Query<
+        &MeshMaterial3d<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>,
+    >,
+    mut extended_materials: ResMut<Assets<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
+) {
+    if lane_materials.is_empty() {
+        return;
+    }
+
+    for (segments, motion, reverse, recall) in &mut lanes {
+        if let Some(mat) = lane_materials.get_mut(segments.mid).ok() {
+            if let Some(lane_mat) = extended_materials.get_mut(&mat.0) {
+                let is_bidirectional = *reverse != ReverseLane::Disable;
+                let forward_speed_limit = motion.speed_limit.unwrap_or(1.0);
+                let backward_speed_limit = match reverse {
+                    ReverseLane::Same => forward_speed_limit,
+                    _ => recall
+                        .and_then(|rec| rec.previous.speed_limit)
+                        .unwrap_or(1.0),
+                };
+
+                lane_mat.extension.forward_speed = forward_speed_limit;
+                lane_mat.extension.backward_speed = backward_speed_limit;
+                lane_mat.extension.bidirectional = is_bidirectional as u32;
+            }
+        }
     }
 }
 
@@ -233,10 +333,20 @@ pub fn update_changed_lane(
     levels: Query<(), With<LevelElevation>>,
     graphs: GraphSelect,
     mut transforms: Query<&mut Transform>,
+    lane_materials: Query<&MeshMaterial3d<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
+    mut extended_materials: ResMut<Assets<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
     current_level: Res<CurrentLevel>,
 ) {
     for (e, edge, associated, segments, mut visibility) in &mut lanes {
-        update_lane_visuals(e, edge, segments, &anchors, &mut transforms);
+        update_lane_visuals(
+            e,
+            edge,
+            segments,
+            &anchors,
+            &mut transforms,
+            lane_materials,
+            &mut extended_materials,
+        );
 
         let new_visibility = if should_display_lane(
             edge,
@@ -267,11 +377,21 @@ pub fn update_lane_for_moved_anchor(
         ),
     >,
     mut transforms: Query<&mut Transform>,
+    lane_materials: Query<&MeshMaterial3d<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
+    mut extended_materials: ResMut<Assets<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>>,
 ) {
     for dependents in &changed_anchors {
         for dependent in dependents.iter() {
             if let Ok((e, edge, segments)) = lanes.get(*dependent) {
-                update_lane_visuals(e, edge, segments, &anchors, &mut transforms);
+                update_lane_visuals(
+                    e,
+                    edge,
+                    segments,
+                    &anchors,
+                    &mut transforms,
+                    lane_materials,
+                    &mut extended_materials,
+                );
             }
         }
     }

--- a/crates/rmf_site_editor/src/site/mod.rs
+++ b/crates/rmf_site_editor/src/site/mod.rs
@@ -152,7 +152,10 @@ use crate::recency::{RecencyRank, RecencyRankingPlugin};
 use crate::{AppState, RegisterIssueType};
 pub use rmf_site_format::{DirectionalLight, PointLight, SpotLight, Style, *};
 
-use bevy::{prelude::*, render::view::visibility::VisibilitySystems, transform::TransformSystem};
+use bevy::{
+    pbr::ExtendedMaterial, prelude::*, render::view::visibility::VisibilitySystems,
+    transform::TransformSystem,
+};
 
 use bevy_infinite_grid::*;
 
@@ -184,7 +187,7 @@ pub struct SitePlugin;
 
 impl Plugin for SitePlugin {
     fn build(&self, app: &mut App) {
-        add_site_icons(app);
+        add_site_assets(app);
         app.configure_sets(
             PreUpdate,
             (
@@ -300,6 +303,7 @@ impl Plugin for SitePlugin {
             PropertyPlugin::<TaskParams, Task>::default(),
             PropertyPlugin::<OnLevel<Entity>, Robot>::default(),
             SlotcarSdfPlugin,
+            MaterialPlugin::<ExtendedMaterial<StandardMaterial, LaneArrowMaterial>>::default(),
         ))
         .add_plugins((InfiniteGridPlugin,))
         .add_issue_type(&DUPLICATED_DOOR_NAME_ISSUE_UUID, "Duplicate door name")
@@ -449,6 +453,7 @@ impl Plugin for SitePlugin {
                 check_selected_is_included,
                 check_for_missing_root_modifiers::<InstanceMarker>,
                 update_default_scenario,
+                update_lane_motion_visuals,
             )
                 .run_if(AppState::in_displaying_mode())
                 .in_set(SiteUpdateSet::BetweenTransformAndVisibility),

--- a/crates/rmf_site_editor/src/site/shaders/lane_arrow_shader.wgsl
+++ b/crates/rmf_site_editor/src/site/shaders/lane_arrow_shader.wgsl
@@ -1,0 +1,151 @@
+#import bevy_pbr::{
+    mesh_view_bindings::globals,
+    pbr_fragment::pbr_input_from_standard_material,
+    pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
+    forward_io::{VertexOutput, FragmentOutput},
+}
+
+@group(2) @binding(100)
+var<uniform> single_arrow_base_color: vec4<f32>;
+@group(2) @binding(101)
+var<uniform> double_arrow_base_color: vec4<f32>;
+@group(2) @binding(102)
+var<uniform> background_base_color: vec4<f32>;
+@group(2) @binding(103)
+var<uniform> number_of_tiles: f32;
+@group(2) @binding(104)
+var<uniform> forward_speed: f32;
+@group(2) @binding(105)
+var<uniform> backward_speed: f32;
+@group(2) @binding(106)
+var<uniform> bidirectional: u32;
+
+@fragment
+fn fragment(
+    in: VertexOutput,
+    @builtin(front_facing) is_front: bool,
+) -> FragmentOutput{
+    let is_bidirectional = (bidirectional == 1);
+
+    let single_arrow_color = single_arrow_base_color.rgb;
+    let double_arrow_color = double_arrow_base_color.rgb;
+    let background_color = background_base_color.rgb;
+
+    var is_forward = false;
+    var is_backward = false;
+
+    let side_margin = 0.1;
+    let end_margin = 1.0 / number_of_tiles;
+    var thickness = 0.2 / number_of_tiles;
+
+    if in.uv.y > side_margin
+        && in.uv.y < (1.0 - side_margin)
+        && in.uv.x > end_margin * 0.5
+        && in.uv.x < (1.0 - end_margin * 0.5)
+    {
+        let forward_progress = fract(globals.time * forward_speed * 0.5);
+
+        if !is_bidirectional {
+            let x_top = 0.5 - abs(in.uv.y - 0.5) + forward_progress;
+
+            is_forward = check_forward_pixel(in.uv.x, x_top, thickness, number_of_tiles);
+        } else {
+            var thickness = thickness * 0.75;
+            var number_of_tiles = number_of_tiles * 1.5;
+            
+            if in.uv.y < 0.5 - (side_margin * 0.25) {
+                let y_val = in.uv.y - side_margin * 0.25;
+                let x_top = 0.25 - abs(y_val - 0.25) + forward_progress;
+
+                is_forward = check_forward_pixel(in.uv.x, x_top, thickness, number_of_tiles);
+            } else if in.uv.y > 0.5 + (side_margin * 0.25) {
+                let backward_progress = fract(globals.time * backward_speed * 0.5);
+
+                let y_val = in.uv.y - 0.5 + side_margin * 0.25;
+                let x_top = 0.25 + abs(y_val - 0.25) - backward_progress;
+
+                is_backward = check_backward_pixel(in.uv.x, x_top, thickness, number_of_tiles);
+            }
+        }
+    }
+
+    let is_arrow_pixel = is_forward || is_backward;
+    let final_arrow_color = select(single_arrow_color, double_arrow_color, is_backward);
+    let final_pixel_color = select(background_color, final_arrow_color, is_arrow_pixel);
+
+    var pbr_input = pbr_input_from_standard_material(in, true);
+    pbr_input.material.base_color = vec4<f32>(final_pixel_color, 1.0);
+
+    var out: FragmentOutput;
+    out.color = apply_pbr_lighting(pbr_input);
+    out.color = main_pass_post_lighting_processing(pbr_input, out.color);
+    return out;
+}
+
+fn check_forward_pixel (
+    x: f32,
+    x_position: f32,
+    thickness: f32,
+    number_of_tiles: f32,
+) -> bool {
+    var x_top = x_position;
+
+    var overlap_x_top = 0.0;
+    var overlap = false;
+
+    if x_top > 1.0 {
+        overlap = true;
+        overlap_x_top = x_top;
+        x_top -= 1.0;
+    }
+
+    x_top /= number_of_tiles;
+    overlap_x_top /= number_of_tiles;
+    let tile_length = 1.0 / number_of_tiles;
+
+    for (var i = 0.0; i < number_of_tiles; i = i + 1.0) {
+        let x_top_tile = (tile_length * i) + x_top;
+        let overlap_x_top_tile = (tile_length * i) + overlap_x_top;
+
+        if ((x_top_tile >= x) && (x_top_tile <= x + thickness)) 
+            || (overlap && (overlap_x_top_tile >= x) && (overlap_x_top_tile <= x + thickness)) 
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn check_backward_pixel (
+    x: f32,
+    x_position: f32,
+    thickness: f32,
+    number_of_tiles: f32,
+) -> bool {
+    var x_top = x_position;
+
+    var overlap_x_top = 1.0;
+    var overlap = false;
+
+    if x_top < 0.0 {
+        overlap = true;
+        overlap_x_top = x_top;
+        x_top += 1.0;
+    }
+
+    x_top /= number_of_tiles;
+    overlap_x_top /= number_of_tiles;
+    let tile_length = 1.0 / number_of_tiles;
+
+    for (var i = 0.0; i < number_of_tiles; i = i + 1.0) {
+        let x_top_tile = (tile_length * i) + x_top;
+        let overlap_x_top_tile = (tile_length * i) + overlap_x_top;
+
+        if ((x >= x_top_tile) && (x <= x_top_tile + thickness))
+            || (overlap && (x >= overlap_x_top_tile) && (x <= overlap_x_top_tile + thickness)) 
+        {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
The aim of this PR is to compare the lane arrows visualisation with [PR #370](https://github.com/open-rmf/rmf_site/pull/370). The implementation of this lane arrow shader is the same as PR #370. The only difference between both PRs is the shader file code, and the color of the arrows moving in the reverse direction.

This shader shows arrows moving in different directions as adjacent lines as per below. This PR is to be compared with PR #370 that show overlapping arrows instead.

https://github.com/user-attachments/assets/75e82996-0ebb-428b-93ea-717e5c69408d
