### PR TITLE
Provide cmake module for generating sdf/nav graphs using rmf_site_editor

### DIFF
--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -11,9 +11,7 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: deps
       run: |
@@ -28,3 +26,29 @@ jobs:
       run: cargo build --all-targets
     - name: Run tests
       run: cargo test
+
+  build_with_colcon:
+    runs-on: ubuntu-latest
+    container:
+      image: osrf/ros:jazzy-desktop-noble
+    steps:
+    - name: deps
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libasound2-dev libudev-dev libgtk-3-dev git libclang-dev python3-pip python3-vcstool
+        pip install git+https://github.com/colcon/colcon-cargo.git --break-system-packages
+        pip install git+https://github.com/colcon/colcon-ros-cargo.git --break-system-packages
+    - name: Set up workspace
+      run: |
+        mkdir -p site_ws/src
+    - uses: actions/checkout@v4
+      with:
+        path: site_ws/src/rmf_site
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+    - name: Build rmf_site_editor with colcon
+      shell: bash
+      run: |
+        cd site_ws
+        source /opt/ros/jazzy/setup.bash
+        colcon build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5672,6 +5672,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmf_site_cmake"
+version = "0.1.0"
+
+[[package]]
 name = "rmf_site_editor"
 version = "0.0.1"
 dependencies = [
@@ -5761,10 +5765,14 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "testdir",
- "thiserror 2.0.12",
+ "thiserror 1.0.69",
  "urdf-rs",
  "uuid",
 ]
+
+[[package]]
+name = "rmf_site_maps"
+version = "0.1.0"
 
 [[package]]
 name = "rmf_site_mesh"
@@ -8278,3 +8286,7 @@ checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
 dependencies = [
  "zune-core",
 ]
+
+[[patch.unused]]
+name = "rmf_site_format"
+version = "0.0.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5672,10 +5672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmf_site_cmake"
-version = "0.1.0"
-
-[[package]]
 name = "rmf_site_editor"
 version = "0.0.1"
 dependencies = [
@@ -5769,10 +5765,6 @@ dependencies = [
  "urdf-rs",
  "uuid",
 ]
-
-[[package]]
-name = "rmf_site_maps"
-version = "0.1.0"
 
 [[package]]
 name = "rmf_site_mesh"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 members = [
-    "crates/*"
+    "crates/rmf_site_animate",
+    "crates/rmf_site_camera",
+    "crates/rmf_site_editor",
+    "crates/rmf_site_editor_web",
+    "crates/rmf_site_egui",
+    "crates/rmf_site_format",
+    "crates/rmf_site_mesh",
+    "crates/rmf_site_picking"
 ]
 
 # This is needed for packages that are part of a workspace to use the 2nd version

--- a/crates/rmf_site_cmake/CMakeLists.txt
+++ b/crates/rmf_site_cmake/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.19)
+project(rmf_site_cmake CXX)
+
+# Default to C++20
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+# Generate and install the package configuration files.
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+configure_package_config_file(
+  cmake/${PROJECT_NAME}Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION share/${PROJECT_NAME}/cmake
+)
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "cmake/rmf_site_generate.cmake"
+  DESTINATION
+    share/${PROJECT_NAME}/cmake
+)

