### PR TITLE
Fixes a bug where all models were spawned at the origin

### DIFF
--- a/crates/rmf_site_editor/src/site/property_plugin.rs
+++ b/crates/rmf_site_editor/src/site/property_plugin.rs
@@ -389,11 +389,12 @@ mod tests {
         // Create a root scenario
         let root_scenario = app
             .world_mut()
-            .spawn((ScenarioModifiers::<Entity>::default(), Affiliation::<Entity>(None)))
+            .spawn((
+                ScenarioModifiers::<Entity>::default(),
+                Affiliation::<Entity>(None),
+            ))
             .id();
-        app.world_mut()
-            .resource_mut::<CurrentScenario>()
-            .0 = Some(root_scenario);
+        app.world_mut().resource_mut::<CurrentScenario>().0 = Some(root_scenario);
 
         // Spawn an instance element with a non-zero initial Pose
         let initial_pose = Pose {
@@ -408,7 +409,8 @@ mod tests {
         app.update();
 
         // Trigger UseModifier as would happen when Inclusion is modified
-        app.world_mut().trigger(UseModifier::new(element, root_scenario));
+        app.world_mut()
+            .trigger(UseModifier::new(element, root_scenario));
         app.update();
 
         // Verify the element's Pose was NOT overwritten with Pose::default() [0, 0, 0]

--- a/crates/rmf_site_editor/src/site/property_plugin.rs
+++ b/crates/rmf_site_editor/src/site/property_plugin.rs
@@ -68,12 +68,14 @@ pub trait StandardProperty:
 
 impl<T: StandardProperty> Property for T {
     fn get_fallback(for_element: Entity, _in_scenario: Entity, world: &mut World) -> Self {
-        let mut state: SystemState<Query<&LastSetValue<Self>>> = SystemState::new(world);
-        let last_set_value = state.get(world);
+        let mut state: SystemState<(Query<&LastSetValue<Self>>, Query<&Self>)> =
+            SystemState::new(world);
+        let (last_set_value, current_value) = state.get(world);
 
         last_set_value
             .get(for_element)
             .map(|value| (**value).clone())
+            .or_else(|_| current_value.get(for_element).cloned())
             .unwrap_or(Self::default())
     }
 
@@ -367,5 +369,58 @@ fn update_changed_property<T: Property, E: Element>(
                 new_value.clone(),
             ));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::site::Pose;
+    use rmf_site_format::InstanceMarker;
+
+    #[test]
+    fn test_standard_property_fallback_preserves_initial_pose() {
+        let mut app = App::new();
+        app.add_plugins(PropertyPlugin::<Pose, InstanceMarker>::default());
+        app.init_resource::<CurrentScenario>();
+        app.init_resource::<Trashcan>();
+        app.add_event::<ChangeCurrentScenario>();
+
+        // Create a root scenario
+        let root_scenario = app
+            .world_mut()
+            .spawn((ScenarioModifiers::<Entity>::default(), Affiliation::<Entity>(None)))
+            .id();
+        app.world_mut()
+            .resource_mut::<CurrentScenario>()
+            .0 = Some(root_scenario);
+
+        // Spawn an instance element with a non-zero initial Pose
+        let initial_pose = Pose {
+            trans: [12.0, 34.0, 5.0],
+            rot: Default::default(),
+        };
+        let element = app
+            .world_mut()
+            .spawn((initial_pose.clone(), InstanceMarker))
+            .id();
+
+        app.update();
+
+        // Trigger UseModifier as would happen when Inclusion is modified
+        app.world_mut().trigger(UseModifier::new(element, root_scenario));
+        app.update();
+
+        // Verify the element's Pose was NOT overwritten with Pose::default() [0, 0, 0]
+        let pose = app.world().get::<Pose>(element).unwrap();
+        assert_eq!(pose.trans, [12.0, 34.0, 5.0]);
+
+        // Also verify the root scenario modifier was populated with the initial pose
+        let mut get_modifier_state =
+            SystemState::<GetModifier<Modifier<Pose>>>::new(app.world_mut());
+        let get_modifier = get_modifier_state.get(app.world());
+        let modifier = get_modifier.get(root_scenario, element);
+        assert!(modifier.is_some());
+        assert_eq!(modifier.unwrap().trans, [12.0, 34.0, 5.0]);
     }
 }


### PR DESCRIPTION
## Bug fix


### Fixed bug

Currently adding a model using the add description spawns a preview of the model at the point of the mouse cursor. Upon clicking, one would expect the model to be spawned at the mouse cursor's position. However, it seems to be spawned at the origin. This commit fixes this behaviour.

Before:
<img width="2638" height="1490" alt="bug_hd" src="https://github.com/user-attachments/assets/d06053a3-bea2-4207-9db6-67c18994160c" />

After:
<img width="2638" height="1490" alt="fixed_bug_hd" src="https://github.com/user-attachments/assets/9f398054-acdf-447a-bd00-aa8d3de8f563" />


### Fix applied
Preserve the initial element values before spawning.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x] I used a GenAI tool in this PR.
- [ ] I did not use GenAI

Generated-by: Gemini
