### PR TITLE
Retry spawning scenes if assets are not ready

### DIFF
--- a/crates/rmf_site_format/src/door.rs
+++ b/crates/rmf_site_format/src/door.rs
@@ -109,6 +109,7 @@ impl Default for DoorType {
 pub struct SingleSlidingDoor {
     /// Which side the door slides towards
     pub towards: Side,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub position: f32,
 }
 
@@ -132,7 +133,9 @@ impl From<SingleSlidingDoor> for DoorType {
 pub struct DoubleSlidingDoor {
     /// Length of the left door divided by the length of the right door
     pub left_right_ratio: f32,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub left_position: f32,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub right_position: f32,
 }
 
@@ -170,6 +173,7 @@ pub struct SingleSwingDoor {
     pub pivot_on: Side,
     /// How does the door swing
     pub swing: Swing,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub position: f32,
 }
 
@@ -196,7 +200,9 @@ pub struct DoubleSwingDoor {
     pub swing: Swing,
     /// Length of the left door divided by the length of the right door
     pub left_right_ratio: f32,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub left_position: f32,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub right_position: f32,
 }
 


### PR DESCRIPTION
This PR closes https://github.com/open-rmf/rmf_site/issues/375 where some models may not load successfully in large worlds. It turns out some Gltf assets have not arrived in the `Assets<Gltf>` database, so the current approach of failing the entire model loading workflow after one try would result in some models not being spawned, even if they are valid. Here we introduced a timeout loop and implemented a retry mechanism for these late-arriving assets.

Additionally I added some `skip_serializing_if = "is_default"` for our new door features, so that older site files can still be imported fine.