### PR TITLE
Fix panic when deleting new edges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ testdir = "*"
 file_diff = "*"
 web-time = "1"
 
-bevy = "0.16"
+bevy = {version = "0.16", features = ["configurable_error_handler"]}
 bevy_a11y = "0.16"
 bevy_animation = "0.16"
 bevy_app = "0.16"
@@ -89,7 +89,7 @@ bevy_derive = "0.16"
 bevy_dev_tools = "0.16"
 bevy_diagnostic = "0.16"
 bevy_dylib = "0.16"
-bevy_ecs = "0.16"
+bevy_ecs = {version = "0.16", features = ["configurable_error_handler"]}
 bevy_encase_derive = "0.16"
 bevy_gilrs = "0.16"
 bevy_gizmos = "0.16"

--- a/crates/rmf_site_editor/src/interaction/user_camera.rs
+++ b/crates/rmf_site_editor/src/interaction/user_camera.rs
@@ -76,7 +76,13 @@ fn calculate_new_target(
 
 pub fn update_camera_targets(
     mut commands: Commands,
-    changed_anchors: Query<&Dependents, (With<Anchor>, Or<(Changed<Anchor>, Changed<Transform>)>)>,
+    changed_anchors: Query<
+        &Dependents,
+        (
+            With<Anchor>,
+            Or<(Changed<Anchor>, Changed<GlobalTransform>)>,
+        ),
+    >,
     changed_elements: Query<
         Entity,
         Or<(

--- a/crates/rmf_site_editor/src/interaction/user_camera.rs
+++ b/crates/rmf_site_editor/src/interaction/user_camera.rs
@@ -76,13 +76,7 @@ fn calculate_new_target(
 
 pub fn update_camera_targets(
     mut commands: Commands,
-    changed_anchors: Query<
-        &Dependents,
-        (
-            With<Anchor>,
-            Or<(Changed<Anchor>, Changed<GlobalTransform>)>,
-        ),
-    >,
+    changed_anchors: Query<&Dependents, (With<Anchor>, Or<(Changed<Anchor>, Changed<Transform>)>)>,
     changed_elements: Query<
         Entity,
         Or<(

--- a/crates/rmf_site_editor/src/lib.rs
+++ b/crates/rmf_site_editor/src/lib.rs
@@ -120,7 +120,19 @@ impl AppState {
     }
 }
 
+fn handle_errors(error: BevyError, ctx: bevy::ecs::error::ErrorContext) {
+    warn!(
+        "Encountered an error in {} `{}`: {}",
+        ctx.kind(),
+        ctx.name(),
+        error
+    );
+}
+
 pub fn run(command_line_args: Vec<String>) {
+    bevy::ecs::error::GLOBAL_ERROR_HANDLER
+        .set(handle_errors)
+        .expect("The error handler can only be set once, globally.");
     let mut app = App::new();
     let mut _export_sdf = None;
     let mut _export_nav = None;


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes #390 

### Fix applied

Change detection for `GlobalTransform` triggers every time the mouse is moved and it causes the component to be inserted on a deleted entity. By contrast, the one for `Transform` only triggers, correctly, when the actual anchor transform is changed.
We should investigate why `GlobalTransform` change detection seems to trigger so often or, if no real cause is found, investigate all our queries for `Changed<GlobalTransform>` and see how often they get triggered and if we can get away with a simple `Changed<Transform>` instead.
For now this PR fixes panics that occurred when deleting any edge after it was created (the original issue doesn't mention it but walls panic as well)