### PR TITLE
Add site map server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/*"
 ]
+default-members = ["crates/rmf_site_editor"]
 
 # This is needed for packages that are part of a workspace to use the 2nd version
 # of the cargo dependency resolving algorithm. In ordinary crates this would be

--- a/crates/rmf_site_map_server/Cargo.toml
+++ b/crates/rmf_site_map_server/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rmf_site_map_server"
+version = "0.0.1"
+authors = ["Luca Della Vedova <lucadv@intrinsic.ai>"]
+edition = "2021"
+
+[dependencies]
+anyhow = {version = "1", features = ["backtrace"]}
+rmf_site_format = { workspace = true }
+
+[[bin]]
+name = "site_map_server"
+path = "src/main.rs"
+
+[dependencies.rclrs]
+version = "0.4"
+
+[dependencies.rosidl_runtime_rs]
+version = "0.4"
+
+[dependencies.rmf_building_map_msgs]
+version = "*"
+
+[dependencies.service_msgs]
+version = "*"
+
+[package.metadata.ros]
+install_to_share = ["launch"]

--- a/crates/rmf_site_map_server/package.xml
+++ b/crates/rmf_site_map_server/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model
+   href="http://download.ros.org/schema/package_format3.xsd"
+   schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmf_site_map_server</name>
+  <version>0.0.1</version>
+  <description>Building map server</description>
+  <maintainer email="lucadv@intrinsic.ai">Luca Della Vedova</maintainer>
+  <license>Apache License 2.0</license>
+
+  <depend>rclrs</depend>
+  <depend>rosidl_runtime_rs</depend>
+  <depend>service_msgs</depend>
+  <depend>rmf_building_map_msgs</depend>
+
+  <export>
+    <build_type>ament_cargo</build_type>
+  </export>
+</package>

--- a/crates/rmf_site_map_server/src/main.rs
+++ b/crates/rmf_site_map_server/src/main.rs
@@ -1,0 +1,213 @@
+use rclrs::{QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy};
+use rmf_site_format::{AssetSource, Category, DoorType, LiftCabin, Rotation, Side, Site, Swing};
+use std::env;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Error, Result};
+
+fn get_map_msg(site: &Site, map_folder: &Path) -> rmf_building_map_msgs::msg::BuildingMap {
+    let mut lifts = Vec::new();
+    let mut levels = Vec::new();
+
+    for lift in site.lifts.values() {
+        // Lift wall graph is ignored
+        let pose = lift.properties.center(site).unwrap();
+        let Rotation::Yaw(angle) = pose.rot else {
+            // TODO(luca) error logging
+            continue;
+        };
+        match &lift.properties.cabin {
+            LiftCabin::Rect(params) => {
+                // TODO(luca) There are many properties that seem unused, specifically skipping for
+                // now: doors, wall_graph and levels.
+                lifts.push(rmf_building_map_msgs::msg::Lift {
+                    name: lift.properties.name.0.clone(),
+                    ref_x: pose.trans[0],
+                    ref_y: pose.trans[1],
+                    ref_yaw: angle.radians(),
+                    // Note in site editor width and depth are flipped
+                    width: params.depth,
+                    depth: params.width,
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    for level in site.levels.values() {
+        let mut doors = Vec::new();
+        for door in level.doors.values() {
+            let Some(v1) = site.get_anchor(door.anchors.start()) else {
+                println!("Missing start anchor for door, skipping...");
+                continue;
+            };
+            let Some(v2) = site.get_anchor(door.anchors.end()) else {
+                println!("Missing end anchor for door, skipping...");
+                continue;
+            };
+            let v1 = v1.translation_for_category(Category::Level);
+            let v2 = v2.translation_for_category(Category::Level);
+            let name = door.name.0.clone();
+            let door = match &door.kind {
+                DoorType::SingleSliding(door) => {
+                    // TODO(luca) check that this is not flipped
+                    let (v1, v2) = match door.towards {
+                        Side::Left => (v1, v2),
+                        Side::Right => (v2, v1),
+                    };
+                    rmf_building_map_msgs::msg::Door {
+                        name,
+                        v1_x: v1[0],
+                        v1_y: v1[1],
+                        v2_x: v2[0],
+                        v2_y: v2[1],
+                        door_type: rmf_building_map_msgs::msg::Door::DOOR_TYPE_SINGLE_SLIDING,
+                        ..Default::default()
+                    }
+                }
+                DoorType::DoubleSliding(_) => {
+                    // TODO(luca) check that this is not flipped
+                    rmf_building_map_msgs::msg::Door {
+                        name,
+                        v1_x: v1[0],
+                        v1_y: v1[1],
+                        v2_x: v2[0],
+                        v2_y: v2[1],
+                        door_type: rmf_building_map_msgs::msg::Door::DOOR_TYPE_DOUBLE_SLIDING,
+                        ..Default::default()
+                    }
+                }
+                DoorType::SingleSwing(door) => {
+                    // TODO(luca) check that this is not flipped
+                    let (v1, v2) = match door.pivot_on {
+                        Side::Left => (v1, v2),
+                        Side::Right => (v2, v1),
+                    };
+                    let (motion_range, motion_direction) = match door.swing {
+                        Swing::Forward(forward) | Swing::Both { forward, .. } => {
+                            (forward.radians(), 1)
+                        }
+                        Swing::Backward(backward) => (backward.radians(), -1),
+                    };
+                    rmf_building_map_msgs::msg::Door {
+                        name,
+                        v1_x: v1[0],
+                        v1_y: v1[1],
+                        v2_x: v2[0],
+                        v2_y: v2[1],
+                        door_type: rmf_building_map_msgs::msg::Door::DOOR_TYPE_SINGLE_SWING,
+                        motion_range,
+                        motion_direction,
+                    }
+                }
+                DoorType::DoubleSwing(door) => {
+                    let (motion_range, motion_direction) = match door.swing {
+                        Swing::Forward(forward) | Swing::Both { forward, .. } => {
+                            (forward.radians(), 1)
+                        }
+                        Swing::Backward(backward) => (backward.radians(), -1),
+                    };
+                    rmf_building_map_msgs::msg::Door {
+                        name,
+                        v1_x: v1[0],
+                        v1_y: v1[1],
+                        v2_x: v2[0],
+                        v2_y: v2[1],
+                        door_type: rmf_building_map_msgs::msg::Door::DOOR_TYPE_DOUBLE_SWING,
+                        motion_range,
+                        motion_direction,
+                    }
+                }
+                DoorType::Model(_) => {
+                    println!("Found unsupported Model door! Skipping...");
+                    continue;
+                }
+            };
+            doors.push(door);
+        }
+        let mut images = Vec::new();
+        for drawing in level.drawings.values() {
+            // TODO(luca) Floorplan visualizer does not support yet more than one drawing, revisit
+            // when that is the case
+            if !images.is_empty() {
+                continue;
+            }
+            let AssetSource::Local(path) = &drawing.properties.source else {
+                println!("Found unsupported drawing type! Skipping...");
+                continue;
+            };
+            let image_path = map_folder.join(path);
+            let Ok(data) = std::fs::read(&image_path) else {
+                println!("Unable to read image! Skipping...");
+                continue;
+            };
+            let Some(extension) = image_path.extension().and_then(|ext| ext.to_str()) else {
+                println!("Unable to get image extension! Skipping...");
+                continue;
+            };
+            let pose = &drawing.properties.pose;
+            let Rotation::Yaw(angle) = pose.rot else {
+                // TODO(luca) error logging
+                continue;
+            };
+            images.push(rmf_building_map_msgs::msg::AffineImage {
+                data,
+                name: drawing.properties.name.0.clone(),
+                encoding: extension.to_string(),
+                scale: 1.0 / drawing.properties.pixels_per_meter.0,
+                x_offset: pose.trans[0],
+                y_offset: pose.trans[1],
+                yaw: angle.radians(),
+            });
+        }
+        levels.push(rmf_building_map_msgs::msg::Level {
+            name: level.properties.name.0.clone(),
+            elevation: level.properties.elevation.0,
+            images,
+            places: vec![],
+            doors,
+            nav_graphs: vec![],
+            wall_graph: Default::default(),
+        });
+    }
+
+    rmf_building_map_msgs::msg::BuildingMap {
+        name: site.properties.name.0.clone(),
+        levels,
+        lifts,
+    }
+}
+
+fn main() -> Result<(), Error> {
+    let args: Vec<String> = env::args().collect();
+    let Some(map_path) = args.get(1) else {
+        panic!("Map path must be provided as a command line argument");
+    };
+    let site = if map_path.ends_with(".building.yaml") {
+        let building_map = rmf_site_format::legacy::building_map::BuildingMap::from_bytes(
+            &std::fs::read(map_path)?,
+        )?;
+        building_map.to_site()?
+    } else if map_path.ends_with(".site.ron") {
+        rmf_site_format::Site::from_bytes(&std::fs::read(map_path)?)?
+    } else {
+        panic!("Unsupported file type {map_path}");
+    };
+    let context = rclrs::Context::new(env::args())?;
+
+    let node = rclrs::create_node(&context, "rmf_building_map_server_rs")?;
+
+    let mut qos = rclrs::QOS_PROFILE_DEFAULT;
+    qos.history = QoSHistoryPolicy::KeepLast { depth: 1 };
+    qos.reliability = QoSReliabilityPolicy::Reliable;
+    qos.durability = QoSDurabilityPolicy::TransientLocal;
+
+    let publisher = node.create_publisher::<rmf_building_map_msgs::msg::BuildingMap>("map", qos)?;
+
+    let site_folder = PathBuf::from(map_path);
+    let site_folder = site_folder.parent().unwrap();
+    let map = get_map_msg(&site, site_folder);
+
+    publisher.publish(map)?;
+    rclrs::spin(node).map_err(|err| err.into())
+}


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Implement a map server based on `rmf_site_format`.

### Implementation description

The server is a replacement for traffic editor's [building_map_server](https://github.com/open-rmf/rmf_traffic_editor/tree/main/rmf_building_map_tools/building_map_server). It still allows publishing legacy maps but allows publishing site files as well.
Note that there is a major caveat with adding this crate to this repo that we should figure out before merging it, specifically, it depends on `rclrs` (OK) and message packages (not OK).
Depending on message packages _right now_ has a few issues.

#### Buildfarm distribution

The messages distributed in the build farm don't (yet) include rust bindings. This might change in the future but in the current stage it will make the package fail to build unless it is in a colcon workspace that also contains the [rust generators](https://github.com/ros2-rust/rosidl_rust) as well as all the message packages that this server depends on (`rmf_building_map_msgs` and `service_msgs`).

#### Colcon building

Even if the above was to be solved, the way Rust packages are able to find ROS dependencies (in this case messages) is through a combination of [cargo-ament-build](https://github.com/ros2-rust/cargo-ament-build/) and [colcon-ros-cargo](https://github.com/colcon/colcon-ros-cargo). Specifically, the latter will generate a `.cargo/config.toml` file that points subsequent cargo builds to the messages found in the ament prefix.
This means that, unless we reimplement some of this logic manually (i.e. in a `build.rs` file), the crate will only be buildable through `colcon`, and not through `cargo` anymore. Or rather to be precise, the _first_ build will have to be through `colcon`, which will generate the `config.toml` file, then subsequent builds can be through `cargo build`.

#### Unable to skip building workspace members

I would be OK with accepting the issues above if there was a way to skip building a workspace member based on a feature flag or something along those lines. For example, we could have a `build_map_server` feature, disable it by default, and make sure people can still build the site editor normally without having to go through the message generation + colcon trouble mentioned above.
However, I couldn't find a way to fully skip compilation of workspace members based on feature flags, happy to hear if there is any feedback.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI