### PR TITLE
Propagate is_active to camera children

### DIFF
--- a/crates/rmf_site_camera/src/systems.rs
+++ b/crates/rmf_site_camera/src/systems.rs
@@ -156,42 +156,66 @@ pub fn init_cameras(
 pub fn change_projection_mode(
     projection_mode: Res<ProjectionMode>,
     mut cameras: Query<(&mut Camera, &mut Visibility)>,
-    ortho_cams: Query<Entity, With<OrthographicCameraRoot>>,
-    persp_cams: Query<Entity, With<PerspectiveCameraRoot>>,
+    ortho_cams: Query<(Entity, &Children), With<OrthographicCameraRoot>>,
+    persp_cams: Query<(Entity, &Children), With<PerspectiveCameraRoot>>,
 ) {
     let projection_mode = *projection_mode;
 
     match projection_mode {
         ProjectionMode::Perspective => {
-            for ortho_cam in ortho_cams {
+            for (ortho_cam, children) in ortho_cams {
                 let Ok((mut camera, mut visibility)) = cameras.get_mut(ortho_cam) else {
                     continue;
                 };
                 camera.is_active = false;
                 *visibility = Visibility::Hidden;
+                for child in children {
+                    let Ok((mut child_camera, _)) = cameras.get_mut(*child) else {
+                        continue;
+                    };
+                    child_camera.is_active = false;
+                }
             }
-            for persp_cam in persp_cams {
+            for (persp_cam, children) in persp_cams {
                 let Ok((mut camera, mut visibility)) = cameras.get_mut(persp_cam) else {
                     continue;
                 };
                 camera.is_active = true;
                 *visibility = Visibility::Inherited;
+                for child in children {
+                    let Ok((mut child_camera, _)) = cameras.get_mut(*child) else {
+                        continue;
+                    };
+                    child_camera.is_active = true;
+                }
             }
         }
         ProjectionMode::Orthographic => {
-            for ortho_cam in ortho_cams {
+            for (ortho_cam, children) in ortho_cams {
                 let Ok((mut camera, mut visibility)) = cameras.get_mut(ortho_cam) else {
                     continue;
                 };
                 camera.is_active = true;
                 *visibility = Visibility::Inherited;
+                for child in children {
+                    let Ok((mut child_camera, _)) = cameras.get_mut(*child) else {
+                        continue;
+                    };
+                    child_camera.is_active = true;
+                }
             }
-            for persp_cam in persp_cams {
+            for (persp_cam, children) in persp_cams {
                 let Ok((mut camera, mut visibility)) = cameras.get_mut(persp_cam) else {
                     continue;
                 };
                 camera.is_active = false;
                 *visibility = Visibility::Hidden;
+                for child in children {
+                    let Ok((mut child_camera, _)) = cameras.get_mut(*child) else {
+                        continue;
+                    };
+                    child_camera.is_active = false;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR closes https://github.com/open-rmf/rmf_site/issues/351 to fix misaligned outlines when in 2D drawing mode. It turns out that the active camera being used to render outlines was wrong - `is_active` for children cameras for both Perspective and Orthographic modes weren't being updated.