### PR TITLE
Make Change event into an observer

### DIFF
--- a/crates/rmf_site_editor/src/mapf_rse/debug_panel.rs
+++ b/crates/rmf_site_editor/src/mapf_rse/debug_panel.rs
@@ -611,8 +611,8 @@ fn handle_debug_panel_visibility(
 
 pub fn handle_debug_panel_changed(
     mapf_debug_window: Res<MAPFDebugDisplay>,
+    mut commands: Commands,
     mut robots: Query<(Entity, &Pose, Option<&mut Original<Pose>>), With<Robot>>,
-    mut change_pose: EventWriter<Change<Pose>>,
     mut change_plan: EventWriter<NegotiationRequest>,
     mut path_mesh_visibilities: Query<&mut Visibility, With<PathVisualMarker>>,
     mut occ_mesh_visibilities: Query<
@@ -649,7 +649,7 @@ pub fn handle_debug_panel_changed(
             // If debug window is closed, move robot to original pose
             for (robot_entity, _, robot_opose) in robots.iter() {
                 if let Some(opose) = robot_opose {
-                    change_pose.write(Change::new(opose.0, robot_entity));
+                    commands.trigger(Change::new(opose.0, robot_entity));
                 }
             }
 

--- a/crates/rmf_site_editor/src/mapf_rse/mod.rs
+++ b/crates/rmf_site_editor/src/mapf_rse/mod.rs
@@ -476,14 +476,13 @@ fn handle_changed_debug_goal(
     debug_goals_changed: Query<(Entity, Option<&Original<Pose>>, &DebugGoal), Changed<DebugGoal>>,
     debug_goals_added: Query<(), Added<DebugGoal>>,
     mut negotiation_request: EventWriter<NegotiationRequest>,
-    mut change_pose: EventWriter<Change<Pose>>,
     mut commands: Commands,
 ) {
     let mut any_debug_goal_changed = false;
     for (entity, original_pose, debug_goal) in debug_goals_changed.iter() {
         if debug_goal.location.is_empty() {
             if let Some(pose) = original_pose {
-                change_pose.write(Change::new(pose.0, entity));
+                commands.trigger(Change::new(pose.0, entity));
                 commands.entity(entity).remove::<Original<Pose>>();
             }
         }
@@ -523,7 +522,6 @@ fn handle_changed_plan_info(
     mut materials: ResMut<Assets<StandardMaterial>>,
     robot_debug_materials: Query<&DebugMaterial, With<Robot>>,
     mut commands: Commands,
-    mut change_pose: EventWriter<Change<Pose>>,
     mut debug_data: ResMut<NegotiationDebugData>,
     site_assets: Res<SiteAssets>,
     current_level: Res<CurrentLevel>,
@@ -707,7 +705,7 @@ fn handle_changed_plan_info(
         MAPFDebugInfo::InProgress { .. } => {
             for (robot_entity, _, _, robot_opose) in robots.iter() {
                 if let Some(opose) = robot_opose {
-                    change_pose.write(Change::new(opose.0, robot_entity));
+                    commands.trigger(Change::new(opose.0, robot_entity));
                     commands.entity(robot_entity).remove::<Original<Pose>>();
                 }
             }

--- a/crates/rmf_site_editor/src/mapf_rse/visual.rs
+++ b/crates/rmf_site_editor/src/mapf_rse/visual.rs
@@ -47,7 +47,7 @@ pub enum MAPFDebugInfo {
 
 pub fn visualise_selected_node(
     mut debug_data: ResMut<NegotiationDebugData>,
-    mut change_pose: EventWriter<Change<Pose>>,
+    mut commands: Commands,
     now: Res<Time>,
     open_sites: Query<Entity, With<NameOfSite>>,
     current_workspace: Res<CurrentWorkspace>,
@@ -109,7 +109,7 @@ pub fn visualise_selected_node(
             .compute_position(&mapf::motion::TimePoint::from_secs_f32(time_now))
         {
             let robot_yaw = crate::ops::atan2(interp.rotation.im as f32, interp.rotation.re as f32);
-            change_pose.write(Change::new(
+            commands.trigger(Change::new(
                 Pose {
                     trans: [
                         interp.translation.x as f32,

--- a/crates/rmf_site_editor/src/site/model.rs
+++ b/crates/rmf_site_editor/src/site/model.rs
@@ -756,7 +756,7 @@ pub fn insert_robot_collision_model(
     mesh_handles: Query<&Mesh3d>,
     all_children: Query<&Children>,
     meshes: Res<Assets<Mesh>>,
-    mut change_robot_property: EventWriter<Change<ModelProperty<Robot>>>,
+    mut commands: Commands,
 ) -> ModelLoadingRequest {
     let Ok(robot_affiliation) = robot_model_descriptions.get(req.parent) else {
         return req;
@@ -820,7 +820,7 @@ pub fn insert_robot_collision_model(
         new_robot
             .properties
             .insert(Collision::label(), serialized_collision);
-        change_robot_property.write(Change::new(ModelProperty(new_robot), description_entity));
+        commands.trigger(Change::new(ModelProperty(new_robot), description_entity));
     };
 
     req

--- a/crates/rmf_site_editor/src/site/robot_properties.rs
+++ b/crates/rmf_site_editor/src/site/robot_properties.rs
@@ -105,7 +105,7 @@ pub fn update_robot_property_kind_components<
 
 /// This system updates ModelProperty<Robot> based on updates to the RobotProperty components
 pub fn serialize_and_change_robot_property<Property: RobotProperty>(
-    change_robot_property: &mut EventWriter<Change<ModelProperty<Robot>>>,
+    commands: &mut Commands,
     property: Property,
     robot: &Robot,
     description_entity: Entity,
@@ -115,7 +115,7 @@ pub fn serialize_and_change_robot_property<Property: RobotProperty>(
         new_robot
             .properties
             .insert(Property::label(), new_property_value);
-        change_robot_property.write(Change::new(ModelProperty(new_robot), description_entity));
+        commands.trigger(Change::new(ModelProperty(new_robot), description_entity));
     }
 }
 
@@ -125,7 +125,7 @@ pub fn serialize_and_change_robot_property_kind<
     Property: RobotProperty,
     Kind: RobotPropertyKind,
 >(
-    change_robot_property: &mut EventWriter<Change<ModelProperty<Robot>>>,
+    commands: &mut Commands,
     property_kind: Kind,
     robot: &Robot,
     description_entity: Entity,
@@ -137,6 +137,6 @@ pub fn serialize_and_change_robot_property_kind<
         new_robot
             .properties
             .insert(Property::label(), new_property_value);
-        change_robot_property.write(Change::new(ModelProperty(new_robot), description_entity));
+        commands.trigger(Change::new(ModelProperty(new_robot), description_entity));
     }
 }

--- a/crates/rmf_site_editor/src/site/slotcar.rs
+++ b/crates/rmf_site_editor/src/site/slotcar.rs
@@ -45,7 +45,6 @@ impl Plugin for SlotcarSdfPlugin {
 
 fn insert_slotcar_components(
     mut commands: Commands,
-    mut change_robot_property: EventWriter<Change<ModelProperty<Robot>>>,
     is_static: Query<&ModelProperty<IsStatic>, (With<ModelMarker>, With<Group>)>,
     robot_property_kinds: Query<
         (
@@ -135,7 +134,7 @@ fn insert_slotcar_components(
                     );
                 }
 
-                change_robot_property.write(Change::new(ModelProperty(robot), desc));
+                commands.trigger(Change::new(ModelProperty(robot), desc));
             }
             commands
                 .entity(e)

--- a/crates/rmf_site_editor/src/widgets/diagnostics.rs
+++ b/crates/rmf_site_editor/src/widgets/diagnostics.rs
@@ -63,6 +63,7 @@ fn diagnostics_panel(In(input): In<PanelWidgetInput>, world: &mut World) {
 /// Use [`DiagnosticsPlugin`] to add this to your application.
 #[derive(SystemParam)]
 pub struct Diagnostics<'w, 's> {
+    commands: Commands<'w, 's>,
     icons: Res<'w, Icons>,
     filters: Query<'w, 's, (&'static FilteredIssues<Entity>, &'static FilteredIssueKinds)>,
     issue_dictionary: Res<'w, IssueDictionary>,
@@ -70,8 +71,6 @@ pub struct Diagnostics<'w, 's> {
     display_diagnostics: ResMut<'w, DiagnosticsDisplay>,
     current_workspace: ResMut<'w, CurrentWorkspace>,
     validate_workspace: EventWriter<'w, ValidateWorkspace>,
-    change_filtered_issues: EventWriter<'w, Change<FilteredIssues<Entity>>>,
-    change_filtered_issue_kinds: EventWriter<'w, Change<FilteredIssueKinds>>,
     selector: SelectorWidget<'w, 's>,
 }
 
@@ -202,12 +201,12 @@ impl<'w, 's> Diagnostics<'w, 's> {
             }
         });
         if new_filtered_issues != *filtered_issues {
-            self.change_filtered_issues
-                .write(Change::new(new_filtered_issues, root));
+            self.commands
+                .trigger(Change::new(new_filtered_issues, root));
         }
         if new_filtered_issue_kinds != *filtered_issue_kinds {
-            self.change_filtered_issue_kinds
-                .write(Change::new(new_filtered_issue_kinds, root));
+            self.commands
+                .trigger(Change::new(new_filtered_issue_kinds, root));
         }
         *self.display_diagnostics = state;
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_asset_source.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_asset_source.rs
@@ -164,6 +164,7 @@ impl<'a> InspectAssetSourceComponent<'a> {
 
 #[derive(SystemParam)]
 pub struct InspectAssetSource<'w, 's> {
+    commands: Commands<'w, 's>,
     query: Query<
         'w,
         's,
@@ -172,7 +173,6 @@ pub struct InspectAssetSource<'w, 's> {
     >,
     default_file: Query<'w, 's, &'static DefaultFile>,
     current_workspace: Res<'w, CurrentWorkspace>,
-    change_asset_source: EventWriter<'w, Change<AssetSource>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectAssetSource<'w, 's> {
@@ -195,9 +195,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectAssetSource<'w, 's> {
         if let Some(new_source) =
             InspectAssetSourceComponent::new(source, recall, default_file).show(ui)
         {
-            params
-                .change_asset_source
-                .write(Change::new(new_source, selection));
+            params.commands.trigger(Change::new(new_source, selection));
         }
     }
 }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_associated_graphs.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_associated_graphs.rs
@@ -30,6 +30,7 @@ use std::collections::BTreeMap;
 
 #[derive(SystemParam)]
 pub struct InspectAssociatedGraphs<'w, 's> {
+    commands: Commands<'w, 's>,
     associated: Query<
         'w,
         's,
@@ -41,7 +42,6 @@ pub struct InspectAssociatedGraphs<'w, 's> {
     graphs: Query<'w, 's, (Entity, &'static NameInSite), With<NavGraphMarker>>,
     icons: Res<'w, Icons>,
     consider_graph: EventWriter<'w, ConsiderAssociatedGraph>,
-    change_associated_graphs: EventWriter<'w, Change<AssociatedGraphs<Entity>>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectAssociatedGraphs<'w, 's> {
@@ -135,8 +135,7 @@ impl<'w, 's> InspectAssociatedGraphs<'w, 's> {
         }
 
         if new_associated != *associated {
-            self.change_associated_graphs
-                .write(Change::new(new_associated, id));
+            self.commands.trigger(Change::new(new_associated, id));
         }
 
         ui.add_space(10.0);

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_door.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_door.rs
@@ -30,8 +30,8 @@ use rmf_site_format::{DoorType, RecallDoorType, Swing};
 
 #[derive(SystemParam)]
 pub struct InspectDoor<'w, 's> {
+    commands: Commands<'w, 's>,
     doors: Query<'w, 's, (&'static DoorType, &'static RecallDoorType)>,
-    change_door: EventWriter<'w, Change<DoorType>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectDoor<'w, 's> {
@@ -47,7 +47,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectDoor<'w, 's> {
         };
 
         if let Some(new_door) = InspectDoorType::new(door, recall).show(ui) {
-            params.change_door.write(Change::new(new_door, selection));
+            params.commands.trigger(Change::new(new_door, selection));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_drawing.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_drawing.rs
@@ -26,8 +26,8 @@ use rmf_site_egui::WidgetSystem;
 
 #[derive(SystemParam)]
 pub struct InspectDrawing<'w, 's> {
+    commands: Commands<'w, 's>,
     pixels_per_meter: Query<'w, 's, &'static PixelsPerMeter>,
-    change_pixels_per_meter: EventWriter<'w, Change<PixelsPerMeter>>,
     current_workspace: Res<'w, CurrentWorkspace>,
     align_site: EventWriter<'w, AlignSiteDrawings>,
     app_state: Res<'w, State<AppState>>,
@@ -85,8 +85,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectDrawing<'w, 's> {
             .show(ui)
         {
             params
-                .change_pixels_per_meter
-                .write(Change::new(PixelsPerMeter(new_ppm), selection));
+                .commands
+                .trigger(Change::new(PixelsPerMeter(new_ppm), selection));
         }
     }
 }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_fiducial.rs
@@ -80,7 +80,6 @@ pub struct InspectFiducial<'w, 's> {
     icons: Res<'w, Icons>,
     search_for_fiducial: ResMut<'w, SearchForFiducial>,
     commands: Commands<'w, 's>,
-    change_affiliation: EventWriter<'w, Change<Affiliation<Entity>>>,
     names: Query<'w, 's, &'static NameInSite>,
 }
 
@@ -205,8 +204,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectFiducial<'w, 's> {
                                 .insert(ChildOf(tracker.site()))
                                 .id();
                             params
-                                .change_affiliation
-                                .write(Change::new(Affiliation(Some(new_group)), selection));
+                                .commands
+                                .trigger(Change::new(Affiliation(Some(new_group)), selection));
                         }
                     }
                     SearchResult::Match(group) => {
@@ -216,8 +215,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectFiducial<'w, 's> {
                             .clicked()
                         {
                             params
-                                .change_affiliation
-                                .write(Change::new(Affiliation(Some(group)), selection));
+                                .commands
+                                .trigger(Change::new(Affiliation(Some(group)), selection));
                         }
                     }
                     SearchResult::Conflict(text) => {
@@ -274,8 +273,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectFiducial<'w, 's> {
 
             if new_affiliation != *affiliation {
                 params
-                    .change_affiliation
-                    .write(Change::new(new_affiliation, selection));
+                    .commands
+                    .trigger(Change::new(new_affiliation, selection));
             }
             ui.separator();
         });

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_group.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_group.rs
@@ -26,6 +26,7 @@ use rmf_site_egui::WidgetSystem;
 
 #[derive(SystemParam)]
 pub struct InspectGroup<'w, 's> {
+    commands: Commands<'w, 's>,
     is_group: Query<'w, 's, (), With<Group>>,
     affiliation: Query<'w, 's, &'static Affiliation<Entity>, Without<ModelMarker>>,
     names: Query<'w, 's, &'static NameInSite>,
@@ -33,7 +34,6 @@ pub struct InspectGroup<'w, 's> {
     members: Query<'w, 's, &'static Members>,
     default_file: Query<'w, 's, &'static DefaultFile>,
     current_workspace: Res<'w, CurrentWorkspace>,
-    change_texture: EventWriter<'w, Change<Texture>>,
     selector: SelectorWidget<'w, 's>,
 }
 
@@ -74,7 +74,7 @@ impl<'w, 's> InspectGroup<'w, 's> {
         if let Ok(texture) = self.textures.get(id) {
             ui.label(RichText::new("Texture Properties").size(18.0));
             if let Some(new_texture) = InspectTexture::new(texture, default_file).show(ui) {
-                self.change_texture.write(Change::new(new_texture, id));
+                self.commands.trigger(Change::new(new_texture, id));
             }
             ui.add_space(10.0);
         }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_layer.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_layer.rs
@@ -44,8 +44,6 @@ pub struct InspectLayer<'w, 's> {
     pub icons: Res<'w, Icons>,
     pub selection: Res<'w, Selection>,
     pub begin_edit_drawing: EventWriter<'w, BeginEditDrawing>,
-    pub change_layer_visibility: EventWriter<'w, Change<LayerVisibility>>,
-    pub change_preferred_alpha: EventWriter<'w, Change<PreferredSemiTransparency>>,
     pub floor_change_rank: EventWriter<'w, ChangeRank<FloorMarker>>,
     pub drawing_change_rank: EventWriter<'w, ChangeRank<DrawingMarker>>,
     pub commands: Commands<'w, 's>,
@@ -169,8 +167,7 @@ impl<'w, 's> InspectLayer<'w, 's> {
             if resp.clicked() {
                 match vis.next(default_alpha) {
                     Some(v) => {
-                        self.change_layer_visibility
-                            .write(Change::new(v, id).or_insert());
+                        self.commands.trigger(Change::new(v, id).or_insert());
                     }
                     None => {
                         self.commands.entity(id).remove::<LayerVisibility>();
@@ -183,10 +180,10 @@ impl<'w, 's> InspectLayer<'w, 's> {
                     .add(DragValue::new(&mut alpha).range(0_f32..=1_f32).speed(0.01))
                     .changed()
                 {
-                    self.change_layer_visibility
-                        .write(Change::new(LayerVisibility::Alpha(alpha), id));
-                    self.change_preferred_alpha
-                        .write(Change::new(PreferredSemiTransparency(alpha), id));
+                    self.commands
+                        .trigger(Change::new(LayerVisibility::Alpha(alpha), id));
+                    self.commands
+                        .trigger(Change::new(PreferredSemiTransparency(alpha), id));
                 }
             }
         });

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_lift.rs
@@ -41,11 +41,11 @@ impl Plugin for InspectLiftPlugin {
 
 #[derive(SystemParam)]
 pub struct InspectLiftCabin<'w, 's> {
+    commands: Commands<'w, 's>,
     cabins: Query<'w, 's, (&'static LiftCabin<Entity>, &'static RecallLiftCabin<Entity>)>,
     doors: Query<'w, 's, &'static LevelVisits<Entity>>,
     levels: Query<'w, 's, (&'static NameInSite, &'static LevelElevation)>,
     display_level: Res<'w, LevelDisplay>,
-    change_lift_cabin: EventWriter<'w, Change<LiftCabin<Entity>>>,
     selector: SelectorWidget<'w, 's>,
     toggle_door_levels: EventWriter<'w, ToggleLiftDoorAvailability>,
     current_level: Res<'w, CurrentLevel>,
@@ -254,7 +254,7 @@ impl<'w, 's> InspectLiftCabin<'w, 's> {
                 }
             }
 
-            self.change_lift_cabin.write(Change::new(new_cabin, id));
+            self.commands.trigger(Change::new(new_cabin, id));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_light.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_light.rs
@@ -25,8 +25,8 @@ use rmf_site_egui::WidgetSystem;
 
 #[derive(SystemParam)]
 pub struct InspectLight<'w, 's> {
+    commands: Commands<'w, 's>,
     lights: Query<'w, 's, (&'static LightKind, &'static RecallLightKind)>,
-    change_light: EventWriter<'w, Change<LightKind>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectLight<'w, 's> {
@@ -42,7 +42,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectLight<'w, 's> {
         };
 
         if let Some(new_light) = InspectLightKind::new(light, recall).show(ui) {
-            params.change_light.write(Change::new(new_light, selection));
+            params.commands.trigger(Change::new(new_light, selection));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_location.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_location.rs
@@ -26,10 +26,10 @@ use smallvec::SmallVec;
 
 #[derive(SystemParam)]
 pub struct InspectLocation<'w, 's> {
+    commands: Commands<'w, 's>,
     location_tags: Query<'w, 's, (&'static LocationTags, &'static RecallLocationTags)>,
     icons: Res<'w, Icons>,
     consider_tag: EventWriter<'w, ConsiderLocationTag>,
-    change_tags: EventWriter<'w, Change<LocationTags>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectLocation<'w, 's> {
@@ -124,7 +124,7 @@ impl<'w, 's> InspectLocation<'w, 's> {
                 new_tags.push(new_tag);
             }
 
-            self.change_tags.write(Change::new(new_tags, id));
+            self.commands.trigger(Change::new(new_tags, id));
         }
     }
 }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_measurement.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_measurement.rs
@@ -24,8 +24,8 @@ use rmf_site_egui::WidgetSystem;
 
 #[derive(SystemParam)]
 pub struct InspectMeasurement<'w, 's> {
+    commands: Commands<'w, 's>,
     distances: Query<'w, 's, &'static Distance>,
-    change_distance: EventWriter<'w, Change<Distance>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectMeasurement<'w, 's> {
@@ -49,8 +49,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectMeasurement<'w, 's> {
             .show(ui)
         {
             params
-                .change_distance
-                .write(Change::new(Distance(new_distance), selection));
+                .commands
+                .trigger(Change::new(Distance(new_distance), selection));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_power_dissipation.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_power_dissipation.rs
@@ -38,12 +38,12 @@ use smallvec::SmallVec;
 
 #[derive(SystemParam)]
 pub struct InspectPowerDissipation<'w, 's> {
+    commands: Commands<'w, 's>,
     robot_property_widgets: Res<'w, RobotPropertyWidgetRegistry>,
     model_instances: ModelPropertyQuery<'w, 's, Robot>,
     model_descriptions:
         Query<'w, 's, &'static ModelProperty<Robot>, (With<ModelMarker>, With<Group>)>,
     power_dissipation: Query<'w, 's, &'static PowerDissipation, (With<ModelMarker>, With<Group>)>,
-    change_robot_property: EventWriter<'w, Change<ModelProperty<Robot>>>,
     children: Query<'w, 's, &'static Children>,
     recall_power_dissipation:
         Query<'w, 's, &'static RecallPowerDissipation, (With<ModelMarker>, With<Group>)>,
@@ -124,8 +124,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectPowerDissipation<'w, 's> {
 
         if update_robot {
             params
-                .change_robot_property
-                .write(Change::new(ModelProperty(new_robot), description_entity));
+                .commands
+                .trigger(Change::new(ModelProperty(new_robot), description_entity));
         }
 
         // Show children widgets
@@ -227,6 +227,7 @@ impl Plugin for InspectMechanicalSystemPlugin {
 
 #[derive(SystemParam)]
 pub struct InspectMechanicalSystem<'w, 's> {
+    commands: Commands<'w, 's>,
     model_instances: ModelPropertyQuery<'w, 's, Robot>,
     model_descriptions: Query<
         'w,
@@ -237,7 +238,6 @@ pub struct InspectMechanicalSystem<'w, 's> {
         ),
         (With<ModelMarker>, With<Group>),
     >,
-    change_robot_property: EventWriter<'w, Change<ModelProperty<Robot>>>,
     recall_mechanical_system:
         Query<'w, 's, &'static RecallMechanicalSystem, (With<ModelMarker>, With<Group>)>,
 }
@@ -350,8 +350,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectMechanicalSystem<'w, 's> {
         }
 
         params
-            .change_robot_property
-            .write(Change::new(ModelProperty(new_robot), description_entity));
+            .commands
+            .trigger(Change::new(ModelProperty(new_robot), description_entity));
     }
 }
 
@@ -395,6 +395,7 @@ impl Plugin for InspectAmbientSystemPlugin {
 
 #[derive(SystemParam)]
 pub struct InspectAmbientSystem<'w, 's> {
+    commands: Commands<'w, 's>,
     model_instances: ModelPropertyQuery<'w, 's, Robot>,
     model_descriptions: Query<
         'w,
@@ -405,7 +406,6 @@ pub struct InspectAmbientSystem<'w, 's> {
         ),
         (With<ModelMarker>, With<Group>),
     >,
-    change_robot_property: EventWriter<'w, Change<ModelProperty<Robot>>>,
     recall_ambient_system:
         Query<'w, 's, &'static RecallAmbientSystem, (With<ModelMarker>, With<Group>)>,
 }
@@ -501,7 +501,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectAmbientSystem<'w, 's> {
         }
 
         params
-            .change_robot_property
-            .write(Change::new(ModelProperty(new_robot), description_entity));
+            .commands
+            .trigger(Change::new(ModelProperty(new_robot), description_entity));
     }
 }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_required_properties.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_required_properties.rs
@@ -29,10 +29,10 @@ use rmf_site_egui::*;
 
 #[derive(SystemParam)]
 pub struct InspectModelScale<'w, 's> {
+    commands: Commands<'w, 's>,
     model_instances: ModelPropertyQuery<'w, 's, Scale>,
     model_descriptions:
         Query<'w, 's, &'static ModelProperty<Scale>, (With<ModelMarker>, With<Group>)>,
-    change_scale: EventWriter<'w, Change<ModelProperty<Scale>>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectModelScale<'w, 's> {
@@ -56,18 +56,18 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectModelScale<'w, 's> {
         };
         if let Some(new_scale) = InspectScaleComponent::new(scale).show(ui) {
             params
-                .change_scale
-                .write(Change::new(ModelProperty(new_scale), description_entity));
+                .commands
+                .trigger(Change::new(ModelProperty(new_scale), description_entity));
         }
     }
 }
 
 #[derive(SystemParam)]
 pub struct InspectModelAssetSource<'w, 's> {
+    commands: Commands<'w, 's>,
     model_instances: ModelPropertyQuery<'w, 's, AssetSource>,
     model_descriptions:
         Query<'w, 's, &'static ModelProperty<AssetSource>, (With<ModelMarker>, With<Group>)>,
-    change_asset_source: EventWriter<'w, Change<ModelProperty<AssetSource>>>,
     current_workspace: Res<'w, CurrentWorkspace>,
     default_file: Query<'w, 's, &'static DefaultFile>,
     model_loader: ModelLoader<'w, 's>,
@@ -104,7 +104,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectModelAssetSource<'w, 's> {
                 .show(ui)
         {
             // TODO(@xiyuoh) look into removing Change for description asset source updates
-            params.change_asset_source.write(Change::new(
+            params.commands.trigger(Change::new(
                 ModelProperty(new_source.clone()),
                 description_entity,
             ));

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_robot_properties.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/inspect_robot_properties.rs
@@ -309,9 +309,9 @@ where
 /// the properties on and off, and select relevant RobotPropertyKinds.
 pub fn show_robot_property_widget<T: RobotProperty>(
     ui: &mut Ui,
+    commands: &mut Commands,
     property_query: Query<&T, (With<ModelMarker>, With<Group>)>,
     property_recall: Option<T>,
-    mut change_robot_property: EventWriter<Change<ModelProperty<Robot>>>,
     robot: &Robot,
     robot_property_widgets: &Res<RobotPropertyWidgetRegistry>,
     description_entity: Entity,
@@ -388,7 +388,7 @@ pub fn show_robot_property_widget<T: RobotProperty>(
             }
         }
     }
-    change_robot_property.write(Change::new(ModelProperty(new_robot), description_entity));
+    commands.trigger(Change::new(ModelProperty(new_robot), description_entity));
 }
 
 /// Unique UUID to identify issue of invalid robot property kind

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/mod.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_model_description/mod.rs
@@ -368,6 +368,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectModelDescription<'w, 's> {
 /// and change its description
 #[derive(SystemParam)]
 pub struct InspectSelectedModelDescription<'w, 's> {
+    commands: Commands<'w, 's>,
     model_instances: ModelPropertyQuery<'w, 's, NameInSite>,
     model_descriptions: Query<
         'w,
@@ -380,7 +381,6 @@ pub struct InspectSelectedModelDescription<'w, 's> {
         (With<ModelMarker>, With<Group>),
     >,
     model_loader: ModelLoader<'w, 's>,
-    change_affiliation: EventWriter<'w, Change<Affiliation<Entity>>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectSelectedModelDescription<'w, 's> {
@@ -423,8 +423,8 @@ impl<'w, 's> InspectSelectedModelDescription<'w, 's> {
                 });
         });
         if new_description_entity != current_description_entity {
-            self.change_affiliation
-                .write(Change::new(Affiliation(Some(new_description_entity)), id));
+            self.commands
+                .trigger(Change::new(Affiliation(Some(new_description_entity)), id));
             let (_, _, new_source) = self.model_descriptions.get(new_description_entity).unwrap();
             self.model_loader
                 .update_asset_source(id, new_source.0.clone());

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_motion.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_motion.rs
@@ -51,8 +51,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectMotion<'w, 's> {
 
 #[derive(SystemParam)]
 pub struct InspectForwardMotion<'w, 's> {
+    commands: Commands<'w, 's>,
     motions: Query<'w, 's, (&'static Motion, &'static RecallMotion)>,
-    change_lane_motion: EventWriter<'w, Change<Motion>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectForwardMotion<'w, 's> {
@@ -74,7 +74,7 @@ impl<'w, 's> InspectForwardMotion<'w, 's> {
         };
 
         if let Some(new_motion) = InspectMotionComponent::new(motion, recall).show(ui) {
-            self.change_lane_motion.write(Change::new(new_motion, id));
+            self.commands.trigger(Change::new(new_motion, id));
         }
         ui.add_space(10.0);
     }
@@ -82,8 +82,8 @@ impl<'w, 's> InspectForwardMotion<'w, 's> {
 
 #[derive(SystemParam)]
 pub struct InspectReverseMotion<'w, 's> {
+    commands: Commands<'w, 's>,
     reverse_motions: Query<'w, 's, (&'static ReverseLane, &'static RecallReverseLane)>,
-    change_lane_reverse: EventWriter<'w, Change<ReverseLane>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectReverseMotion<'w, 's> {
@@ -140,7 +140,7 @@ impl<'w, 's> InspectReverseMotion<'w, 's> {
         });
 
         if new_reverse != *reverse {
-            self.change_lane_reverse.write(Change::new(new_reverse, id));
+            self.commands.trigger(Change::new(new_reverse, id));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_name.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_name.rs
@@ -26,8 +26,8 @@ use rmf_site_format::NameInSite;
 
 #[derive(SystemParam)]
 pub struct InspectName<'w, 's> {
+    commands: Commands<'w, 's>,
     names_in_site: Query<'w, 's, &'static NameInSite>,
-    change_name_in_site: EventWriter<'w, Change<NameInSite>>,
 }
 
 impl<'w, 's> ShareableWidget for InspectName<'w, 's> {}
@@ -47,9 +47,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectName<'w, 's> {
                 ui.text_edit_singleline(&mut new_name.0);
             });
             if new_name != *name {
-                params
-                    .change_name_in_site
-                    .write(Change::new(new_name, selection));
+                params.commands.trigger(Change::new(new_name, selection));
             }
         }
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_physical_camera_properties.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_physical_camera_properties.rs
@@ -27,8 +27,8 @@ use rmf_site_format::PhysicalCameraProperties;
 
 #[derive(SystemParam)]
 pub struct InspectPhysicalCameraProperties<'w, 's> {
+    commands: Commands<'w, 's>,
     physical_camera_properties: Query<'w, 's, &'static PhysicalCameraProperties>,
-    change_physical_camera_properties: EventWriter<'w, Change<PhysicalCameraProperties>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectPhysicalCameraProperties<'w, 's> {
@@ -85,8 +85,8 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectPhysicalCameraProperties<'w, 's> {
             || new_properties.frame_rate != properties.frame_rate
         {
             params
-                .change_physical_camera_properties
-                .write(Change::new(new_properties, selection));
+                .commands
+                .trigger(Change::new(new_properties, selection));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_pose.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_pose.rs
@@ -28,7 +28,6 @@ use rmf_site_format::{Pose, Rotation};
 pub struct InspectPose<'w, 's> {
     commands: Commands<'w, 's>,
     poses: Query<'w, 's, &'static Pose>,
-    change_pose: EventWriter<'w, Change<Pose>>,
     current_scenario: Res<'w, CurrentScenario>,
     pose_modifiers: Query<'w, 's, (&'static Modifier<Pose>, &'static Affiliation<Entity>)>,
     scenarios: Query<
@@ -54,7 +53,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectPose<'w, 's> {
             return;
         };
         if let Some(new_pose) = InspectPoseComponent::new(pose).show(ui) {
-            params.change_pose.write(Change::new(new_pose, selection));
+            params.commands.trigger(Change::new(new_pose, selection));
         }
 
         // Reset model instance pose to parent scenario pose (if any)

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_primitive_shape.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_primitive_shape.rs
@@ -25,8 +25,8 @@ use rmf_site_format::{PrimitiveShape, RecallPrimitiveShape};
 
 #[derive(SystemParam)]
 pub struct InspectPrimitiveShape<'w, 's> {
+    commands: Commands<'w, 's>,
     primitive_shapes: Query<'w, 's, (&'static PrimitiveShape, &'static RecallPrimitiveShape)>,
-    change_primitive_shape: EventWriter<'w, Change<PrimitiveShape>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectPrimitiveShape<'w, 's> {
@@ -42,9 +42,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectPrimitiveShape<'w, 's> {
         };
 
         if let Some(new_shape) = InspectPrimitiveShapeComponent::new(shape, recall).show(ui) {
-            params
-                .change_primitive_shape
-                .write(Change::new(new_shape, selection));
+            params.commands.trigger(Change::new(new_shape, selection));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_scale.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_scale.rs
@@ -26,8 +26,8 @@ use rmf_site_format::{Affiliation, Scale};
 
 #[derive(SystemParam)]
 pub struct InspectScale<'w, 's> {
+    commands: Commands<'w, 's>,
     scales: Query<'w, 's, &'static Scale, Without<Affiliation<Entity>>>,
-    change_scale: EventWriter<'w, Change<Scale>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectScale<'w, 's> {
@@ -43,7 +43,7 @@ impl<'w, 's> WidgetSystem<Inspect> for InspectScale<'w, 's> {
         };
 
         if let Some(new_scale) = InspectScaleComponent::new(scale).show(ui) {
-            params.change_scale.write(Change::new(new_scale, selection));
+            params.commands.trigger(Change::new(new_scale, selection));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
+++ b/crates/rmf_site_editor/src/widgets/inspector/inspect_texture.rs
@@ -56,7 +56,6 @@ pub struct InspectTextureAffiliation<'w, 's> {
     icons: Res<'w, Icons>,
     search_for_texture: ResMut<'w, SearchForTexture>,
     commands: Commands<'w, 's>,
-    change_affiliation: EventWriter<'w, Change<Affiliation<Entity>>>,
 }
 
 impl<'w, 's> WidgetSystem<Inspect> for InspectTextureAffiliation<'w, 's> {
@@ -182,8 +181,8 @@ impl<'w, 's> InspectTextureAffiliation<'w, 's> {
                             })
                             .insert(ChildOf(site))
                             .id();
-                        self.change_affiliation
-                            .write(Change::new(Affiliation(Some(new_texture_group)), id));
+                        self.commands
+                            .trigger(Change::new(Affiliation(Some(new_texture_group)), id));
                     }
                 }
                 SearchResult::Match(group) => {
@@ -192,8 +191,8 @@ impl<'w, 's> InspectTextureAffiliation<'w, 's> {
                         .on_hover_text("Select this texture")
                         .clicked()
                     {
-                        self.change_affiliation
-                            .write(Change::new(Affiliation(Some(group)), id));
+                        self.commands
+                            .trigger(Change::new(Affiliation(Some(group)), id));
                     }
                 }
                 SearchResult::Conflict(text) => {
@@ -261,8 +260,7 @@ impl<'w, 's> InspectTextureAffiliation<'w, 's> {
         });
 
         if new_affiliation != *affiliation {
-            self.change_affiliation
-                .write(Change::new(new_affiliation, id));
+            self.commands.trigger(Change::new(new_affiliation, id));
         }
         ui.add_space(10.0);
     }

--- a/crates/rmf_site_editor/src/widgets/tasks/mod.rs
+++ b/crates/rmf_site_editor/src/widgets/tasks/mod.rs
@@ -120,7 +120,6 @@ pub struct EditModeEvent {
 pub struct ViewTasks<'w, 's> {
     children: Query<'w, 's, &'static Children>,
     commands: Commands<'w, 's>,
-    change_task: EventWriter<'w, Change<Task>>,
     current_scenario: ResMut<'w, CurrentScenario>,
     delete: EventWriter<'w, Delete>,
     edit_mode: EventWriter<'w, EditModeEvent>,
@@ -255,7 +254,6 @@ impl<'w, 's> ViewTasks<'w, 's> {
                     &pending_task_params,
                     &self.task_kinds,
                     &self.robots,
-                    &mut self.change_task,
                 );
             } else {
                 if let Ok((_, existing_task)) = self.tasks.get_mut(task_entity) {
@@ -285,7 +283,6 @@ impl<'w, 's> ViewTasks<'w, 's> {
                         &existing_task_params,
                         &self.task_kinds,
                         &self.robots,
-                        &mut self.change_task,
                     );
                 }
             }
@@ -551,7 +548,6 @@ fn edit_task(
     task_params: &TaskParams,
     task_kinds: &ResMut<TaskKinds>,
     robots: &Query<(Entity, &NameInSite), (With<Robot>, Without<Group>)>,
-    change_task: &mut EventWriter<Change<Task>>,
 ) {
     Grid::new("edit_task_".to_owned() + &task_entity.index().to_string())
         .num_columns(2)
@@ -681,7 +677,7 @@ fn edit_task(
             ui.end_row();
 
             if new_task != *task {
-                change_task.write(Change::new(new_task, task_entity));
+                commands.trigger(Change::new(new_task, task_entity));
             } else {
             }
         });

--- a/crates/rmf_site_editor/src/widgets/view_groups.rs
+++ b/crates/rmf_site_editor/src/widgets/view_groups.rs
@@ -69,7 +69,6 @@ pub struct ViewGroupsEvents<'w, 's> {
     selector: SelectorWidget<'w, 's>,
     merge_groups: EventWriter<'w, MergeGroups>,
     delete: EventWriter<'w, Delete>,
-    name: EventWriter<'w, Change<NameInSite>>,
     commands: Commands<'w, 's>,
     object_placement: ObjectPlacement<'w, 's>,
 }
@@ -258,7 +257,9 @@ impl<'w, 's> ViewGroups<'w, 's> {
                     .ui(ui)
                     .changed()
                 {
-                    events.name.write(Change::new(NameInSite(new_name), *child));
+                    events
+                        .commands
+                        .trigger(Change::new(NameInSite(new_name), *child));
                 }
             });
         }

--- a/crates/rmf_site_editor/src/widgets/view_layers.rs
+++ b/crates/rmf_site_editor/src/widgets/view_layers.rs
@@ -42,6 +42,7 @@ impl Plugin for ViewLayersPlugin {
 
 #[derive(SystemParam)]
 pub struct ViewLayers<'w, 's> {
+    commands: Commands<'w, 's>,
     floors: Query<
         'w,
         's,
@@ -61,8 +62,6 @@ pub struct ViewLayers<'w, 's> {
     icons: Res<'w, Icons>,
     selection: Res<'w, Selection>,
     current_level: Res<'w, CurrentLevel>,
-    global_floor_vis: EventWriter<'w, Change<GlobalFloorVisibility>>,
-    global_drawing_vis: EventWriter<'w, Change<GlobalDrawingVisibility>>,
     view_layer: InspectLayer<'w, 's>,
     app_state: Res<'w, State<AppState>>,
 }
@@ -112,8 +111,8 @@ impl<'w, 's> ViewLayers<'w, 's> {
                         Self::show_global(text, &self.icons, vis, default_alpha, ui);
 
                         if shown_global != *global {
-                            self.global_floor_vis
-                                .write(Change::new(shown_global, current_level));
+                            self.commands
+                                .trigger(Change::new(shown_global, current_level));
                         }
                     });
                     ui.separator();
@@ -166,8 +165,8 @@ impl<'w, 's> ViewLayers<'w, 's> {
                     });
 
                     if shown_global != *global {
-                        self.global_drawing_vis
-                            .write(Change::new(shown_global, current_level));
+                        self.commands
+                            .trigger(Change::new(shown_global, current_level));
                     }
 
                     if let Some(selected) = Self::show_rankings(

--- a/crates/rmf_site_editor/src/widgets/view_levels.rs
+++ b/crates/rmf_site_editor/src/widgets/view_levels.rs
@@ -50,8 +50,6 @@ pub struct ViewLevels<'w, 's> {
     display_levels: ResMut<'w, LevelDisplay>,
     current_level: ResMut<'w, CurrentLevel>,
     current_workspace: ResMut<'w, CurrentWorkspace>,
-    change_name: EventWriter<'w, Change<NameInSite>>,
-    change_level_elevation: EventWriter<'w, Change<LevelElevation>>,
     delete: EventWriter<'w, Delete>,
     commands: Commands<'w, 's>,
     app_state: Res<'w, State<AppState>>,
@@ -195,13 +193,13 @@ impl<'w, 's> ViewLevels<'w, 's> {
                 });
 
                 if shown_name != name.0 {
-                    self.change_name
-                        .write(Change::new(NameInSite(shown_name), e));
+                    self.commands
+                        .trigger(Change::new(NameInSite(shown_name), e));
                 }
 
                 if shown_elevation != elevation.0 {
-                    self.change_level_elevation
-                        .write(Change::new(LevelElevation(shown_elevation), e));
+                    self.commands
+                        .trigger(Change::new(LevelElevation(shown_elevation), e));
                 }
             }
         }

--- a/crates/rmf_site_editor/src/widgets/view_nav_graphs.rs
+++ b/crates/rmf_site_editor/src/widgets/view_nav_graphs.rs
@@ -69,9 +69,6 @@ pub struct ViewNavGraphs<'w, 's> {
     current_workspace: ResMut<'w, CurrentWorkspace>,
     display_nav_graph: ResMut<'w, NavGraphDisplay>,
     delete: EventWriter<'w, Delete>,
-    change_visibility: EventWriter<'w, Change<Visibility>>,
-    change_name: EventWriter<'w, Change<NameInSite>>,
-    change_color: EventWriter<'w, Change<DisplayColor>>,
     change_rank: EventWriter<'w, ChangeRank<NavGraphMarker>>,
     selector: SelectorWidget<'w, 's>,
     commands: Commands<'w, 's>,
@@ -181,7 +178,7 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
                         } else {
                             Visibility::Hidden
                         };
-                        self.change_visibility.write(Change::new(visibility, e));
+                        self.commands.trigger(Change::new(visibility, e));
                     }
                 }
 
@@ -190,8 +187,8 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
                 let mut new_color = color.0;
                 color_edit(ui, &mut new_color);
                 if new_color != color.0 {
-                    self.change_color
-                        .write(Change::new(DisplayColor(new_color), e));
+                    self.commands
+                        .trigger(Change::new(DisplayColor(new_color), e));
                 }
 
                 let mut new_name = name.0.clone();
@@ -200,7 +197,7 @@ impl<'w, 's> ViewNavGraphs<'w, 's> {
                     .ui(ui)
                     .changed()
                 {
-                    self.change_name.write(Change::new(NameInSite(new_name), e));
+                    self.commands.trigger(Change::new(NameInSite(new_name), e));
                 }
             });
         }


### PR DESCRIPTION
This PR modifies the `Change` event into an observer, so that event updates can be reflected instantly.