### PR TITLE
Use web-time for wasm compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5720,6 +5720,7 @@ dependencies = [
  "urdf-rs",
  "utm",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -5808,6 +5809,7 @@ dependencies = [
  "rmf_site_mesh",
  "smallvec",
  "tracing",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ bytemuck = {version = "1.22"}
 bevy_infinite_grid = { version = "0.15"}
 testdir = "*"
 file_diff = "*"
+web-time = "1"
 
 bevy = "0.16"
 bevy_a11y = "0.16"

--- a/crates/rmf_site_editor/Cargo.toml
+++ b/crates/rmf_site_editor/Cargo.toml
@@ -60,10 +60,12 @@ bevy_rich_text3d = {workspace = true}
 clap = { workspace = true, features = ["color", "derive", "help", "usage", "suggestions"] }
 bevy_egui = {workspace = true}
 bevy_impulse = { workspace = true}
+web-time = {workspace = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bevy_egui = { workspace = true, default-features = false, features = ["open_url", "default_fonts", "render"] }
 bevy_impulse = { workspace = true, features = ["single_threaded_async"]}
+web-time = {workspace = true}
 
 [dev-dependencies]
 file_diff = {workspace = true}

--- a/crates/rmf_site_editor/src/mapf_rse/negotiation/mod.rs
+++ b/crates/rmf_site_editor/src/mapf_rse/negotiation/mod.rs
@@ -23,8 +23,8 @@ use bevy::{
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
-    time::{Duration, Instant},
 };
+use web_time::{Duration, Instant};
 
 use crate::{
     occupancy::{Cell, Grid},

--- a/crates/rmf_site_editor/src/occupancy.rs
+++ b/crates/rmf_site_editor/src/occupancy.rs
@@ -31,10 +31,7 @@ use bevy::{
 use itertools::Itertools;
 use rmf_site_mesh::*;
 use rmf_site_picking::ComputedVisualCue;
-use std::{
-    collections::{HashMap, HashSet},
-    time::Instant,
-};
+use std::collections::{HashMap, HashSet};
 
 pub struct OccupancyPlugin;
 
@@ -180,7 +177,6 @@ fn calculate_grid(
     grids: Query<Entity, With<Grid>>,
 ) {
     if let Some(request) = request.read().last() {
-        let start_time = Instant::now();
         // let mut occupied: HashSet<Cell> = HashSet::new();
         let mut occupied: HashMap<Entity, HashSet<Cell>> = HashMap::new();
         let mut range = GridRange::new();
@@ -263,10 +259,6 @@ fn calculate_grid(
                 }
             }
         }
-
-        let finish_time = Instant::now();
-        let delta = finish_time - start_time;
-        info!("Occupancy calculation time: {}", delta.as_secs_f32());
 
         for grid in &grids {
             commands.entity(grid).despawn();

--- a/crates/rmf_site_picking/Cargo.toml
+++ b/crates/rmf_site_picking/Cargo.toml
@@ -25,6 +25,7 @@ rmf_site_camera = {workspace = true}
 rmf_site_mesh = {workspace = true}
 rmf_site_animate = {workspace = true}
 bevy_egui = {workspace = true}
+web-time = {workspace = true}
 
 [dev-dependencies]
 bevy = {workspace = true, features = ["dynamic_linking"]}

--- a/crates/rmf_site_picking/src/select/resources.rs
+++ b/crates/rmf_site_picking/src/select/resources.rs
@@ -4,7 +4,7 @@ use bevy_impulse::Service;
 use bytemuck::TransparentWrapper;
 
 use crate::*;
-use std::time::Instant;
+use web_time::Instant;
 
 /// Used as a resource to keep track of which entity is currently selected.
 #[derive(Default, Debug, Clone, Copy, Deref, DerefMut, Resource)]

--- a/crates/rmf_site_picking/src/select/systems.rs
+++ b/crates/rmf_site_picking/src/select/systems.rs
@@ -8,8 +8,8 @@ use bevy_math::prelude::*;
 use bevy_picking::pointer::{PointerId, PointerInteraction};
 use bevy_transform::components::Transform;
 use rmf_site_camera::*;
-use std::time::Instant;
 use tracing::warn;
+use web_time::Instant;
 
 use crate::*;
 


### PR DESCRIPTION
Some recent PRs added the use of `std::time::Instant::now` throughout the repo. Unfortunately that function does not have an implementation for `wasm32-unknown-unknown` targets and leads to a crash when trying to run the site editor in the web browser.

This PR replaces all uses of `Instant::now` with an implementation from the `web-time` crate which does provide an implementation for the `wasm32-unknown-unknown` target. This will allow `main` to be deployed on the web.