--- a/crates/rmf_site_cmake/cmake/rmf_site_cmakeConfig.cmake.in
+++ b/crates/rmf_site_cmake/cmake/rmf_site_cmakeConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+get_filename_component(rmf_site_cmake_DIR "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+
+include("${rmf_site_cmake_DIR}/rmf_site_generate.cmake")
+set(rmf_site_cmake_DATADIR "@DATADIR@")

--- a/crates/rmf_site_cmake/cmake/rmf_site_generate.cmake
+++ b/crates/rmf_site_cmake/cmake/rmf_site_generate.cmake
@@ -1,0 +1,139 @@
+# ==============================================================================
+# Function: rmf_site_generate
+#
+# Generates a world file and a navigation graph directory from an RMF building.yaml.
+#
+# Arguments:
+#   INPUT_MAP           <path_to_yaml_file>    (REQUIRED) Input path to a single RMF building input file (.building.yaml/.json/.ron).
+#   OUTPUT_WORLD_DIR    <path_to_world_dir>    (REQUIRED) Output directory for the output world file.
+#   OUTPUT_NAV_DIR      <path_to_nav_dir>      (REQUIRED) Output directory for the nav_graph files.
+#                                                         Generated nav_graphs will be placed inside.
+#   DEPENDS             <list_of_dependencies> (OPTIONAL) List of files or targets that this generation depends on.
+#
+# Example:
+#   rmf_site_generate(
+#     INPUT_MAP hotel.building.yaml
+#     OUTPUT_WORLD_DIR ${CMAKE_CURRENT_BINARY_DIR}/maps/hotel/
+#     OUTPUT_NAV_DIR ${CMAKE_CURRENT_BINARY_DIR}/maps/hotel/nav_graphs
+#   )
+# ==============================================================================
+function(rmf_site_generate)
+  set(options)
+  set(one_value_args INPUT_MAP OUTPUT_WORLD_DIR OUTPUT_NAV_DIR)
+  set(multi_value_args DEPENDS)
+
+  cmake_parse_arguments(
+    rmf_site_gen
+    "${options}"
+    "${one_value_args}"
+    "${multi_value_args}"
+    ${ARGN}
+  )
+
+  # --- Argument Validation ---
+  if(NOT rmf_site_gen_INPUT_MAP)
+    message(FATAL_ERROR "rmf_site_generate: INPUT_MAP argument is required.")
+  endif()
+  if(NOT rmf_site_gen_OUTPUT_WORLD_DIR)
+    message(FATAL_ERROR "rmf_site_generate: OUTPUT_WORLD_DIR argument is required.")
+  endif()
+  if(NOT rmf_site_gen_OUTPUT_NAV_DIR)
+    message(FATAL_ERROR "rmf_site_generate: OUTPUT_NAV_DIR argument is required.")
+  endif()
+
+  # Ensure the output directories exist before running the command
+  file(MAKE_DIRECTORY "${rmf_site_gen_OUTPUT_WORLD_DIR}")
+  file(MAKE_DIRECTORY "${rmf_site_gen_OUTPUT_NAV_DIR}")
+
+  set(output_world_phony ${rmf_site_gen_OUTPUT_WORLD_DIR}/phony)
+  set(output_nav_graphs_phony ${rmf_site_gen_OUTPUT_NAV_DIR}/phony)
+
+  # Add a custom command to run rmf_site_editor.
+  add_custom_command(
+    OUTPUT ${output_world_phony} ${output_nav_graphs_phony}
+    COMMAND rmf_site_editor
+            ${rmf_site_gen_INPUT_MAP}
+            --export-sdf ${rmf_site_gen_OUTPUT_WORLD_DIR}
+            --export-nav ${rmf_site_gen_OUTPUT_NAV_DIR}
+    DEPENDS ${rmf_site_gen_INPUT_MAP} ${rmf_site_gen_DEPENDS}
+    VERBATIM
+  )
+
+  # Define a unique target name for this generation task
+  get_filename_component(input_basename "${rmf_site_gen_INPUT_MAP}" NAME_WE)
+  set(target_name "generate_${input_basename}_site")
+
+  add_custom_target(generate_${target_name}_nav_graphs ALL
+    DEPENDS ${output_nav_graphs_phony}
+  )
+
+endfunction()
+
+
+# ==============================================================================
+# Function: rmf_site_generate_map_package
+#
+# Generates a complete RMF map package from a site input directory.
+# The package includes the world file and a navigation graph directory.
+#
+# Arguments:
+#   INPUT_MAP_DIR       <path_to_map_dir>       (REQUIRED) Input path to a directory containing map files (.building.yaml/.site.json/.site.ron).
+#   OUTPUT_PACKAGE_DIR  <path_to_pkg_dir>       (REQUIRED) Output directory for the generated package.
+#   DEPENDS             <list_of_dependencies>  (OPTIONAL) List of files or targets that this generation depends on.
+#
+# Example:
+#   rmf_site_generate_map_package(
+#     INPUT_MAP_DIR maps
+#     OUTPUT_PACKAGE_DIR ${CMAKE_CURRENT_BINARY_DIR}/maps
+#   )
+# ==============================================================================
+function(rmf_site_generate_map_package)
+  set(options)
+  set(one_value_args INPUT_MAP_DIR OUTPUT_PACKAGE_DIR)
+  set(multi_value_args DEPENDS)
+
+  cmake_parse_arguments(
+    rmf_site_pkg_gen
+    "${options}"
+    "${one_value_args}"
+    "${multi_value_args}"
+    ${ARGN}
+  )
+
+  # --- Argument Validation ---
+  if(NOT rmf_site_pkg_gen_INPUT_MAP_DIR)
+    message(FATAL_ERROR "rmf_site_generate_map_package: INPUT_MAP_DIR argument is required.")
+  endif()
+  if(NOT rmf_site_pkg_gen_OUTPUT_PACKAGE_DIR)
+    message(FATAL_ERROR "rmf_site_generate_map_package: OUTPUT_PACKAGE_DIR argument is required.")
+  endif()
+
+  # Consolidate all the relevant map files
+  file(GLOB_RECURSE
+    site_paths
+    "${rmf_site_pkg_gen_INPUT_MAP_DIR}/*.building.yaml"
+    "${rmf_site_pkg_gen_INPUT_MAP_DIR}/*.site.json"
+    "${rmf_site_pkg_gen_INPUT_MAP_DIR}/*.site.ron"
+  )
+
+  foreach(path ${site_paths})
+    # Get the output world name
+    string(REGEX REPLACE "\\.[^.]*\.[^.]*$" "" no_extension_path ${path})
+    string(REGEX MATCH "[^\/]+$" world_name  ${no_extension_path})
+
+    set(map_path ${path})
+    set(output_world_name ${world_name})
+    set(output_dir ${rmf_site_pkg_gen_OUTPUT_PACKAGE_DIR}/${output_world_name})
+    set(output_world_dir ${output_dir}/)
+    set(output_nav_dir ${output_dir}/nav_graphs/)
+
+    # Run the command to generate world file and nav graphs
+    rmf_site_generate(
+      INPUT_MAP ${map_path}
+      OUTPUT_WORLD_DIR ${output_world_dir}
+      OUTPUT_NAV_DIR ${output_nav_dir}
+    )
+
+  endforeach()
+
+endfunction()

--- a/crates/rmf_site_format/Cargo.toml
+++ b/crates/rmf_site_format/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Grey <grey@openrobotics.org>"]
 [lib]
 crate-type = ["rlib"]
 
+[package.metadata.ros]
+install_to_share = ["../../Cargo.toml"]
+
 [dependencies]
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_yaml = {workspace = true}


### PR DESCRIPTION
This PR closes https://github.com/open-rmf/rmf_site/issues/307 and https://github.com/open-rmf/rmf_site/issues/361:
- Copied workspace `Cargo.toml` to `rmf_site_format`'s install folder, should allow the remaining packages to be built successfully with colcon now
- Added CI for checking that the workspace can be built with `colcon build`
- Added a cmake module for generating nav graphs from various map file extensions, we can now create nav graphs during a colcon build process. Custom commands added are `rmf_site_generate` and `rmf_site_generate_map_package`, as suggested in the issue ticket.

### Test

Check out to [xiyu/cmake_test](https://github.com/open-rmf/rmf_site/tree/xiyu/cmake_test) branch, whrere I've created a sample map package `rmf_site_maps` with map files and a `CMakeLists.txt` that triggers the `rmf_site_generate_map_package` command. Building the workspace (or just up to `rmf_site_maps`) should generate world files and nav graphs in the map package's install folder.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI